### PR TITLE
Remove `.venv` from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,6 @@
 *.fls
 *.log
 *.synctex.gz
-# Python virtual environment 
-/.venv/
-# Lean blueprint 
+# Lean blueprint
 /blueprint/lean_decls
 /blueprint/src/web.bbl


### PR DESCRIPTION
This PR remove `/.venv` from the `.gitignore` since it's unique to my setup and not generalisable. 

Sorry for the previous commit. 