### PR TITLE
Use capitalised clever references

### DIFF
--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -25,7 +25,7 @@ Note  that even Carleson's classical result has not yet been computer-verified.
 
 \chapter{Introduction}
 
-In \cite{carleson}, L. Carleson addressed a classical question regarding the convergence of Fourier series of continuous functions by proving their pointwise convergence almost everywhere. Theorem \ref{classical-Carleson} represents a version of this result.
+In \cite{carleson}, L. Carleson addressed a classical question regarding the convergence of Fourier series of continuous functions by proving their pointwise convergence almost everywhere. \Cref{classical-Carleson} represents a version of this result.
 
 Let $f$ be a complex-valued, $2\pi$-periodic bounded Borel measurable function on the real line, and for an integer $n$, define the Fourier coefficient as
 \begin{equation}
@@ -49,7 +49,7 @@ Let $f$ be a $2\pi$-periodic complex-valued uniformly continuous function on $\m
 
 Note that mere continuity implies uniform continuity in the setting of this theorem. By applying this theorem with a sequence of $\epsilon_n:= 2^{-n}\delta$ for $n\ge 1$ and taking the union of corresponding exceptional sets $E_n$, we see that outside a set of measure $\delta$, the partial Fourier sums converge pointwise for $N\to \infty$. Applying this with a sequence of $\delta$ shrinking to zero and taking the intersection of the corresponding exceptional sets, which has measure zero, we see that the Fourier series converges outside a set of measure zero.
 
-The purpose of this paper is twofold. On the one hand, it prepares computer verification of Theorem \ref{classical-Carleson} by presenting a very detailed proof as a blueprint for coding in Lean. We pass through a bound for a generalization of the so-called Carleson operator to doubling metric measure spaces. This generalization is new, and proving these bounds constitutes the second purpose of this paper. This generalization incorporates several results from the recent literature, most prominently bounds for the polynomial Carleson operator of V. Lie \cite{lie-polynomial} as well as its generalization \cite{zk-polynomial}. A computer verification of our theorem will also entail a computer verification for the bulk of the work in these results.
+The purpose of this paper is twofold. On the one hand, it prepares computer verification of \Cref{classical-Carleson} by presenting a very detailed proof as a blueprint for coding in Lean. We pass through a bound for a generalization of the so-called Carleson operator to doubling metric measure spaces. This generalization is new, and proving these bounds constitutes the second purpose of this paper. This generalization incorporates several results from the recent literature, most prominently bounds for the polynomial Carleson operator of V. Lie \cite{lie-polynomial} as well as its generalization \cite{zk-polynomial}. A computer verification of our theorem will also entail a computer verification for the bulk of the work in these results.
 
 
 We proceed to introduce the setup for our general theorem.
@@ -173,7 +173,7 @@ Doubling metric measure spaces are instances of spaces of homogeneous type. Inde
 
 Our concept of a compatible collection $\Mf$ as a natural class of phase functions on a doubling metric measure space does not appear in \cite{stein-book} but is implicitly anticipated in \cite{zk-polynomial} and subsequent work of \cite{mnatsakanyan}, who proves a Carleson-type theorem for the Malmquist-Takenaka series, which leads to classes of phases related to Blaschke products. A generalization of \eqref{def-main-op} from the previously mentioned Euclidean setting into the anisotropic setting that was suggested in \cite{zk-polynomial} is included in our theory. The polynomial Carleson operator also plays a role in the study of maximally modulated singular Radon transforms along the parabola, see \cite{ramos} and \cite{becker2024maximal}.
 
-For the proof of Theorem \ref{metric-space-Carleson}, we largely follow \cite{zk-polynomial}, which in turn was inspired by \cite{lie-polynomial}. We make suitable modifications to adapt to our more general setting and have made a few technical improvements in the proof. In particular, in Section \ref{overviewsection}, we explicitly divide the main work of the proof into mutually independent sections \ref{thmfromproplinear}, \ref{christsection}, \ref{proptopropprop}, \ref{antichainboundary}, \ref{treesection}, \ref{liphoel}, and \ref{sec-hlm}. Some of these sections follow a similar pattern, starting with a subsection dividing the proof into further mutually independent subsections. This modularization of our proof was strongly endorsed in personal communication by the author of \cite{zk-polynomial}.
+For the proof of \Cref{metric-space-Carleson}, we largely follow \cite{zk-polynomial}, which in turn was inspired by \cite{lie-polynomial}. We make suitable modifications to adapt to our more general setting and have made a few technical improvements in the proof. In particular, in Section \ref{overviewsection}, we explicitly divide the main work of the proof into mutually independent sections \ref{thmfromproplinear}, \ref{christsection}, \ref{proptopropprop}, \ref{antichainboundary}, \ref{treesection}, \ref{liphoel}, and \ref{sec-hlm}. Some of these sections follow a similar pattern, starting with a subsection dividing the proof into further mutually independent subsections. This modularization of our proof was strongly endorsed in personal communication by the author of \cite{zk-polynomial}.
 
 
 
@@ -194,11 +194,11 @@ A.J. is funded by the T\"UBITAK (Scientific and Technological Research Council o
 \label{overviewsection}
 
 
-This section organizes the proof of Theorem \ref{metric-space-Carleson} into sections \ref{thmfromproplinear}, \ref{christsection}, \ref{proptopropprop}, \ref{antichainboundary}, \ref{treesection}, \ref{liphoel}, and \ref{sec-hlm}. These sections are mutually independent except for referring to the statements formulated in the present section. Section \ref{thmfromproplinear} proves the main Theorem \ref{metric-space-Carleson}, while sections \ref{christsection}, \ref{proptopropprop}, \ref{antichainboundary}, \ref{treesection}, \ref{liphoel}, and \ref{sec-hlm} each prove one proposition that is stated in the present section. The present section also introduces all definitions used across these sections.
+This section organizes the proof of \Cref{metric-space-Carleson} into sections \ref{thmfromproplinear}, \ref{christsection}, \ref{proptopropprop}, \ref{antichainboundary}, \ref{treesection}, \ref{liphoel}, and \ref{sec-hlm}. These sections are mutually independent except for referring to the statements formulated in the present section. Section \ref{thmfromproplinear} proves the main \Cref{metric-space-Carleson}, while sections \ref{christsection}, \ref{proptopropprop}, \ref{antichainboundary}, \ref{treesection}, \ref{liphoel}, and \ref{sec-hlm} each prove one proposition that is stated in the present section. The present section also introduces all definitions used across these sections.
 
 Subsection \ref{global-auxiliary-lemmas} proves some auxiliary lemmas that are used in more than one of the sections 3-9.
 
-Let $a, q$ be given as in Theorem \ref{metric-space-Carleson}.
+Let $a, q$ be given as in \Cref{metric-space-Carleson}.
 
 
 
@@ -253,8 +253,8 @@ For $s\in\mathbb{Z}$, we define
 \end{equation}
 so that for each $x, y \in X$ with $x\neq y$  we have
 $$K(x,y)=\sum_{s\in\mathbb{Z}}K_s(x,y).$$
- In Section \ref{thmfromproplinear}, we prove Theorem \ref{metric-space-Carleson}
- from its finitary version, Proposition \ref{finitary-Carleson} below. Recall
+ In Section \ref{thmfromproplinear}, we prove \Cref{metric-space-Carleson}
+ from its finitary version, \Cref{finitary-Carleson} below. Recall
  that a function from a measure space to a finite set is measurable if the pre-image of each of the elements in the range is measurable.
 
 
@@ -282,7 +282,7 @@ in the ball $B(o, D^S)$.
 
 
 In Section \ref{christsection},
-we prove Proposition \ref{finitary-Carleson}
+we prove \Cref{finitary-Carleson}
  using  a
 bound for a dyadic model formulated in Proposition
 \ref{discrete-Carleson} below.
@@ -404,7 +404,7 @@ we have
 
 
 
-The proof of Proposition \ref{discrete-Carleson} is done in Section \ref{proptopropprop}
+The proof of \Cref{discrete-Carleson} is done in Section \ref{proptopropprop}
 by a reduction to two further propositions that we state below.
 
 
@@ -532,7 +532,7 @@ $$
 $$
 \end{proposition}
 
-Theorem \ref{metric-space-Carleson} is formulated at the level of generality
+\Cref{metric-space-Carleson} is formulated at the level of generality
 for general kernels satisfying the mere H\"older regularity condition \eqref{eqkernel-y-smooth}. On the other hand, the cancellative condition \eqref{eq-vdc-cond} is a testing condition against more regular,
 namely Lipschitz functions. To bridge the gap, we follow \cite{zk-polynomial} to observe a variant of \eqref{eq-vdc-cond} that we formulate
 in the following proposition proved in Section \ref{liphoel}.
@@ -607,7 +607,7 @@ and for all $1 < p_1 \le p_2 \le \infty$
 
 \end{proposition}
 
-This completes the overview of the proof of Theorem \ref{metric-space-Carleson}.
+This completes the overview of the proof of \Cref{metric-space-Carleson}.
 
 \section{Auxiliary lemmas}
 \label{global-auxiliary-lemmas}
@@ -763,9 +763,9 @@ where
 \end{equation}
 \end{lemma}
 
-We first show how Lemma \ref{R-truncation} implies Theorem \ref{metric-space-Carleson}. As $R$ tends to $\infty$, the integrand of the left-hand side of \eqref{Rcut} grows monotonically toward the integrand of the left-hand side of \eqref{resweak} for all $x$. By Lebesgue's monotone convergence theorem, the left-hand side of \eqref{Rcut} converges to the left-hand side of \eqref{resweak}. This verifies Theorem \ref{metric-space-Carleson}.
+We first show how \Cref{R-truncation} implies \Cref{metric-space-Carleson}. As $R$ tends to $\infty$, the integrand of the left-hand side of \eqref{Rcut} grows monotonically toward the integrand of the left-hand side of \eqref{resweak} for all $x$. By Lebesgue's monotone convergence theorem, the left-hand side of \eqref{Rcut} converges to the left-hand side of \eqref{resweak}. This verifies \Cref{metric-space-Carleson}.
 
-It remains to prove Lemma \ref{R-truncation}. Fix an integer $R>0$. By replacing $G$ with $G\cap B(o,R)$ if necessary, it suffices to show \eqref{Rcut} under the assumption that $G$ is contained in $B(o,R)$. We make this assumption. For every $x\in G$, the domain of integration in \eqref{TRR} is contained in $B(o,2R)$. By replacing $F$ with $F\cap B(o,2R)$ if necessary, it suffices to show \eqref{Rcut} under the assumption that $F$ is contained in $B(o,2R)$. We make this assumption.
+It remains to prove \Cref{R-truncation}. Fix an integer $R>0$. By replacing $G$ with $G\cap B(o,R)$ if necessary, it suffices to show \eqref{Rcut} under the assumption that $G$ is contained in $B(o,R)$. We make this assumption. For every $x\in G$, the domain of integration in \eqref{TRR} is contained in $B(o,2R)$. By replacing $F$ with $F\cap B(o,2R)$ if necessary, it suffices to show \eqref{Rcut} under the assumption that $F$ is contained in $B(o,2R)$. We make this assumption.
 
 Using the definition \eqref{defks} of $K_s$ and the partition of unity \eqref{eq-psisum}, we express \eqref{TRR} as the sum of
 \begin{equation}\label{middles}
@@ -800,22 +800,22 @@ $$
 where $T_{1, s_1,s_2,\mfa}$ is defined in \eqref{middles}.
 \end{lemma}
 
-To reduce Lemma \ref{R-truncation} to Lemma \ref{S-truncation}, we need estimates for the summands in \eqref{boundarys}. Using Lemma \ref{kernel-summand}, we obtain for arbitrary $s$ the inequality
+To reduce \Cref{R-truncation} to \Cref{S-truncation}, we need estimates for the summands in \eqref{boundarys}. Using \Cref{kernel-summand}, we obtain for arbitrary $s$ the inequality
 \begin{multline}
 \left|\int_{R_1 <  \rho(x,y) < R_2}  K_s(x,y) f(y) e(\mfa(y)) \,  \mathrm{d}\mu(y)\right|\\
 \leq \frac{2^{102 a^3}}{\mu(B(x, D^{s}))}
  \int_{B(x, D^s)} \mathbf{1}_F(y)  \, \mathrm{d}\mu(y)
 \leq 2^{102 a^3} M\mathbf{1}_F(x),
 \end{multline}
-where $M\mathbf{1}_F$ is as defined in Proposition \ref{Hardy-Littlewood}.
-Now, the left-hand side of \eqref{Rcut}, with $T_{R_1,R_2,\mfa}$ replaced by a summand of \eqref{boundarys}, can be estimated using H\"older's inequality and Proposition \ref{Hardy-Littlewood} by
+where $M\mathbf{1}_F$ is as defined in \Cref{Hardy-Littlewood}.
+Now, the left-hand side of \eqref{Rcut}, with $T_{R_1,R_2,\mfa}$ replaced by a summand of \eqref{boundarys}, can be estimated using H\"older's inequality and \Cref{Hardy-Littlewood} by
 $$
     2^{102 a^3}\int \mathbf{1}_{G}(x) M\mathbf{1}_F(x)\, d\mu(x)
     \leq \frac{2^{102 a^3+4a}q}{q-1}\mu(G)^{1-\frac{1}{q}} \mu(F)^{\frac{1}{q}}\,.
 $$
-Applying the triangle inequality to estimate the left-hand side of \eqref{Rcut} by contributions from the summands in \eqref{middles} and \eqref{boundarys}, using Lemma \ref{S-truncation} to control the first term, and the above to estimate the contribution from the four summands in \eqref{boundarys}, combined with $a\geq 4$ and $q < 2$, completes the reduction of Lemma \ref{R-truncation} to Lemma \ref{S-truncation}.
+Applying the triangle inequality to estimate the left-hand side of \eqref{Rcut} by contributions from the summands in \eqref{middles} and \eqref{boundarys}, using \Cref{S-truncation} to control the first term, and the above to estimate the contribution from the four summands in \eqref{boundarys}, combined with $a\geq 4$ and $q < 2$, completes the reduction of \Cref{R-truncation} to \Cref{S-truncation}.
 
-It remains to prove Lemma \ref{S-truncation}. Fix $S>0$.
+It remains to prove \Cref{S-truncation}. Fix $S>0$.
 \begin{lemma}[finitary S truncation]
 \label{finitary-S-truncation}
 \uses{linearized-truncation}
@@ -830,13 +830,13 @@ $$
 \end{equation}
 \end{lemma}
 
-We reduce Lemma \ref{S-truncation} to Lemma \ref{finitary-S-truncation}.
+We reduce \Cref{S-truncation} to \Cref{finitary-S-truncation}.
 By the Lebesgue monotone convergence theorem,
 applied to an increasing sequence of finite sets $\tilde{\Mf}$, inequality \eqref{Sqcut}
 continues to hold for countable $\tilde{\Mf}$.
 
 Let $\epsilon=\frac{1}{2S+1}$. Pick some $\mfa_0 \in \Mf$.
-For $k \ge 0$, let the set $\tilde{\Mf}_k$ be a subset of $B_{B(o,2R)}(\mfa_0, k)$ of maximal size, such that for all $\mfa, \mfb \in \tilde{\Mf}_k$, it holds that $d_{B(o, 2R)}(\mfa, \mfb) \ge \epsilon$. Such a set exists, since by Lemma \ref{ball-metric-entropy} there exists an upper bound for the size of such subsets in $B_{B(o, 2R)}(\mfa_0, k)$. Define
+For $k \ge 0$, let the set $\tilde{\Mf}_k$ be a subset of $B_{B(o,2R)}(\mfa_0, k)$ of maximal size, such that for all $\mfa, \mfb \in \tilde{\Mf}_k$, it holds that $d_{B(o, 2R)}(\mfa, \mfb) \ge \epsilon$. Such a set exists, since by \Cref{ball-metric-entropy} there exists an upper bound for the size of such subsets in $B_{B(o, 2R)}(\mfa_0, k)$. Define
 $$
     \tilde{\Mf} := \bigcup_{k \in \mathbb{N}} \tilde{\Mf}_k\,.
 $$
@@ -858,7 +858,7 @@ Moreover, there is a $\tilde{\mfa}
   &\leq\sum_{s_1 \le s\le s_2} \int |K_s(x,y)|  \mathbf{1}_F(y) |e(\mfa(y)-{\mfa(x)})-e({\tilde{\mfa}(y)}-{\tilde{\mfa}(x)})| \, \mathrm{d}\mu(y)\\
     &\leq \sum_{s_1 \le s\le s_2} \epsilon \int |K_s(x,y)|  \mathbf{1}_F(y) \, \mathrm{d}\mu(y)
 \end{align*}
-Using Lemma \ref{kernel-summand}, we can estimate the above expression by
+Using \Cref{kernel-summand}, we can estimate the above expression by
 \begin{align*}
     &\sum_{s_1 \le s\le s_2} \frac{2^{102 a^3}}{\mu(B(x, D^{s}))}
 \epsilon \int_{B(x, D^s)} \mathbf{1}_F(y)  \, \mathrm{d}\mu(y)\\
@@ -877,18 +877,18 @@ which, as we have just shown, is estimated by
      &2^{102 a^3}\int \mathbf{1}_{G}(x)
 M\mathbf{1}_{F}(x)\, d\mu(x).
 \end{align*}
-By H\"older's inequality and Proposition \ref{Hardy-Littlewood}
+By H\"older's inequality and \Cref{Hardy-Littlewood}
  (more precisely, \eqref{eq-hlm-2} with $p=q$), the above is no greater than
 \begin{align*}
 &\frac{2^{102 a^3+4a}q}{q-1} \mu(G)^{1-\frac{1}{q}} \mu(F)^{\frac{1}{q}}.
 \end{align*}
-Combining this with Lemma \ref{finitary-S-truncation} and the fact that
+Combining this with \Cref{finitary-S-truncation} and the fact that
 \begin{align*}
     \frac{2^{102 a^3+4a}q}{q-1}\leq \frac{2^{445a^3}}{(q-1)^5}
 \end{align*}
-proves Lemma \ref{S-truncation}.
+proves \Cref{S-truncation}.
 
-It remains to prove Lemma \ref{finitary-S-truncation}.
+It remains to prove \Cref{finitary-S-truncation}.
 Fix a finite set
 $\tilde{\Mf}$.
 \begin{lemma}[linearized truncation]
@@ -909,8 +909,8 @@ with
 \end{equation}
 \end{lemma}
 
-We reduce Lemma \ref{finitary-S-truncation} to
-Lemma \ref{linearized-truncation}.
+We reduce \Cref{finitary-S-truncation} to
+\Cref{linearized-truncation}.
 For each $x$, let $\sigma_1(x)$ be the
 minimal element $s'\in [-S,S]$ such that
 \[\max_{s'\leq s_2<S}\max_{\mfa\in\tilde{\Mf}}
@@ -936,13 +936,13 @@ With these choices, and noting that
 {T}_{1, {\sigma}_1(x),{\sigma}_2(x),\tQ(x)} \mathbf{1}_{F}(x)={T}_{2, {\sigma}_1,{\sigma}_2,\tQ} \mathbf{1}_{F}(x),
 \end{equation*}
 we conclude that the left-hand side of \eqref{Sqcut}
-and \eqref{Sqlin} are equal. Thus, Lemma \ref{finitary-S-truncation}
-follows from Lemma \ref{linearized-truncation}.
+and \eqref{Sqlin} are equal. Thus, \Cref{finitary-S-truncation}
+follows from \Cref{linearized-truncation}.
 
-It remains to prove Lemma \ref{linearized-truncation}.
+It remains to prove \Cref{linearized-truncation}.
 Fix $\sigma_1$, $\sigma_2$,
 and $\tQ$ as in the lemma.
-Applying Proposition \ref{finitary-Carleson} recursively, we obtain
+Applying \Cref{finitary-Carleson} recursively, we obtain
 a sequence of sets $G_n$ with $G_0=G$ and,
 for each $n\ge 0$, $\mu(G_{n})\le 2^{-n} \mu(G)$ and
 \begin{equation*}
@@ -972,8 +972,8 @@ which by interchange of summation and integration is seen to be integrable, we o
 
 
 
-This completes the proof of Lemma \ref{linearized-truncation}
-and thus Theorem \ref{metric-space-Carleson}.
+This completes the proof of \Cref{linearized-truncation}
+and thus \Cref{metric-space-Carleson}.
 
 \chapter{Proof of Finitary Carleson}
 \label{christsection}
@@ -1008,9 +1008,9 @@ with the construction in \cite[Lemma 2.12]{zk-polynomial}.
     $(\fP,\scI,\fc,\fcc,\pc,\ps)$.
 \end{lemma}
 
-Choose a grid structure $(\mathcal{D}, c,s)$ with Lemma \ref{grid-existence} and a tile structure for this
-grid structure $(\fP,\scI,\fc,\fcc,\pc,\ps)$ with Lemma \ref{tile-structure}.
-Applying Proposition \ref{discrete-Carleson}, we obtain a Borel set $G'$ in $X$ with $2\mu(G')\leq \mu(G)$ such that for all Borel functions $f:X\to \C$ with $|f|\le \mathbf{1}_F$
+Choose a grid structure $(\mathcal{D}, c,s)$ with \Cref{grid-existence} and a tile structure for this
+grid structure $(\fP,\scI,\fc,\fcc,\pc,\ps)$ with \Cref{tile-structure}.
+Applying \Cref{discrete-Carleson}, we obtain a Borel set $G'$ in $X$ with $2\mu(G')\leq \mu(G)$ such that for all Borel functions $f:X\to \C$ with $|f|\le \mathbf{1}_F$
 we have \eqref{disclesssim}.
 
 \begin{lemma}[tile sum operator]
@@ -1047,7 +1047,7 @@ $x\in E(\fp)$. For this $\fp$, the value $T_{\fp}(x)$ by its definition in \eqre
 equals the right-hand side of \eqref{insump}. This proves the lemma.
 \end{proof}
 
-We now estimate with Lemma \ref{tile-sum-operator} and Proposition \ref{discrete-Carleson}
+We now estimate with \Cref{tile-sum-operator} and \Cref{discrete-Carleson}
 \begin{equation}
  \int_{G \setminus G'} \left|\sum_{s={\sigma_1}(x)}^{{\sigma_2}(x)} \int K_s(x,y) f(y) e(\tQ(x)(y))  \, \mathrm{d}\mu(y)\right| \mathrm{d}\mu(x)
 \end{equation}
@@ -1110,7 +1110,7 @@ As $\mu(o,4D^S)$ is not zero, the lemma follows.
 For each $-S\le k\le S$, let $Y_k$ be a set of
 maximal cardinality in $X$ such that $Y=Y_k$ satisfies
 the properties \eqref{ybinb} and \eqref{eq-disj-yballs}.
-By the upper bound of Lemma \ref{counting-balls}, such a set exists.
+By the upper bound of \Cref{counting-balls}, such a set exists.
 
 For each $-S\le k\le S$, choose an enumeration of the points in the finite set $Y_k$ and thus a total
 order  $<$ on $Y_{k}$.
@@ -1197,7 +1197,7 @@ We first consider \eqref{disji} for $j=1$. If $k=-S$, disjointedness of the sets
 
 We next consider \eqref{disji} for $j=3$. Assume $x$ is in $I_3(y_m,k)$ for $m=1,2$ and $y_m\in Y_k$. If $x$ is in $X_k$, then by definition \eqref{definei3}, $x\in I_1(y_m,k)$ for $m=1,2$. As we have already shown \eqref{disji} for $j=1$, we conclude $y_1=y_2$. This completes the proof in case $x\in X_k$, and we may assume $x$ is not in $X_k$. By definition \eqref{definei3}, $x$ is not in $I_3(z,k)$ for any $z$ with $z<y_1$ or $z<y_2$. Hence, neither $y_1<y_2$ nor $y_2<y_1$, and by totality of the order of $Y_k$, we have $y_1=y_2$. This completes the proof of \eqref{disji} for $j=3$.
 
-We show \eqref{unioni} for $j=2$. In case $k=-S$, this follows from Lemma \ref{cover-big-ball}. Assume $k>-S$. Let $x$ be a point of $B(o, 4D^S-2D^k)$. By induction, there is $y'\in Y_{k-1}$ such that $x\in I_3(y',k-1)$. Using the inductive statement \eqref{squeezedyadic}, we obtain $x\in B(y',4D^{k-1})$. As $D>4$, by applying the triangle inequality with the points, $o$, $x$, and $y'$, we obtain that $y'\in B(o, 4D^S-D^k)$. By Lemma \ref{cover-big-ball}, $y'$ is in $B(y,2D^k)$ for some $y\in Y_k$. It follows that $x\in I_2(y,k)$. This proves \eqref{unioni} for $j=2$.
+We show \eqref{unioni} for $j=2$. In case $k=-S$, this follows from \Cref{cover-big-ball}. Assume $k>-S$. Let $x$ be a point of $B(o, 4D^S-2D^k)$. By induction, there is $y'\in Y_{k-1}$ such that $x\in I_3(y',k-1)$. Using the inductive statement \eqref{squeezedyadic}, we obtain $x\in B(y',4D^{k-1})$. As $D>4$, by applying the triangle inequality with the points, $o$, $x$, and $y'$, we obtain that $y'\in B(o, 4D^S-D^k)$. By \Cref{cover-big-ball}, $y'$ is in $B(y,2D^k)$ for some $y\in Y_k$. It follows that $x\in I_2(y,k)$. This proves \eqref{unioni} for $j=2$.
 
 We show \eqref{unioni} for $j=3$. Let $x\in B(o, 4D^S-2D^k)$. In case $x\in X_k$, then by definition of $X_k$ we have $x\in I_1(y,k)$ for some $y\in Y_k$ and thus $x\in I_3(y,k)$. We may thus assume $x\not\in X_k$. As we have already seen \eqref{unioni} for $j=2$, there is $y\in Y_k$ such that $x\in I_2(y,k)$. We may assume this $y$ is minimal with respect to the order in $Y_k$. Then $x\in I_3(y,k)$. This proves \eqref{unioni} for $j=3$.
 
@@ -1242,15 +1242,15 @@ I_3(y',l)\subset I_3(y,k).
 \end{lemma}
 
 \begin{proof}
-Let $l,k,y,y'$ be as in the lemma. Pick $x\in I_3(y',l)\cap I_3(y,k)$. Assume first $l=k$. By \eqref{disji} of Lemma \ref{basic-grid-structure}, we conclude $y'=y$, and thus \eqref{3dyadicproperty}. Now assume $l<k$. By induction, we may assume that the statement of the lemma is proven for $k-1$ in place of $k$.
+Let $l,k,y,y'$ be as in the lemma. Pick $x\in I_3(y',l)\cap I_3(y,k)$. Assume first $l=k$. By \eqref{disji} of \Cref{basic-grid-structure}, we conclude $y'=y$, and thus \eqref{3dyadicproperty}. Now assume $l<k$. By induction, we may assume that the statement of the lemma is proven for $k-1$ in place of $k$.
 
-By Lemma \ref{cover-by-cubes}, there is a $y''\in Y_{k-1}$ such that $x\in I_3(y'',k-1)$. By induction, we have $I_3(y',l)\subset I_3(y'',k-1)$. If $l=k-1$, then by the disjointedness property of Lemma \ref{basic-grid-structure}, we see that $y'=y''$, and hence \eqref{3dyadicproperty} follows. For $l<k-1$, it remains to prove
+By \Cref{cover-by-cubes}, there is a $y''\in Y_{k-1}$ such that $x\in I_3(y'',k-1)$. By induction, we have $I_3(y',l)\subset I_3(y'',k-1)$. If $l=k-1$, then by the disjointedness property of \Cref{basic-grid-structure}, we see that $y'=y''$, and hence \eqref{3dyadicproperty} follows. For $l<k-1$, it remains to prove
 \begin{equation}\label{wyclaim}
 I_3(y'',k-1)\subset I_3(y,k).
 \end{equation}
-We make a case distinction and assume first $x\in X_k$. By Definition \eqref{definei3}, we have $x\in I_1(y,k)$. By Definition \eqref{defineij}, there is a $v\in Y_{k-1}\cap B(y,D^k)$ with $x\in I_3(v,k-1)$. By \eqref{disji} of Lemma \ref{basic-grid-structure}, we have $v=y''$. By Definition \eqref{defineij}, we then have $I_3(y'',k-1)\subset I_1(y,k)$. Then \eqref{wyclaim} follows by Definition \eqref{definei3} in the given case.
+We make a case distinction and assume first $x\in X_k$. By Definition \eqref{definei3}, we have $x\in I_1(y,k)$. By Definition \eqref{defineij}, there is a $v\in Y_{k-1}\cap B(y,D^k)$ with $x\in I_3(v,k-1)$. By \eqref{disji} of \Cref{basic-grid-structure}, we have $v=y''$. By Definition \eqref{defineij}, we then have $I_3(y'',k-1)\subset I_1(y,k)$. Then \eqref{wyclaim} follows by Definition \eqref{definei3} in the given case.
 
-Assume now the case $x\notin X_k$. By \eqref{definei3}, we have $x\in I_2(y,k)$. Moreover, for any $u<y$ in $Y_k$, we have $x\not\in I_3(u,k)$. Let $u<y$. By transitivity of the order in $Y_k$, we conclude $x\not \in I_2(u,k)$. By \eqref{defineij} and the disjointedness property of Lemma \ref{basic-grid-structure}, we have $I_3(y'',k-1)\cap  I_2(u,k)= \emptyset$. Similarly, $I_3(y'',k-1)\cap  I_1(u,k)= \emptyset$. Hence $I_3(y'',k-1)\cap  I_3(u,k)=\emptyset$. As $u<y$ was arbitrary, we conclude with \eqref{definei3} the claim in the given case. This completes the proof of \eqref{wyclaim}, and thus also \eqref{3dyadicproperty}.
+Assume now the case $x\notin X_k$. By \eqref{definei3}, we have $x\in I_2(y,k)$. Moreover, for any $u<y$ in $Y_k$, we have $x\not\in I_3(u,k)$. Let $u<y$. By transitivity of the order in $Y_k$, we conclude $x\not \in I_2(u,k)$. By \eqref{defineij} and the disjointedness property of \Cref{basic-grid-structure}, we have $I_3(y'',k-1)\cap  I_2(u,k)= \emptyset$. Similarly, $I_3(y'',k-1)\cap  I_1(u,k)= \emptyset$. Hence $I_3(y'',k-1)\cap  I_3(u,k)=\emptyset$. As $u<y$ was arbitrary, we conclude with \eqref{definei3} the claim in the given case. This completes the proof of \eqref{wyclaim}, and thus also \eqref{3dyadicproperty}.
 \end{proof}
 
 
@@ -1277,7 +1277,7 @@ $(y'',k''|y',k')$ and $(y',k'|y,k)$
 \end{lemma}
 
 \begin{proof}
-As $x\in I_3(y'',k'')\cap I_3(y',k')$ and $k''< k'$, we have by Lemma \ref{dyadic-property} that
+As $x\in I_3(y'',k'')\cap I_3(y',k')$ and $k''< k'$, we have by \Cref{dyadic-property} that
 $I_3(y'',k'')\subset I_3(y',k')$. Similarly,
 $I_3(y',k')\subset I_3(y,k)$.
 Pick $x'\in X\setminus I_3(y,k)$ such that
@@ -1316,14 +1316,14 @@ Let $K$ be as in the lemma. Let $-S+K\le k\le S$ and $y\in Y_k$.
 
 Pick $k'$ so that $k-K\le k'\le k$.
 For each $y''\in Y_{k-K}$ with $(y'',k-K| y,k)$,
-by Lemma \ref{cover-by-cubes} and Lemma \ref{dyadic-property}, there is a unique $y'\in Y_{k'}$ such that
+by \Cref{cover-by-cubes} and \Cref{dyadic-property}, there is a unique $y'\in Y_{k'}$ such that
 \begin{equation}\label{4.31}
     I_3(y'',k-K)\subset I_3(y',k')\subset I_3(y,k)\, .
 \end{equation}
-Using Lemma \ref{transitive-boundary}, $(y',k'|y,k)$.
+Using \Cref{transitive-boundary}, $(y',k'|y,k)$.
 
 We conclude using the disjointedness property of
-Lemma \ref{basic-grid-structure} that
+\Cref{basic-grid-structure} that
 \begin{equation}\label{scalecompare}
     \sum_{y'': (y'',k-K|y,k)}\mu(I_3(y'',k-K))
    \le
@@ -1364,7 +1364,7 @@ in the sum of \eqref{sumcompare1} and let
 $ B(u, \frac 14 D^l)$ and $B({u'}, \frac 14 D^{l'})$
 be the corresponding balls. If
 $l=l'$, then the balls are equal or disjoint by
-\eqref{squeezedyadic} and \eqref{disji} of Lemma \ref{basic-grid-structure}. Assume then without loss of generality that $l'<l$. Towards a contradiction, assume that
+\eqref{squeezedyadic} and \eqref{disji} of \Cref{basic-grid-structure}. Assume then without loss of generality that $l'<l$. Towards a contradiction, assume that
 \begin{equation}\label{bulbul}
     B(u, \frac 14 D^l)\cap B({u'}, \frac 14 D^{l'})\neq \emptyset
 \end{equation}
@@ -1391,7 +1391,7 @@ for each $-S+nK\le k\le S$ we have
 \begin{proof}
     We prove this by induction on $n$. If $n=0$,
     both sides of \eqref{very-new-small} are equal to
-    $\mu(I_3(y,k))$ by \eqref{disji}. If $n=1$, this follows from Lemma \ref{small-boundary}.
+    $\mu(I_3(y,k))$ by \eqref{disji}. If $n=1$, this follows from \Cref{small-boundary}.
 
     Assume $n>1$ and \eqref{very-new-small} has been proven for  $n-1$.
 We write  \eqref{very-new-small}
@@ -1420,7 +1420,7 @@ Applying \eqref{new-small-boundary} gives
     \end{equation}
 \end{lemma}
 \begin{proof}
-Let $x\in I_3(y,k)$ with  $\rho(x, X \setminus I_3(y,k)) \leq t D^{k}$. Let $K = 2^{4a+1}$ as in Lemma \ref{smaller-boundary}.
+Let $x\in I_3(y,k)$ with  $\rho(x, X \setminus I_3(y,k)) \leq t D^{k}$. Let $K = 2^{4a+1}$ as in \Cref{smaller-boundary}.
 Let $n$ be the largest integer such that
 $D^{nK} \le \frac{1}{t}$, so that $tD^k \le D^{k-nK}$ and
 \begin{equation}
@@ -1442,7 +1442,7 @@ $$
 $$
     \subset \bigcup_{y'\in Y_{k-nK}: (y',k-nK|y,k)}I_3(y',k-nK)\,.
 $$
-Using monotonicity and additivity of the measure and Lemma \ref{smaller-boundary}, we obtain
+Using monotonicity and additivity of the measure and \Cref{smaller-boundary}, we obtain
 $$
     \mu(\{x \in I_3(y,k) \ : \ \rho(x, X \setminus I_3(y,k)) \leq t D^{k}\}) \le 2^{-n} \mu(I_3(y,k))\,.
 $$
@@ -1462,7 +1462,7 @@ s(I_3(y,k)):=k
 c(I_3(y,k)):=y\,.
 \end{equation}
 We show that $(\mathcal{D},c,s)$ constitutes a grid structure. Property \eqref{eq-vol-sp-cube}
-follows from \eqref{squeezedyadic}, while \eqref{eq-small-boundary} follows from Lemma \ref{boundary-measure}.
+follows from \eqref{squeezedyadic}, while \eqref{eq-small-boundary} follows from \Cref{boundary-measure}.
 
 Let $x\in B(o, D^S)$. We show properties
 \eqref{coverdyadic},
@@ -1496,7 +1496,7 @@ x\in B(o, D^S)\subset B(o, 4D^S-2D^k)\subset \bigcup_{y\in Y_k} I_3(y,k)\, .
 
 \section{Proof of Tile Structure Lemma}
 \label{subsectiles}
-Choose a grid structure $(\mathcal{D}, c, s)$ with Lemma \ref{grid-existence}
+Choose a grid structure $(\mathcal{D}, c, s)$ with \Cref{grid-existence}
 Let $I \in \mathcal{D}$. Suppose that
 \begin{equation}
     \label{eq-tile-Z}
@@ -1507,7 +1507,7 @@ is such that for any $\mfa, \mfb \in \mathcal{Z}$ we have
     \label{eq-tile-disjoint-Z}
     B_{I^\circ}(\mfa, 0.3) \cap B_{I^\circ}(\mfb, 0.3) = \emptyset\,.
 \end{equation}
-By Lemma \ref{ball-metric-entropy} applied to each of the balls $B_{I^\circ}(\mfa, 1)$, $\mfa \in \tQ(X)$, we have
+By \Cref{ball-metric-entropy} applied to each of the balls $B_{I^\circ}(\mfa, 1)$, $\mfa \in \tQ(X)$, we have
 $$
     |\mathcal{Z}| \le 2^{2a} |\tQ(X)|\,.
 $$
@@ -1624,7 +1624,7 @@ For cubes $I \in \mathcal{D}$ for which there exists $J \in \mathcal{D}$ with $I
     $$
         d_{I^\circ}(\fcc(\fp),\mfa) \le d_{I^\circ}(\fcc(\fp), z) + d_{I^\circ}(z, \mfa) \le 0.7 + d_{I^\circ}(z, \mfa)\,.
     $$
-    By Lemma \ref{monotone-cube-metrics} and the induction hypothesis, this is estimated by
+    By \Cref{monotone-cube-metrics} and the induction hypothesis, this is estimated by
     $$
         \le 0.7 + 2^{-95a} d_{J^\circ}(z,\mfa) \le 0.7 + 2^{-95a}\cdot 1 < 1\,.
     $$
@@ -1632,33 +1632,33 @@ For cubes $I \in \mathcal{D}$ for which there exists $J \in \mathcal{D}$ with $I
 
     Next, we show \eqref{eq-dis-freq-cover}. Let $I \in \mathcal{D}$.
 
-    If $I$ is maximal with respect to inclusion, then disjointedness of the sets $\fc(\fp)$ for $\fp \in \fP(I)$ follows from the definition \eqref{eq-max-omega} and Lemma \ref{disjoint-frequency-cubes}. To obtain the inclusion in \eqref{eq-dis-freq-cover} one combines the inclusions \eqref{eq-tile-cover} and \eqref{eq-omega1-cover}
-    of Lemma \ref{frequency-cube-cover} with  \eqref{eq-max-omega}.
+    If $I$ is maximal with respect to inclusion, then disjointedness of the sets $\fc(\fp)$ for $\fp \in \fP(I)$ follows from the definition \eqref{eq-max-omega} and \Cref{disjoint-frequency-cubes}. To obtain the inclusion in \eqref{eq-dis-freq-cover} one combines the inclusions \eqref{eq-tile-cover} and \eqref{eq-omega1-cover}
+    of \Cref{frequency-cube-cover} with  \eqref{eq-max-omega}.
 
     Now we turn to the case where there exists $J \in \mathcal{D}$ with $I \subset J$ and $I\ne J$. In this case we use induction: It suffices to show \eqref{eq-dis-freq-cover} under the assumption that it holds for all cubes $J \in \mathcal{D}$ with $I \subset J$. As shown before definition \eqref{eq-it-omega}, we may choose the unique inclusion minimal such $J$. To show disjointedness of the sets $\fc(\fp), \fp \in \fP(I)$ we pick two tiles $\fp, \fp' \in \fP(I)$ and $\mfa \in \fc(\fp) \cap \fc(\fp')$.
     Then we are by \eqref{eq-it-omega} in one of the following four cases.
 
-    1. There exist $z \in \mathcal{Z}(J) \cap \Omega_1(\fp)$ such that $\mfa \in \Omega(J, z)$, and there exists $z' \in \mathcal{Z}(J) \cap \Omega_1(\fp')$ such that $\mfa \in \Omega(J, z')$. By the induction hypothesis, that \eqref{eq-dis-freq-cover} holds for $J$, we must have $z = z'$. By Lemma \ref{disjoint-frequency-cubes}, we must then have $\fp = \fp'$.
+    1. There exist $z \in \mathcal{Z}(J) \cap \Omega_1(\fp)$ such that $\mfa \in \Omega(J, z)$, and there exists $z' \in \mathcal{Z}(J) \cap \Omega_1(\fp')$ such that $\mfa \in \Omega(J, z')$. By the induction hypothesis, that \eqref{eq-dis-freq-cover} holds for $J$, we must have $z = z'$. By \Cref{disjoint-frequency-cubes}, we must then have $\fp = \fp'$.
 
-    2. There exists $z \in \mathcal{Z}(J) \cap \Omega_1(\fp)$ such that $\mfa \in \Omega(J,z)$, and $\mfa \in B_{\fp'}(\fcc(\fp'), 0.2)$.  Using the triangle inequality, Lemma \ref{monotone-cube-metrics} and \eqref{eq-freq-comp-ball}, we obtain
+    2. There exists $z \in \mathcal{Z}(J) \cap \Omega_1(\fp)$ such that $\mfa \in \Omega(J,z)$, and $\mfa \in B_{\fp'}(\fcc(\fp'), 0.2)$.  Using the triangle inequality, \Cref{monotone-cube-metrics} and \eqref{eq-freq-comp-ball}, we obtain
     $$
         d_{\fp'}(\fcc(\fp'),z) \le d_{\fp'}(\fcc(\fp'), \mfa) + d_{\fp'}(z, \mfa) \le 0.2 + 2^{-95a} \cdot 1 < 0.3\,.
     $$
-    Thus $z \in \Omega_1(\fp')$ by \eqref{eq-omega1-incl}. By Lemma \ref{disjoint-frequency-cubes}, it follows that $\fp = \fp'$.
+    Thus $z \in \Omega_1(\fp')$ by \eqref{eq-omega1-incl}. By \Cref{disjoint-frequency-cubes}, it follows that $\fp = \fp'$.
 
     3. There exists $z' \in \mathcal{Z}(J) \cap \Omega_1(\fp')$ such that $\mfa \in \Omega(J,z')$, and $\mfa \in B_{\fp}(\fcc(\fp), 0.2)$. This case is the same as case 2., after swapping $\fp$ and $\fp'$.
 
-    4. We have $\mfa \in B_{\fp}(\fcc(\fp), 0.2) \cap B_{\fp'}(\fcc(\fp'), 0.2)$. In this case it follows that $\fp = \fp'$ since the sets $B_{\fp}(\fcc(\fp), 0.2)$ are pairwise disjoint by the inclusion \eqref{eq-omega1-incl} and Lemma \ref{disjoint-frequency-cubes}.
+    4. We have $\mfa \in B_{\fp}(\fcc(\fp), 0.2) \cap B_{\fp'}(\fcc(\fp'), 0.2)$. In this case it follows that $\fp = \fp'$ since the sets $B_{\fp}(\fcc(\fp), 0.2)$ are pairwise disjoint by the inclusion \eqref{eq-omega1-incl} and \Cref{disjoint-frequency-cubes}.
 
-    To show the inclusion in \eqref{eq-dis-freq-cover}, let $\mfa \in \tQ(X)$. By the induction hypothesis, there exists $\fp \in \fP(J)$ such that $\mfa \in \Omega(\fp)$. By definition of the set $\fP$, we have $\fp = (J, z)$ for some $z \in \mathcal{Z}(J)$. By \eqref{eq-tile-Z}, there exists $x \in X$ with $d_{J^\circ}(\tQ(x), z) \le 1$. By Lemma \ref{monotone-cube-metrics}, it follows that $d_{I^\circ}(\tQ(x), z) \le 1$.
+    To show the inclusion in \eqref{eq-dis-freq-cover}, let $\mfa \in \tQ(X)$. By the induction hypothesis, there exists $\fp \in \fP(J)$ such that $\mfa \in \Omega(\fp)$. By definition of the set $\fP$, we have $\fp = (J, z)$ for some $z \in \mathcal{Z}(J)$. By \eqref{eq-tile-Z}, there exists $x \in X$ with $d_{J^\circ}(\tQ(x), z) \le 1$. By \Cref{monotone-cube-metrics}, it follows that $d_{I^\circ}(\tQ(x), z) \le 1$.
     Thus, by \eqref{eq-tile-cover}, there exists $z' \in \mathcal{Z}(I)$ with $z \in B_{I^\circ}(z', 0.7)$. Then by Lemma \eqref{frequency-cube-cover} there exists $\fp' \in \fP(I)$ with $z \in \mathcal{Z}(J) \cap \Omega_1(\fp')$. Consequently, by \eqref{eq-it-omega}, $\mfa \in \fc(\fp')$. This completes the proof of \eqref{eq-dis-freq-cover}.
 
     Finally, we show \eqref{eq-freq-dyadic}. Let $\fp, \fq \in \fP$ with $\scI(\fp) \subset \scI(\fp)$ and $\fc(\fp) \cap \fc(\fq) \ne \emptyset$. If we have $\ps(\fp) \ge \ps(\fq)$, then it follows from \eqref{dyadicproperty} that $I = J$, thus $\fp, \fq \in \fP(I)$. By \eqref{eq-dis-freq-cover} we have then either $\fc(\fp) \cap \fc(\fq) = \emptyset$ or $\fc(\fp) = \fc(\fq)$. By the assumption in \eqref{eq-freq-dyadic} we have $\fc(\fp) \cap \fc(\fq) \ne \emptyset$, so we must have $\fc(\fp) = \fc(\fq)$ and in particular $\fc(\fq) \subset \fc(\fp)$.
 
     So it remains to show \eqref{eq-freq-dyadic} under the additional assumption that $\ps(\fq) > \ps(\fp)$. In this case, we argue by induction on $\ps(\fq)-\ps(\fp)$. By \eqref{coverdyadic}, there exists a cube $J \in \mathcal{D}$ with $s(J) = \ps(\fq) - 1$ and $J \cap\scI(\fp) \ne \emptyset$. We pick one such $J$. By \eqref{dyadicproperty}, we have $\scI(\fp) \subset J \subset \scI(\fq)$.
 
-    By \eqref{eq-tile-Z}, there exists $x \in X$ with $d_{\fq}(\tQ(x), \fcc(\fq)) \le 1$. By Lemma \ref{monotone-cube-metrics}, it follows that $d_{J^\circ}(\tQ(x), \fcc(\fq)) \le 1$.
-    Thus, by \eqref{eq-tile-cover}, there exists $z' \in \mathcal{Z}(J)$ with $\fcc(\fq) \in B_{J^\circ}(z', 0.7)$. Then by Lemma \ref{frequency-cube-cover} there exists $\fq' \in \fP(J)$ with $\fcc(\fq) \in\Omega_1(\fq')$.
+    By \eqref{eq-tile-Z}, there exists $x \in X$ with $d_{\fq}(\tQ(x), \fcc(\fq)) \le 1$. By \Cref{monotone-cube-metrics}, it follows that $d_{J^\circ}(\tQ(x), \fcc(\fq)) \le 1$.
+    Thus, by \eqref{eq-tile-cover}, there exists $z' \in \mathcal{Z}(J)$ with $\fcc(\fq) \in B_{J^\circ}(z', 0.7)$. Then by \Cref{frequency-cube-cover} there exists $\fq' \in \fP(J)$ with $\fcc(\fq) \in\Omega_1(\fq')$.
     By \eqref{eq-it-omega}, it follows that $\Omega(\fq) \subset \Omega(\fq')$. Note that then $\scI(\fp) \subset \scI(\fq')$ and $\fc(\fp) \cap \fc(\fq') \ne \emptyset$ and $\ps(\fq') - \ps(\fp) = \ps(\fq) - \ps(\fp) - 1$. Thus, we have by the induction hypothesis that $\Omega(\fq') \subset \Omega(\fp)$. This completes the proof.
 \end{proof}
 
@@ -1667,7 +1667,7 @@ For cubes $I \in \mathcal{D}$ for which there exists $J \in \mathcal{D}$ with $I
 
 
 
-Let a grid structure $(\mathcal{D}, c, s)$ and a tile structure $(\fP, \scI, \fc, \fcc)$ for this grid structure be given. In Subsection \ref{subsectilesorg}, we decompose the set $\fP$ of tiles into subsets. Each subset will be controlled by one of three methods. The guiding principle of the decomposition is to be able to apply the forest estimate of Proposition \ref{forest-operator} to the final subsets defined in \eqref{defc5}. This application is done in Subsection \ref{subsecforest}. The miscellaneous subsets along the construction of the forests will either be thrown into exceptional sets, which are defined and controlled in Subsection \ref{subsetexcset}, or will be controlled by the antichain estimate of Proposition \ref{antichain-operator}, which is done in Subsection \ref{subsecantichain}. Subsection \ref{subsec-lessim-aux} contains some auxiliary lemmas needed for the proofs in Subsections \ref{subsecforest}-\ref{subsecantichain}.
+Let a grid structure $(\mathcal{D}, c, s)$ and a tile structure $(\fP, \scI, \fc, \fcc)$ for this grid structure be given. In Subsection \ref{subsectilesorg}, we decompose the set $\fP$ of tiles into subsets. Each subset will be controlled by one of three methods. The guiding principle of the decomposition is to be able to apply the forest estimate of \Cref{forest-operator} to the final subsets defined in \eqref{defc5}. This application is done in Subsection \ref{subsecforest}. The miscellaneous subsets along the construction of the forests will either be thrown into exceptional sets, which are defined and controlled in Subsection \ref{subsetexcset}, or will be controlled by the antichain estimate of \Cref{antichain-operator}, which is done in Subsection \ref{subsecantichain}. Subsection \ref{subsec-lessim-aux} contains some auxiliary lemmas needed for the proofs in Subsections \ref{subsecforest}-\ref{subsecantichain}.
 
 
 
@@ -1879,7 +1879,7 @@ In Subsection \ref{subsecforest}, we identify each set $\fC_5(k,n,j)$ outside $G
 In Subsection \ref{subsecantichain}, we decompose
 the complement of the set of tiles in Lemma
 \ref{forest-union} and apply the antichain estimate of
-Proposition \ref{antichain-operator} to prove the following lemma.
+\Cref{antichain-operator} to prove the following lemma.
 
 \begin{lemma}[forest complement]
 \label{forest-complement}
@@ -1894,11 +1894,11 @@ Proposition \ref{antichain-operator} to prove the following lemma.
     \int_{G \setminus  G'} \left|\sum_{\fp \in \fP_2} T_{\fp} f\right| \, \mathrm{d}\mu  \le \frac{2^{210a^3}}{(q-1)^4} \mu(G)^{1 - \frac{1}{q}} \mu(F)^{\frac{1}{q}}\,.
 \end{equation}
 \end{lemma}
-Proposition \ref{discrete-Carleson} follows by applying
+\Cref{discrete-Carleson} follows by applying
 triangle inequality to \eqref{disclesssim}
-according to the splitting in Lemma \ref{forest-union}
-and Lemma \ref{forest-complement} and using both Lemmas as well
-as the bound on the set $G'$ given by Lemma \ref{exceptional-set}.
+according to the splitting in \Cref{forest-union}
+and \Cref{forest-complement} and using both Lemmas as well
+as the bound on the set $G'$ given by \Cref{exceptional-set}.
 
 
 \section{Proof of the Exceptional Sets Lemma}
@@ -1907,9 +1907,9 @@ as the bound on the set $G'$ given by Lemma \ref{exceptional-set}.
 
 We prove separate bounds for $G_1$, $G_2$, and $G_3$
 in Lemmas  \ref{first-exception},
-\ref{second-exception}, and \ref{third-exception}. Adding up these bounds proves Lemma \ref{exceptional-set}.
+\ref{second-exception}, and \ref{third-exception}. Adding up these bounds proves \Cref{exceptional-set}.
 
-The bound for $G_1$ is follows from the Vitali covering lemma, Proposition \ref{Hardy-Littlewood}.
+The bound for $G_1$ is follows from the Vitali covering lemma, \Cref{Hardy-Littlewood}.
 
 \begin{lemma}
 [first exception]\label{first-exception}
@@ -1930,7 +1930,7 @@ $$
   {\mu(F\cap B(\pc(\fp),r(\fp)))}\ge K{\mu(B(\pc(\fp),r(\fp)))}\, .
 $$
 This ball exists by definition of $\fP_{F,G}$
-and $\dens_2$. By applying Proposition \ref{Hardy-Littlewood}to the collection of balls
+and $\dens_2$. By applying \Cref{Hardy-Littlewood}to the collection of balls
 $$
     \mathcal{B} = \{B(\pc(\fp),r(\fp)) \ : \ \fp \in \fP_{F,G}\}
 $$
@@ -1946,8 +1946,8 @@ $$
 \end{proof}
 
 
-We turn to the bound of $G_2$, which relies on the Dyadic Covering Lemma \ref{dense-cover} and the
-John-Nirenberg Lemma \ref{John-Nirenberg} below.
+We turn to the bound of $G_2$, which relies on the Dyadic Covering \Cref{dense-cover} and the
+John-Nirenberg \Cref{John-Nirenberg} below.
 
 \begin{lemma}[dense cover]
 \label{dense-cover}
@@ -2037,12 +2037,12 @@ Fix $k,n$ as in the lemma
 and suppress notation to write
 $A(\lambda)$ for $A(\lambda,k,n)$.
 We prove the lemma by induction on $\lambda$.
-For $\lambda=0$, we use that $A(\lambda)$ by definition of $\mathfrak{M}(k,n)$ is contained in the union of elements in $ \mathcal{C}(G,k)$. Lemma \ref{dense-cover} then completes  the base of the induction.
+For $\lambda=0$, we use that $A(\lambda)$ by definition of $\mathfrak{M}(k,n)$ is contained in the union of elements in $ \mathcal{C}(G,k)$. \Cref{dense-cover} then completes  the base of the induction.
 
-Now assume that the statement of Lemma \ref{John-Nirenberg}
+Now assume that the statement of \Cref{John-Nirenberg}
 is proven for some integer $\lambda\ge 0$.
 The set $A(\lambda+1)$ is contained in the set $A(\lambda)$.
-Let  $\mathcal{M}$ be the set of dyadic cubes which are a subset of $A(\lambda)$. By Lemma \ref{dyadic-union}, the union of $\mathcal{M}$ is $A(\lambda)$.
+Let  $\mathcal{M}$ be the set of dyadic cubes which are a subset of $A(\lambda)$. By \Cref{dyadic-union}, the union of $\mathcal{M}$ is $A(\lambda)$.
 Let $\mathcal{M}^*$ be the set of maximal dyadic cubes in $\mathcal{M}$.
 
 Let $L\in \mathcal{M}^*$. For each $x\in L$, we have
@@ -2065,7 +2065,7 @@ the left-hand-side of \eqref{suminout} is at least
 $1+(\lambda+1) 2^{n+1}$, so we have by the triangle inequality for the first sum on the right-hand side
 \begin{equation}\label{mnkonl}
 \sum_{\fp \in {\mathfrak{M}}(k,n):\scI(\fp) \subset L} \mathbf{1}_{\scI(\fp)}(x)\ge 2^{n+1}\, .\end{equation}
-By Lemma \ref{pairwise-disjoint}, we have
+By \Cref{pairwise-disjoint}, we have
 \begin{equation}
 \sum_{\fp \in {\mathfrak{M}}(k,n):\scI(\fp) \subset L} \mu({E_1}(\fp)) \leq \mu(L)\, .
 \end{equation}
@@ -2103,7 +2103,7 @@ We have
 \end{lemma}
 \begin{proof}
 
-We use Lemma \ref{John-Nirenberg} and sum twice a geometric series
+We use \Cref{John-Nirenberg} and sum twice a geometric series
 to obtain
 \begin{equation}
     \sum_{0\le  k}\sum_{k< n}
@@ -2132,7 +2132,7 @@ We turn to the set $G_3$.
     \int \sum_{\mathfrak{m} \in \mathfrak{M}(k,n)} \mathbf{1}_{\scI(\mathfrak{m})}(x) \, d\mu(x) \le
 2^{n+1} \sum_{\lambda=1}^{|\mathfrak{M}|}\mu(A(\lambda, k,n))\,.
 \end{equation}
-Using Lemma \ref{John-Nirenberg}
+Using \Cref{John-Nirenberg}
 and then summing a geometric series, we estimate this by
 \begin{equation}
     \le
@@ -2284,7 +2284,7 @@ $\fu\in \fU_1(k,n,l)$, we have
 \le \sum_{\fu\in \fU_1(k,n,j)}
 \mu(\bigcup_{I \in \mathcal{L} (\fu)}I).
 \end{equation}
-Using Lemma \ref{boundary-exception} and then Lemma \ref{tree-count}, we estimate this further
+Using \Cref{boundary-exception} and then \Cref{tree-count}, we estimate this further
  by
 \begin{equation}
     \le \sum_{\fu\in \fU_1(k,n,j)}
@@ -2296,7 +2296,7 @@ Using Lemma \ref{boundary-exception} and then Lemma \ref{tree-count}, we estimat
      D^{-\kappa Z(n+1)}
     \mu(\scI(\mathfrak{m}))\,.
 \end{equation}
-Using Lemma \ref{top-tiles}, we estimate this by
+Using \Cref{top-tiles}, we estimate this by
   \begin{equation}
      \le
 2^{100a^2 + 9a + 1-j}  D^{-\kappa Z(n+1)}
@@ -2334,7 +2334,7 @@ Using $D = 2^{100a^2}$ and $a \ge 4$ and $\kappa Z \ge 2$ by \eqref{defineD} and
 
 \section{Auxiliary lemmas}
 \label{subsec-lessim-aux}
-Before proving Lemma \ref{forest-union} and Lemma \ref{forest-complement}, we collect some useful properties of $\lesssim$.
+Before proving \Cref{forest-union} and \Cref{forest-complement}, we collect some useful properties of $\lesssim$.
 
 \begin{lemma}[wiggle order 1]
     \label{wiggle-order-1}
@@ -2369,7 +2369,7 @@ Before proving Lemma \ref{forest-union} and Lemma \ref{forest-complement}, we co
     $$
         d_{\fp}(\fcc(\fp), \mfa) \le  d_{\fp}(\fcc(\fp), \fcc(\fp')) +  d_{\fp}(\fcc(\fp'), \mfa)
     $$
-    Using \eqref{eq-wiggle1} and \eqref{wiggleorder} for the first summand, and Lemma \ref{monotone-cube-metrics} for the second summand, this is estimated by
+    Using \eqref{eq-wiggle1} and \eqref{wiggleorder} for the first summand, and \Cref{monotone-cube-metrics} for the second summand, this is estimated by
     $$
         n + 2^{-95a} d_{\fp'}(\fcc(\fp'), \mfa) < n + 2^{-95a} m\,.
     $$
@@ -2395,7 +2395,7 @@ Before proving Lemma \ref{forest-union} and Lemma \ref{forest-complement}, we co
 \end{lemma}
 
 \begin{proof}
-    All three implications are easy consequences of Lemma \ref{wiggle-order-1}, Lemma \ref{wiggle-order-2} and the fact that $a \ge 4$.
+    All three implications are easy consequences of \Cref{wiggle-order-1}, \Cref{wiggle-order-2} and the fact that $a \ge 4$.
 \end{proof}
 
 
@@ -2427,7 +2427,7 @@ We call a collection $\mathfrak{A}$ of tiles convex if
 \end{lemma}
 
 \begin{proof}
-    Let $\fp \le \fp' \le \fp''$ with $\fp, \fp'' \in \fC(k,n)$. Then, in particular, $\fp, \fp'' \in \fP(k)$, so, by Lemma \ref{P-convex}, $\fp' \in \fP(k)$. Next, we show that if $\fq \le \fq' \in \fP(k)$ then $\dens'_k(\{\fq\}) \ge \dens_k'(\{\fq'\})$. If $\fp \in \fP(k)$ and $\lambda \ge 2$ with $\lambda \fq' \lesssim \lambda \fp$, then it follows from $\fq \le \fq'$, \eqref{eq-sc1} of Lemma \ref{wiggle-order-3} and transitivity of $\lesssim$ that $\lambda \fq \lesssim \lambda \fp$. Thus the supremum in the definition \eqref{eq-densdef} of $\dens_k'(\{\fq\})$ is over a superset of the set the  supremum in the definition of $\dens_k'(\{\fq'\})$ is taken over, which shows $\dens'_k(\{\fq\}) \ge \dens_k'(\{\fq'\})$. From $\fp' \le \fp''$, $\fp'' \in \fC(k,n)$ and \eqref{def-cnk} it then follows that
+    Let $\fp \le \fp' \le \fp''$ with $\fp, \fp'' \in \fC(k,n)$. Then, in particular, $\fp, \fp'' \in \fP(k)$, so, by \Cref{P-convex}, $\fp' \in \fP(k)$. Next, we show that if $\fq \le \fq' \in \fP(k)$ then $\dens'_k(\{\fq\}) \ge \dens_k'(\{\fq'\})$. If $\fp \in \fP(k)$ and $\lambda \ge 2$ with $\lambda \fq' \lesssim \lambda \fp$, then it follows from $\fq \le \fq'$, \eqref{eq-sc1} of \Cref{wiggle-order-3} and transitivity of $\lesssim$ that $\lambda \fq \lesssim \lambda \fp$. Thus the supremum in the definition \eqref{eq-densdef} of $\dens_k'(\{\fq\})$ is over a superset of the set the  supremum in the definition of $\dens_k'(\{\fq'\})$ is taken over, which shows $\dens'_k(\{\fq\}) \ge \dens_k'(\{\fq'\})$. From $\fp' \le \fp''$, $\fp'' \in \fC(k,n)$ and \eqref{def-cnk} it then follows that
     $$
         2^{4a}2^{-n} < \dens_k'(\{\fp''\}) \le \dens_k'(\{\fp'\})\,.
     $$
@@ -2445,7 +2445,7 @@ We call a collection $\mathfrak{A}$ of tiles convex if
 \end{lemma}
 
 \begin{proof}
-    Let $\fp\le\fp'\le\fp''$ with $\fp, \fp'' \in \fC_1(k,n,j)$. By Lemma \ref{C-convex} and the inclusion $\fC_1(k,n,j) \subset \fC(k,n)$, which holds by definition \eqref{defcnkj}, we have $\fp' \in \fC(k,n)$. By \eqref{eq-sc1} and transitivity of $\lesssim$ we have that $\fq \le \fq'$ and $100 \fq' \lesssim \mathfrak{m}$ imply $100 \fq \lesssim \mathfrak{m}$. So, by \eqref{defbfp}, $\mathfrak{B}(\fp'') \subset \mathfrak{B}(\fp') \subset \mathfrak{B}(\fp)$. Consequently, by \eqref{defcnkj}
+    Let $\fp\le\fp'\le\fp''$ with $\fp, \fp'' \in \fC_1(k,n,j)$. By \Cref{C-convex} and the inclusion $\fC_1(k,n,j) \subset \fC(k,n)$, which holds by definition \eqref{defcnkj}, we have $\fp' \in \fC(k,n)$. By \eqref{eq-sc1} and transitivity of $\lesssim$ we have that $\fq \le \fq'$ and $100 \fq' \lesssim \mathfrak{m}$ imply $100 \fq \lesssim \mathfrak{m}$. So, by \eqref{defbfp}, $\mathfrak{B}(\fp'') \subset \mathfrak{B}(\fp') \subset \mathfrak{B}(\fp)$. Consequently, by \eqref{defcnkj}
     $$
         2^j \le |\mathfrak{B}(\fp'')|\le |\mathfrak{B}(\fp')| \le |\mathfrak{B}(\fp)| < 2^{j+1}\,,
     $$
@@ -2462,7 +2462,7 @@ We call a collection $\mathfrak{A}$ of tiles convex if
      Let $\fp \le \fp' \le \fp''$ with $\fp, \fp'' \in \fC_2(k,n,j)$. By \eqref{eq-C2-def}, we have
      \begin{equation*}
          \fC_2(k,n,j) \subset \fC_1(k,n,j)\ .
-     \end{equation*} Combined with Lemma \ref{C1-convex}, it follows that $\fp' \in \fC_1(k,n,j)$. Suppose that $\fp' \notin \fC_2(k,n,j)$. By \eqref{eq-C2-def}, this implies that there exists $0 \le l' \le Z(n+1)$ with $\fp' \in \fL_1(k,n,j,l')$. By the definition \eqref{eq-L1-def} of $\fL_1(k,n,j,l')$, this implies that $\fp$ is minimal with respect to $\le$  in $\fC_1(k,n,j) \setminus \bigcup_{l < l'} \fL_1(k,n,j,l)$. Since $\fp \in \fC_2(k,n,j)$ we must have $\fp \ne \fp'$. Thus $\fp \le \fp'$ and $\fp \ne \fp'$. By minimality of $\fp'$ it follows that $\fp \notin \fC_1(k,n,j) \setminus \bigcup_{l < l'} \fL_1(k,n,j,l)$. But by \eqref{eq-C2-def} this implies $\fp \notin \fC_2(k,n,j)$, a contradiction.
+     \end{equation*} Combined with \Cref{C1-convex}, it follows that $\fp' \in \fC_1(k,n,j)$. Suppose that $\fp' \notin \fC_2(k,n,j)$. By \eqref{eq-C2-def}, this implies that there exists $0 \le l' \le Z(n+1)$ with $\fp' \in \fL_1(k,n,j,l')$. By the definition \eqref{eq-L1-def} of $\fL_1(k,n,j,l')$, this implies that $\fp$ is minimal with respect to $\le$  in $\fC_1(k,n,j) \setminus \bigcup_{l < l'} \fL_1(k,n,j,l)$. Since $\fp \in \fC_2(k,n,j)$ we must have $\fp \ne \fp'$. Thus $\fp \le \fp'$ and $\fp \ne \fp'$. By minimality of $\fp'$ it follows that $\fp \notin \fC_1(k,n,j) \setminus \bigcup_{l < l'} \fL_1(k,n,j,l)$. But by \eqref{eq-C2-def} this implies $\fp \notin \fC_2(k,n,j)$, a contradiction.
 \end{proof}
 
 \begin{lemma}[C3 convex]
@@ -2472,7 +2472,7 @@ We call a collection $\mathfrak{A}$ of tiles convex if
 \end{lemma}
 
 \begin{proof}
-    Let $\fp \le \fp' \le \fp''$ with $\fp, \fp'' \in \fC_3(k,n,j)$. By \eqref{eq-C3-def} and Lemma \ref{C2-convex} it follows that $\fp' \in \fC_2(k,n,j)$. Suppose that $\fp' \notin \fC_3(k,n,j)$. Then, by \eqref{eq-C3-def} and \eqref{eq-L2-def}, there exists $\fu \in \fU_1(k,n,j)$ with $2\fp' \lesssim \fu$ and $\scI(\fp') \ne \scI(\fu)$. Together this gives $\scI(\fp') \subsetneq \scI(\fu)$. From $\fp' \le \fp$, \eqref{eq-sc1} and transitivity of $\lesssim$ we then have $2\fp \lesssim \fu$. Also, $\scI(\fp) \subset \scI(\fp') \subsetneq \scI(\fu)$, so $\scI(\fp) \ne \scI(\fu)$. But then $\fp \in \fL_2(k,n,j)$, contradicting by \eqref{eq-C3-def} the assumption $\fp \in \fC_3(k,n,j)$.
+    Let $\fp \le \fp' \le \fp''$ with $\fp, \fp'' \in \fC_3(k,n,j)$. By \eqref{eq-C3-def} and \Cref{C2-convex} it follows that $\fp' \in \fC_2(k,n,j)$. Suppose that $\fp' \notin \fC_3(k,n,j)$. Then, by \eqref{eq-C3-def} and \eqref{eq-L2-def}, there exists $\fu \in \fU_1(k,n,j)$ with $2\fp' \lesssim \fu$ and $\scI(\fp') \ne \scI(\fu)$. Together this gives $\scI(\fp') \subsetneq \scI(\fu)$. From $\fp' \le \fp$, \eqref{eq-sc1} and transitivity of $\lesssim$ we then have $2\fp \lesssim \fu$. Also, $\scI(\fp) \subset \scI(\fp') \subsetneq \scI(\fu)$, so $\scI(\fp) \ne \scI(\fu)$. But then $\fp \in \fL_2(k,n,j)$, contradicting by \eqref{eq-C3-def} the assumption $\fp \in \fC_3(k,n,j)$.
 \end{proof}
 
 \begin{lemma}[C4 convex]
@@ -2482,7 +2482,7 @@ We call a collection $\mathfrak{A}$ of tiles convex if
 \end{lemma}
 
 \begin{proof}
-    Let $\fp \le \fp' \le\fp''$ with $\fp, \fp'' \in \fC_4(k,n,j)$. As before we obtain from the inclusion $\fC_4(k,n,j) \subset \fC_3(k,n,j)$ and Lemma \ref{C3-convex} that $\fp' \in \fC_3(k,n,j)$. Thus, if $\fp' \notin \fC_4(k,n,j)$ then by \eqref{eq-L3-def} there exists $l$ such that $\fp' \in \fL_3(k,n,j,l)$. Thus $\fp'$ is maximal with respect to $\le$ in $\fC_3(k,n,j) \setminus \bigcup_{0 \le l' < l} \fL_3(k,n,j,l')$.  Since $\fp'' \in \fC_4(k,n,j)$ we must have $\fp' \ne \fp''$. Thus $\fp' \le \fp''$ and $\fp'\ne \fp''$. By minimality of $\fp'$ it follows that $\fp'' \notin \fC_3(k,n,j) \setminus \bigcup_{l < l'} \fL_3(k,n,j,l)$. But by \eqref{eq-C4-def} this implies $\fp'' \notin \fC_4(k,n,j)$, a contradiction.
+    Let $\fp \le \fp' \le\fp''$ with $\fp, \fp'' \in \fC_4(k,n,j)$. As before we obtain from the inclusion $\fC_4(k,n,j) \subset \fC_3(k,n,j)$ and \Cref{C3-convex} that $\fp' \in \fC_3(k,n,j)$. Thus, if $\fp' \notin \fC_4(k,n,j)$ then by \eqref{eq-L3-def} there exists $l$ such that $\fp' \in \fL_3(k,n,j,l)$. Thus $\fp'$ is maximal with respect to $\le$ in $\fC_3(k,n,j) \setminus \bigcup_{0 \le l' < l} \fL_3(k,n,j,l')$.  Since $\fp'' \in \fC_4(k,n,j)$ we must have $\fp' \ne \fp''$. Thus $\fp' \le \fp''$ and $\fp'\ne \fp''$. By minimality of $\fp'$ it follows that $\fp'' \notin \fC_3(k,n,j) \setminus \bigcup_{l < l'} \fL_3(k,n,j,l)$. But by \eqref{eq-C4-def} this implies $\fp'' \notin \fC_4(k,n,j)$, a contradiction.
 \end{proof}
 
 \begin{lemma}[C5 convex]
@@ -2492,7 +2492,7 @@ We call a collection $\mathfrak{A}$ of tiles convex if
 \end{lemma}
 
 \begin{proof}
-    Let $\fp \le \fp' \le\fp''$ with $\fp, \fp'' \in \fC_5(k,n,j)$. Then $\fp, \fp'' \in \fC_4(k,n,j)$ by \eqref{defc5}, and thus by Lemma \ref{C4-convex} also $\fp' \in \fC_4(k,n,j)$. Suppose that $\fp' \notin \fC_5(k,n,j)$. By \eqref{defc5}, it follows that $\fp' \in \fL_4(k,n,j)$.
+    Let $\fp \le \fp' \le\fp''$ with $\fp, \fp'' \in \fC_5(k,n,j)$. Then $\fp, \fp'' \in \fC_4(k,n,j)$ by \eqref{defc5}, and thus by \Cref{C4-convex} also $\fp' \in \fC_4(k,n,j)$. Suppose that $\fp' \notin \fC_5(k,n,j)$. By \eqref{defc5}, it follows that $\fp' \in \fL_4(k,n,j)$.
     By \eqref{eq-L4-def}, there exists $\fu \in \fU_1(k,n,j)$ with $\scI(\fp') \subset \bigcup \mathcal{L}(\fu)$. Then also $\scI(\fp) \subset \bigcup \mathcal{L}(\fu)$, a contradiction.
 \end{proof}
 
@@ -2550,7 +2550,7 @@ there exists $J\in \mathcal{D}$ with
 \end{lemma}
 
 \begin{proof}
-    We have by Lemma \ref{dens-compare} that
+    We have by \Cref{dens-compare} that
     $\dens_1(\mathfrak{A}) \le \dens_k'(\mathfrak{A})$. Since $\mathfrak{A} \subset \fC(k,n)$, it follows from monotonicity of suprema and the definition \eqref{eq-densdef} that
     $
         \dens_k'(\mathfrak{A}) \le \dens_k'(\fC(k,n))\,.
@@ -2600,7 +2600,7 @@ with $10 \fp\lesssim \fu'$.
 
 \begin{proof}
     Let $\fu, \fu' \in \fU_2(k,n,j)$ with $\fu \sim \fu'$. If $\fu = \fu'$ then the conclusion of the Lemma clearly holds. Else, there exists $\fp \in \fC_1(k,n,j)$ such that $\scI(\fp) \ne \scI(\fu)$ and  $2 \fp \lesssim \fu$ and $10 \fp \lesssim \fu'$.
-    Using Lemma \ref{wiggle-order-1} and \eqref{eq-sc2} of Lemma \ref{wiggle-order-3}, we deduce that
+    Using \Cref{wiggle-order-1} and \eqref{eq-sc2} of \Cref{wiggle-order-3}, we deduce that
     \begin{equation}
         \label{eq-Fefferman-trick0}
         100 \fp\lesssim  100 \fu\,, \qquad 100 \fp \lesssim 100\fu'\,.
@@ -2634,7 +2634,7 @@ $\fU_2(k,n,j)$ is an equivalence relation.
         \fu, \fu', \fu'' \in \fU_1(k,n,j)
     \end{equation*}
     and $\fu \sim \fu'$, $\fu' \sim \fu''$.
-    By Lemma \ref{relation-geometry}, it follows that $\scI(\fu) =\scI(\fu') = \scI(\fu'')$, that there exists
+    By \Cref{relation-geometry}, it follows that $\scI(\fu) =\scI(\fu') = \scI(\fu'')$, that there exists
     \begin{equation*}
         \mfa \in B_{\fu}(\fcc(\fu), 100) \cap B_{\fu'}(\fcc(\fu'), 100)
     \end{equation*}
@@ -2658,7 +2658,7 @@ $\fU_2(k,n,j)$ is an equivalence relation.
     \end{align*}
     Since $4\fp \lesssim 500 \fu$, it follows that $d_{\fp}(\fcc(\fp), q) < 4 < 10$. We have shown that $B_{\fu''}(\fcc(\fu''), 1) \subset B_{\fp}(\fcc(\fp), 10)$, combining this with $\scI(\fu'') = \scI(\fu)$ gives $\fu \sim \fu''$.
 
-    For symmetry suppose that $\fu \sim \fu'$. By Lemma \eqref{relation-geometry}, it follows that $\scI(\fu) = \scI(\fu')$ and that there exists $\mfa \in B_{\fu}(\fcc(\fu), 100) \cap B_{\fu'}(\fcc(\fu'), 100)$. Again, for $\fu = \fu'$ symmetry is obvious. If $\fu \ne \fu'$, then there exists $\fp \in \mathfrak{T}_1(\fu')$ with $10\fp\lesssim \fu$. By definition of $\mathfrak{T}_1(\fu')$, Lemma \ref{wiggle-order-1} and \eqref{eq-sc3}, it follows that
+    For symmetry suppose that $\fu \sim \fu'$. By Lemma \eqref{relation-geometry}, it follows that $\scI(\fu) = \scI(\fu')$ and that there exists $\mfa \in B_{\fu}(\fcc(\fu), 100) \cap B_{\fu'}(\fcc(\fu'), 100)$. Again, for $\fu = \fu'$ symmetry is obvious. If $\fu \ne \fu'$, then there exists $\fp \in \mathfrak{T}_1(\fu')$ with $10\fp\lesssim \fu$. By definition of $\mathfrak{T}_1(\fu')$, \Cref{wiggle-order-1} and \eqref{eq-sc3}, it follows that
     \begin{equation}
         \label{eq-rel1}
         10\fp \lesssim 4\fp \lesssim 500 \fu'\,.
@@ -2704,7 +2704,7 @@ We have
 \end{lemma}
 
 \begin{proof}
-    Suppose that $\fp, \fp'' \in \mathfrak{T}_2(\fu)$. Then by Lemma \ref{C5-convex}, we have
+    Suppose that $\fp, \fp'' \in \mathfrak{T}_2(\fu)$. Then by \Cref{C5-convex}, we have
 $\fp' \in \fC_5(k,n,j)$. Since $\fp \in \fC_6(k,n,j)$ we have $\scI(\fp) \not\subset G'$, hence $\scI(\fp') \not \subset G'$. This implies $\fp' \in \fC_6(k,n,j)$. Since $\fp'' \in \mathfrak{T}_2(\fu)$, we have $2\fp'' \lesssim \fu'$ and $\scI(\fp'')\ne\scI(\fu')$ for some $\fu' \sim \fp''$. By \eqref{eq-sc1}, we have $2\fp' \lesssim 2\fp''$, so by transitivity of $\lesssim$ we have $2\fp' \lesssim \fu'$. Finally, $\scI(\fp') \subset \scI(\fp'')$ implies $\scI(\fp') \ne \scI(\fu')$, thus $\fp' \in \mathfrak{T}_1(\fu') \subset \mathfrak{T}_2(\fu)$.
 \end{proof}
 
@@ -2718,7 +2718,7 @@ $\fp' \in \fC_5(k,n,j)$. Since $\fp \in \fC_6(k,n,j)$ we have $\scI(\fp) \not\su
 \end{lemma}
 \begin{proof}
     Let $\fp \in \mathfrak{T}_2(\fu)$. By \eqref{definesv}, there exists $\fu' \sim \fu$ with $\fp \in \mathfrak{T}_1(\fu')$. Then we have $2\fp \lesssim \fu'$ and $\scI(\fp) \ne \scI(\fu')$, so by \eqref{eq-sc3} $4\fp \lesssim 500\fu'$.
-    Further, by Lemma \ref{relation-geometry}, we have that $\scI(\fu') = \scI(\fu)$ and there exists $\mfa \in B_{\fu'}(\fcc(\fu'),100) \cap B_{\fu}(\fcc(\fu),100)$.
+    Further, by \Cref{relation-geometry}, we have that $\scI(\fu') = \scI(\fu)$ and there exists $\mfa \in B_{\fu'}(\fcc(\fu'),100) \cap B_{\fu}(\fcc(\fu),100)$.
     Let $\mfb \in B_{\fu}(\fcc(\fu), 1)$.
     Using the triangle inequality and the fact that $\scI(\fu')  =\scI(\fu)$, we obtain
     \begin{align*}
@@ -2742,7 +2742,7 @@ $\fp' \in \fC_5(k,n,j)$. Since $\fp \in \fC_6(k,n,j)$ we have $\scI(\fp) \not\su
 \end{lemma}
 
 \begin{proof}
-    Let $\fp, \fp'' \in \mathfrak{T}_2(\fu)$ and $\fp' \in \fP$ with $\fp \le \fp' \le \fp''$. By \eqref{definesv} we have $\fp, \fp'' \in \fC_6(k,n,j) \subset \fC_5(k,n,j)$. By Lemma \ref{C5-convex}, we have $\fp' \in \fC_5(k,n,j)$. Since $\fp \in \fC_6(k,n,j)$ we have $\scI(\fp) \not \subset G'$, so $\scI(\fp') \not \subset G'$ and therefore also $\fp' \in \fC_6(k,n,j)$.
+    Let $\fp, \fp'' \in \mathfrak{T}_2(\fu)$ and $\fp' \in \fP$ with $\fp \le \fp' \le \fp''$. By \eqref{definesv} we have $\fp, \fp'' \in \fC_6(k,n,j) \subset \fC_5(k,n,j)$. By \Cref{C5-convex}, we have $\fp' \in \fC_5(k,n,j)$. Since $\fp \in \fC_6(k,n,j)$ we have $\scI(\fp) \not \subset G'$, so $\scI(\fp') \not \subset G'$ and therefore also $\fp' \in \fC_6(k,n,j)$.
 
     By \eqref{definesv} there exists $\fu' \in \fU_2(k,n,j)$ with $\fp'' \in \mathfrak{T}_1(\fu')$ and hence $2\fp'' \lesssim \fu'$ and $\scI(\fp'') \ne \scI(\fu')$. Together this implies $\scI(\fp'') \subsetneq \scI(\fu')$. With the inclusion $\scI(\fp') \subset \scI(\fp'')$ from $\fp' \le \fp''$, it follows that $\scI(\fp') \subsetneq \scI(\fu')$ and hence $\scI(\fp') \ne \scI(\fu')$.
     By \eqref{eq-sc1} and transitivity of $\lesssim$ we further have $2\fp' \lesssim \fu'$, so $\fp' \in \mathfrak{T}_1(\fu')$.
@@ -2761,13 +2761,13 @@ $\fp' \in \fC_5(k,n,j)$. Since $\fp \in \fC_6(k,n,j)$ we have $\scI(\fp) \not\su
 
 \begin{proof}
     By the definition \eqref{eq-C2-def} of $\fC_2(k,n,j)$, there exists a tile $\fp' \in \fC_1(k,n,j)$ with $\fp' \le \fp$ and $\ps(\fp') = \ps(\fp)- Z(n+1)$.
-    By Lemma \ref{monotone-cube-metrics} we have
+    By \Cref{monotone-cube-metrics} we have
     $$
         d_{\fp}(\fcc(\fp), \fcc(\fu')) \ge 2^{95a Z(n+1)} d_{\fp'}(\fcc(\fp), \fcc(\fu'))\,.
     $$
     By \eqref{eq-sc1} we have $2\fp' \lesssim 2\fp$, so by transitivity of $\lesssim$ there exists $\mathfrak{v} \sim \fu$ with $2\fp' \lesssim \mathfrak{v}$ and $\scI(\fp') \ne \scI(\mathfrak{v})$. Since $\fu, \fu'$ are not equivalent under $\sim$, we have $\mathfrak{v} \not \sim \fu'$, thus $10\fp' \not\lesssim \fu'$. This implies that there exists $q \in B_{\fu'}(\fcc(\fu'), 1) \setminus B_{\fp'}(\fcc(\fp'), 10)$.
 
-    From $\fp' \le \fp$, $\scI(\fp') \subset \scI(\fp) \subset \scI(\fu')$ and Lemma \ref{monotone-cube-metrics} it then follows that
+    From $\fp' \le \fp$, $\scI(\fp') \subset \scI(\fp) \subset \scI(\fu')$ and \Cref{monotone-cube-metrics} it then follows that
     \begin{align*}
         &\quad d_{\fp'}(\fcc(\fp), \fcc(\fu'))\\
         &\ge -d_{\fp'}(\fcc(\fp), \fcc(\fp')) + d_{\fp'}(\fcc(\fp'), q) - d_{\fp'}(q, \fcc(\fu'))\\
@@ -2796,9 +2796,9 @@ $\fp' \in \fC_5(k,n,j)$. Since $\fp \in \fC_6(k,n,j)$ we have $\scI(\fp) \not\su
     \end{equation}
     be a maximal element of this set with respect to $\le$ such that $\fp \le \fq$.
     We show that there is no $\fq' \in \fC_3(k,n,j)$ with $\fq \le \fq'$ and $\fq \ne \fq'$. Indeed, suppose $\fq'$ was such a tile.
-    By \eqref{eq-C3-def} there exists $\fu'' \in \fU_1(k,n,j)$ with $2\fq' \lesssim \fu''$. Then we have in particular by Lemma \ref{wiggle-order-1} that $10 \fp \lesssim \fu''$. Let $\fu' \sim \fu$ be such that $\fp \in \mathfrak{T}_1(\fu')$.  By definition of $\sim$, we have $\fu' \sim \fu''$, hence $\fu \sim \fu''$. This implies that $\fq'$ is in the set in \eqref{eq-c3-tree}, contradicting maximality of $\fq$.
+    By \eqref{eq-C3-def} there exists $\fu'' \in \fU_1(k,n,j)$ with $2\fq' \lesssim \fu''$. Then we have in particular by \Cref{wiggle-order-1} that $10 \fp \lesssim \fu''$. Let $\fu' \sim \fu$ be such that $\fp \in \mathfrak{T}_1(\fu')$.  By definition of $\sim$, we have $\fu' \sim \fu''$, hence $\fu \sim \fu''$. This implies that $\fq'$ is in the set in \eqref{eq-c3-tree}, contradicting maximality of $\fq$.
 
-    Let $\fu' \sim \fu$ with $\fq \in \mathfrak{T}_1(\fu')$. By the definition \eqref{eq-T1-def} of $\mathfrak{T}_1$, we have $\ps(\fp) < \ps(\fu')$. By Lemma \ref{relation-geometry}, we have $\ps(\fu) = \ps(\fu')$, hence $\ps(\fq) < \ps(\fu)$. By definition of $\fC_4(k,n,j)$, $\fp$ is not in any of the maximal $Z(n+1)$ layers of tiles in $\fC_3(k,n,j)$, and hence $\ps(\fp) \le \ps(\fq) - Z(n+1) \le \ps(\fu) - Z(n+1) - 1$.
+    Let $\fu' \sim \fu$ with $\fq \in \mathfrak{T}_1(\fu')$. By the definition \eqref{eq-T1-def} of $\mathfrak{T}_1$, we have $\ps(\fp) < \ps(\fu')$. By \Cref{relation-geometry}, we have $\ps(\fu) = \ps(\fu')$, hence $\ps(\fq) < \ps(\fu)$. By definition of $\fC_4(k,n,j)$, $\fp$ is not in any of the maximal $Z(n+1)$ layers of tiles in $\fC_3(k,n,j)$, and hence $\ps(\fp) \le \ps(\fq) - Z(n+1) \le \ps(\fu) - Z(n+1) - 1$.
 
     Thus, there exists some cube $I \in \mathcal{D}$ with $s(I) = \ps(\fu) - Z(n+1) - 1$ and $I \subset \scI(\fu)$ and $\scI(\fp) \subset I$. Since $\fp \in \fC_5(k,n,j)$, we have that $I \notin \mathcal{L}(\fu)$, so $B(c(I), 8D^{s(I)}) \subset \scI(\fu)$. By the triangle inequality, \eqref{defineD} and $a \ge 4$, the same then holds for the subcube $\scI(\fp) \subset I$.
 \end{proof}
@@ -2821,13 +2821,13 @@ $\fp' \in \fC_5(k,n,j)$. Since $\fp \in \fC_6(k,n,j)$ we have $\scI(\fp) \not\su
     This contradicts $\fu \in \fU_2(k,n,j)$.
 \end{proof}
 
-\begin{proof}[Proof of Lemma \ref{forest-union}]
+\begin{proof}[Proof of \Cref{forest-union}]
     \proves{forest-union}
 
     We first fix $k,n, j$.
     By \eqref{definetp} and \eqref{defineep}, we have that
     $\mathbf{1}_{\scI(\fp)} T_{\fp}f(x) = T_{\fp}f(x)$ and hence $\mathbf{1}_{G \setminus G'} T_{\fp}f(x)= 0$ for all $\fp \in \fC_5(k,n,j) \setminus \fC_6(k,n,j)$.
-    Thus it suffices to estimate the contribution of the sets $\fC_6(k,n,j)$. By Lemma \ref{forest-stacking}, we can decompose $\fU_3(k,n,j)$ as a disjoint union of at most $4n + 13$ collections $\fU_4(k,n,j,l)$, $1 \le l \le 4n+13$, each satisfying
+    Thus it suffices to estimate the contribution of the sets $\fC_6(k,n,j)$. By \Cref{forest-stacking}, we can decompose $\fU_3(k,n,j)$ as a disjoint union of at most $4n + 13$ collections $\fU_4(k,n,j,l)$, $1 \le l \le 4n+13$, each satisfying
     $$
         \sum_{\fu \in \fU_4(k,n,j,l)} \mathbf{1}_{\scI(\fu)} \le 2^n\,.
     $$
@@ -2835,7 +2835,7 @@ $\fp' \in \fC_5(k,n,j)$. Since $\fp \in \fC_6(k,n,j)$ we have $\scI(\fp) \not\su
     $$
         (\fU_4(k,n,j,l), \mathfrak{T}_2|_{\fU_4(k,n,j,l)})
     $$
-    are $n$-forests for each $k,n,j,l$, and by Lemma \ref{C6-forest}, we have
+    are $n$-forests for each $k,n,j,l$, and by \Cref{C6-forest}, we have
     $$
         \fC_6(k,n,j) = \bigcup_{l = 1}^{4n + 13} \bigcup_{\fu \in \fU_4(k,n,j,l)} \mathfrak{T}_2(\fu)\,.
     $$
@@ -2843,7 +2843,7 @@ $\fp' \in \fC_5(k,n,j)$. Since $\fp \in \fC_6(k,n,j)$ we have $\scI(\fp) \not\su
     $$
         \dens_2(\bigcup_{\fu \in \fU_4(k,n,j,l)} \mathfrak{T}_2(\fu)) \le 2^{2a + 5} \frac{\mu(F)}{\mu(G)}\,.
     $$
-    Using the triangle inequality according to the splitting by $k,n,j$ and $l$ in \eqref{disclesssim1} and applying Proposition \ref{forest-operator} to each term, we obtain the estimate
+    Using the triangle inequality according to the splitting by $k,n,j$ and $l$ in \eqref{disclesssim1} and applying \Cref{forest-operator} to each term, we obtain the estimate
     $$
         \sum_{k \ge 0}\sum_{n \ge k} (2n+3)(4n+13) 2^{432a^3}2^{-(1-\frac{1}{q})n}(2^{2a+5} \frac{\mu(F)}{\mu(G)})^{\frac{1}{q} - \frac{1}{2}} \|f\|_2 \|\mathbf{1}_{G\setminus G'}\|_2
     $$
@@ -2923,7 +2923,7 @@ Define $\fP_{X \setminus G'}$ to be the set of all $\fp \in \fP$ such that $\scI
     $$
         2^n \geq 2^{4a} \lambda^{a} \geq \lambda\,.
     $$
-    From the triangle inequality, Lemma \ref{monotone-cube-metrics} and $a \ge 1$, we now obtain for all $\mfa \in B_{\mathfrak{m}}(\fcc(\mathfrak{m}), 1)$ that
+    From the triangle inequality, \Cref{monotone-cube-metrics} and $a \ge 1$, we now obtain for all $\mfa \in B_{\mathfrak{m}}(\fcc(\mathfrak{m}), 1)$ that
     \begin{align*}
         &\quad d_{\fp_0}(\fcc(\fp_0), \mfa)\\
         &\leq d_{\fp_0}(\fcc(\fp_0), \fcc(\fp_{n}))  + d_{\fp_0}(\fcc(\fp_{n}), \fcc(\fp'))  + d_{\fp_0}(\fcc(\fp'), \fcc(\fp''))\\
@@ -2944,8 +2944,8 @@ Define $\fP_{X \setminus G'}$ to be the set of all $\fp \in \fP$ such that $\scI
 \end{lemma}
 
 \begin{proof}
-    Suppose that there are $\fp_0, \fp_1 \in \fL_2(k,n,j)$ with $\fp_0 \ne \fp_1$ and $\fp_0 \le \fp_1$. By Lemma \ref{wiggle-order-1} and Lemma \ref{wiggle-order-2}, it follows that $2\fp_0 \lesssim 200\fp_1$. Since $\fL_2(k,n,j)$ is finite, there exists a maximal $l \ge 1$ such that there exists a chain $2\fp_0 \lesssim 200 \fp_1 \lesssim \dotsb \lesssim 200 \fp_l$ with $\fp_i \ne \fp_{i+1}$ for $i = 0, \dotsc, l-1$.
-    If we have $\fp_l \in \fU_1(k,n,j)$, then it follows from $2\fp_0 \lesssim 200 \fp_l \lesssim \fp_l$ and \eqref{eq-L2-def} that $\fp_0 \not\in \fL_2(k,n,j)$, a contradiction. Thus, by the definition \eqref{defunkj}  of $\fU_1(k,n,j)$, there exists $\fp_{l+1} \in \fC_1(k,n,j)$ with $\scI(\fp_l) \subsetneq \scI(\fp_{l+1}) $ and $\mfa \in B_{\fp_l}(\fcc(\fp_l), 100) \cap B_{\fp_{l+1}}(\fcc(\fp_{l+1}), 100)$. Using the triangle inequality and Lemma \ref{monotone-cube-metrics}, one deduces that $200 \fp_l \lesssim 200\fp_{l+1}$. This contradicts maximality of $l$.
+    Suppose that there are $\fp_0, \fp_1 \in \fL_2(k,n,j)$ with $\fp_0 \ne \fp_1$ and $\fp_0 \le \fp_1$. By \Cref{wiggle-order-1} and \Cref{wiggle-order-2}, it follows that $2\fp_0 \lesssim 200\fp_1$. Since $\fL_2(k,n,j)$ is finite, there exists a maximal $l \ge 1$ such that there exists a chain $2\fp_0 \lesssim 200 \fp_1 \lesssim \dotsb \lesssim 200 \fp_l$ with $\fp_i \ne \fp_{i+1}$ for $i = 0, \dotsc, l-1$.
+    If we have $\fp_l \in \fU_1(k,n,j)$, then it follows from $2\fp_0 \lesssim 200 \fp_l \lesssim \fp_l$ and \eqref{eq-L2-def} that $\fp_0 \not\in \fL_2(k,n,j)$, a contradiction. Thus, by the definition \eqref{defunkj}  of $\fU_1(k,n,j)$, there exists $\fp_{l+1} \in \fC_1(k,n,j)$ with $\scI(\fp_l) \subsetneq \scI(\fp_{l+1}) $ and $\mfa \in B_{\fp_l}(\fcc(\fp_l), 100) \cap B_{\fp_{l+1}}(\fcc(\fp_{l+1}), 100)$. Using the triangle inequality and \Cref{monotone-cube-metrics}, one deduces that $200 \fp_l \lesssim 200\fp_{l+1}$. This contradicts maximality of $l$.
 \end{proof}
 
 \begin{lemma}[L1 L3 antichain]
@@ -2957,7 +2957,7 @@ Define $\fP_{X \setminus G'}$ to be the set of all $\fp \in \fP$ such that $\scI
     By its definition \eqref{eq-L1-def}, each set $\fL_1(k,n,j,l)$ is a set of minimal elements in some set of tiles with respect to $\le$. If there were distinct $\fp, \fq \in \fL_1(k,n,j,l)$ with $\fp \le \fq$, then $\fq$ would not be minimal. Hence such $\fp, \fq$ do not exist. Similarly, by \eqref{eq-L3-def}, each set $\fL_3(k,n,j,l)$ is a set of maximal elements in some set of tiles with respect to $\le$. If there were distinct $\fp, \fq \in \fL_3(k,n,j,l)$ with $\fp \le \fq$, then $\fp$ would not be maximal.
 \end{proof}
 
-\begin{proof}[Proof of Lemma \ref{forest-complement}]
+\begin{proof}[Proof of \Cref{forest-complement}]
     \proves{forest-complement}
     If $\fp \not\in \fP_{X \setminus G'}$, then $\scI(\fp) \subset G'$. By \eqref{definetp} and \eqref{definee1}, it follows that
     $\mathbf{1}_{G \setminus G'} T_{\fp}f(x) = 0$. We thus have
@@ -2968,7 +2968,7 @@ Define $\fP_{X \setminus G'}$ to be the set of all $\fp \in \fP$ such that $\scI
     \begin{equation*}
     \dens_1(\fL(k,n)) \le 2^{4a+1 - n}
     \end{equation*}
-    by Lemma \ref{C-dens1}, and we have
+    by \Cref{C-dens1}, and we have
     \begin{equation*}
      \dens_2(\fL(k,n)) \le 2^{2a+5} \frac{\mu(F)}{\mu(G)},
      \end{equation*}
@@ -2977,7 +2977,7 @@ Define $\fP_{X \setminus G'}$ to be the set of all $\fp \in \fP$ such that $\scI
      \fL(k,n) \cap \fP_{F,G} \subset \fP_{X \setminus \fP_2} \cap \fP_{F, G} = \emptyset.
      \end{equation*}
 
-    Applying now the triangle inequality according to the decomposition in Lemma \ref{antichain-decomposition}, and then applying Proposition \ref{antichain-operator} to each term, we obtain the estimate
+    Applying now the triangle inequality according to the decomposition in \Cref{antichain-decomposition}, and then applying \Cref{antichain-operator} to each term, we obtain the estimate
     \begin{multline*}
         \le \sum_{k \ge 0} \sum_{n \ge k} (n + (2n+4) + 2(2n+4) Z(n+1)) \\
         \times 2^{201a^3}(q-1)^{-1} (2^{4a+1-n})^{\frac{q-1}{8a^4}} (2^{2a+5} \frac{\mu(F)}{\mu(G)})^{\frac{1}{q} - \frac{1}{2}} \|f\|_2\|\mathbf{1}_{G\setminus G'}\|_2\,.
@@ -2998,19 +2998,19 @@ Define $\fP_{X \setminus G'}$ to be the set of all $\fp \in \fP$ such that $\scI
 \label{antichainboundary}
 
 Let an antichain $\mathfrak{A}$
-and functions $f$, $g$ as in Proposition \ref{antichain-operator} be given.
+and functions $f$, $g$ as in \Cref{antichain-operator} be given.
 We prove \eqref{eq-antiprop}
 in Subsection \ref{sec-TT*-T*T}
 as the geometric mean of two inequalities,
 each involving one of the two densities.
 One of these two inequalities will need a careful estimate formulated in
-Lemma \ref{tile-correlation} of
+\Cref{tile-correlation} of
 the $TT^*$ correlation between two tile operators.
-Lemma \ref{tile-correlation} will be proven in
+\Cref{tile-correlation} will be proven in
 Subsection \ref{sec-tile-operator}.
 The summation of the contributions of these individual correlations will require a
-geometric Lemma \ref{antichain-tile-count} counting the relevant tile pairs.
-Lemma \ref{antichain-tile-count} will be proven in Subsection
+geometric \Cref{antichain-tile-count} counting the relevant tile pairs.
+\Cref{antichain-tile-count} will be proven in Subsection
 \ref{subsec-geolem}.
 
 
@@ -3057,7 +3057,7 @@ Then
 
 
 \begin{proof}
-Fix $x\in X$.  By Lemma \ref{tile-disjointness}, there is at most one $\fp \in \mathfrak{A}$
+Fix $x\in X$.  By \Cref{tile-disjointness}, there is at most one $\fp \in \mathfrak{A}$
 such that
  $T_{\fp} f(x)$ is not zero.
  If there is no such $\fp$, the estimate \eqref{hlmbound} follows.
@@ -3132,7 +3132,7 @@ Taking the maximum over all $B'$ containing $x$, we obtain
     M_{\mathcal{B},\frac {2{\tilde{q}}}{3{\tilde{q}}-2} } |f|
     \dens_2(\mathfrak{A})^{\frac 1{\tilde{q}}-\frac 12}\, .
 \end{equation}
-We have with Proposition \ref{Hardy-Littlewood}
+We have with \Cref{Hardy-Littlewood}
 \begin{equation}
 \left\|M_{\mathcal{B}, \frac {2q}{3q-2}} f\right\|_2\le 2^{2a}(3\tilde{q}-2)(2\tilde{q}-2)^{-1}\|f\|_2\, .
 \end{equation}
@@ -3141,7 +3141,7 @@ Using $1<\tilde{q}\le 2$ estimates the last display by
  2^{2a+2} (\tilde{q}-1)^{-1}  \|f\|_2\, .
 \end{equation}
 We obtain with Cauchy-Schwarz
-and then Lemma \ref{maximal-bound-antichain}
+and then \Cref{maximal-bound-antichain}
  \begin{equation}
      |\int \overline{g(x)} \sum_{\fp \in \mathfrak{A}} T_{\fp} f(x)\, d\mu(x)|
 \end{equation}
@@ -3248,7 +3248,7 @@ $6$ times we have
 \begin{equation}\label{eqttt4}
     \mu(B(\fp))\le 2^{6a} \mu(\scI(\fp))\, .
 \end{equation}
-Using Lemma \ref{tile-correlation} and \eqref{eqttt4}, we estimate \eqref{eqtts2} by
+Using \Cref{tile-correlation} and \eqref{eqttt4}, we estimate \eqref{eqtts2} by
 \begin{equation}\label{eqtts3}
      \le  2^{255a^3+6a+1} \sum_{\fp\in \mathfrak{A}}
     \int_{E(\fp)}|g|(y) h(\fp)\, d\mu(y)
@@ -3281,7 +3281,7 @@ We estimate $h(\fp)$ as defined in \eqref{def-hp} with H\"older using  $|g|\le \
     \frac{\|g\mathbf{1}_{B(\fp)}\|_{p'}}{\mu(B(\fp))}
     \Big\|\sum_{\fp\in\mathfrak{A}(\fp)}(1+d_{\fp}(\fcc(\fp), \fc(\fp'))^{-1/(2a^2+a^3)}\mathbf{1}_{E(\fp)}\mathbf{1}_G\Big\|_{p}\, .
 \end{equation}
-Then we apply Lemma \ref{antichain-tile-count} to estimate this by
+Then we apply \Cref{antichain-tile-count} to estimate this by
 \begin{equation}\label{eqttt5}
     \le  2^{104a}
     \frac{\|g\mathbf{1}_{B(\fp)}\|_{p'}}{\mu(B(\fp))}
@@ -3310,13 +3310,13 @@ using $E(\fp)\subset B(\fp)$ by construction of $B(\fp)$, we estimate
  \le  2^{255a^3+110a + 1} { \dens_1(\mathfrak{A})^{\frac 1p}}\sum_{\fp\in \mathfrak{A}}
  \int_{E(\fp)}|g|(y)M_{\mathcal{B}', p'}g(y) \, dy\,.
          \end{equation}
-Using Lemma \ref{tile-disjointness},
+Using \Cref{tile-disjointness},
 the last display is observed to be
 \begin{equation}\label{eqtts4a}
 =  2^{255a^3+110a + 1}
  {\dens_1(\mathfrak{A})^{\frac 1p}} \int |g|(y)(M_{\mathcal{B}', p'}g)(y) \, dy\,.
          \end{equation}
-Applying Cauchy-Schwarz and using Proposition \ref{Hardy-Littlewood}estimates the last display by
+Applying Cauchy-Schwarz and using \Cref{Hardy-Littlewood}estimates the last display by
 \begin{equation}
     2^{255a^3+110a + 1} \dens_1(\mathfrak{A})^{\frac 1p}
     \|g\|_2 \|M_{\mathcal{B}', p'} g\|_2
@@ -3330,7 +3330,7 @@ Using $p>4$ and thus $1<p'<\frac 43$, we estimate the last display by
     \le  2^{255a^3+110a + 5} \dens_1(\mathfrak{A})^{\frac 1p}
     \|g\|_2^2\,.
 \end{equation}
-Now Lemma \ref{dens1-antichain} follows by applying Cauchy-Schwarz on the left-hand side and using
+Now \Cref{dens1-antichain} follows by applying Cauchy-Schwarz on the left-hand side and using
 $a\ge 4$.
 \end{proof}
 We have
@@ -3346,13 +3346,13 @@ and estimating gives after simplification of some factors
     \le  2^{150a^3}({q}-1)^{-1} \dens_1(\mathfrak{A})^{\frac {q-1}{2p}}\dens_2(\mathfrak{A})^{\frac 1{q}-\frac 12}  \|f\|_2\|g\|_2\, .
 \end{equation}
 With the definition of $p$, this  implies
-Proposition \ref{antichain-operator}.
+\Cref{antichain-operator}.
 
 
 \section{Proof of the Tile Correlation Lemma}\label{sec-tile-operator}
 
 The next lemma prepares an application of
-Proposition \ref{Holder-van-der-Corput}.
+\Cref{Holder-van-der-Corput}.
 \begin{lemma}[correlation kernel bound]\label{correlation-kernel-bound}
 Let $-S\le s_1\le s_2\le S$ and let $x_1,x_2\in X$.
 Define \begin{equation}
@@ -3424,7 +3424,7 @@ With \eqref{eq-freq-comp-ball} we then conclude
 \begin{equation}\label{dponetwo}
     d_{\fp_i}(\tQ(x_i),\fcc(\fp_i))\le 1\, .
 \end{equation}
-We have $\scI(\fp_1)\subset \scI(\fp_2)$ by \eqref{dyadicproperty}. Using Lemma \ref{monotone-cube-metrics} it follows that
+We have $\scI(\fp_1)\subset \scI(\fp_2)$ by \eqref{dyadicproperty}. Using \Cref{monotone-cube-metrics} it follows that
 \begin{equation}\label{tgeo0.5}
     d_{\fp_1}(\tQ(x_2), \fcc(\fp_2)) \le 1\,.
 \end{equation}
@@ -3486,7 +3486,7 @@ Now \eqref{ynotfar} follows by the triangle inequality.
 \end{proof}
 
 
-We now prove Lemma \ref{tile-correlation}. We begin with  \eqref{eq-basic-TT*-est}.
+We now prove \Cref{tile-correlation}. We begin with  \eqref{eq-basic-TT*-est}.
 
 We expand the left-hand side of \eqref{eq-basic-TT*-est} as
 \begin{equation}\label{tstartstar}
@@ -3514,9 +3514,9 @@ with
 
 We estimate for fixed $x_1\in E(\fp_1)$ and
 $x_2\in E(\fp_2)$ the inner integral of \eqref{eqa1} with
-Proposition \ref{Holder-van-der-Corput}. The function
+\Cref{Holder-van-der-Corput}. The function
 $\varphi:=\varphi_{x_1,x_2}$ satisfies the assumptions of
-Proposition \ref{Holder-van-der-Corput} with $z = x_1$ and $R = D^{s_1}$ by Lemma \ref{correlation-kernel-bound}.
+\Cref{Holder-van-der-Corput} with $z = x_1$ and $R = D^{s_1}$ by \Cref{correlation-kernel-bound}.
 We obtain with $B':= B(x_1, D^{\ps(\fp_1)})$,
 \begin{equation*}
  {\bf I}(x_1, x_2) \le     2^{8a} \mu(B') \|{\varphi}\|_{C^\tau(B')}
@@ -3528,7 +3528,7 @@ We obtain with $B':= B(x_1, D^{\ps(\fp_1)})$,
  {\mu(B(x_2, D^{\ps(\fp_2)}))}
        (1 + d_{B'}(\tQ(x_1),\tQ(x_2)))^{-1/(2a^2+a^3)}\,.
 \end{equation}
-Using Lemma \ref{tile-uncertainty} and $a\ge 1$ estimates \eqref{eqa1.5} by
+Using \Cref{tile-uncertainty} and $a\ge 1$ estimates \eqref{eqa1.5} by
 \begin{equation}\label{eqa2}
  \le     \frac{2^{254a^3 + 8a + 1}}
  {\mu(B(x_2, D^{\ps(\fp_2)}))}
@@ -3554,7 +3554,7 @@ There is a $y\in X$ with
 \begin{equation}
     T^*_{\fp}g(y)\overline{T^*_{\fp'}g(y)}\neq 0
 \end{equation}
-By the triangle inequality and Lemma \ref{tile-range-support}, we conclude
+By the triangle inequality and \Cref{tile-range-support}, we conclude
 \begin{equation}
    \rho(\pc(\fp),\pc(\fp'))\le  \rho(\pc(\fp),y) +\rho(\pc(\fp'),y)
    \le 5D^{\ps(\fp)}+5D^{\ps(\fp')}\le 10 D^{\ps(\fp)}\, .
@@ -3591,7 +3591,7 @@ Then
 \end{lemma}
 
 \begin{proof}
-By Lemma \ref{monotone-cube-metrics}, we have
+By \Cref{monotone-cube-metrics}, we have
 \begin{equation}
      d_{\fp}(\fcc(\fp'),\mfa)
      \le d_{\fp'}(\fcc(\fp'),\mfa)
@@ -3735,7 +3735,7 @@ We conclude from $\fp \in \mathfrak{A}_{\mfa,N}$ that
 \begin{equation}
     \mfa \in B(\fcc(\fp), 2^{N+1})\, .
 \end{equation}
-With Lemma \ref{tile-reach}, we conclude
+With \Cref{tile-reach}, we conclude
 \begin{equation}
     2^{N+3}\fp_{\mfa}  \lesssim  2^{N+3}\fp \, .
 \end{equation}
@@ -3743,7 +3743,7 @@ By Definition \eqref{definee2} of $E_2$, we conclude
 \begin{equation}
     E(\fp)\cap G \subset E_2(2^{N+3},\fp_{\mfa})\, .
 \end{equation}
-Using disjointedness of the various $E(\fp)$ with $\fp\in \mathfrak{A}$  by Lemma \ref{tile-disjointness}, we obtain \eqref{eqanti-0.5}.
+Using disjointedness of the various $E(\fp)$ with $\fp\in \mathfrak{A}$  by \Cref{tile-disjointness}, we obtain \eqref{eqanti-0.5}.
 This proves the lemma.
 \end{proof}
 \begin{lemma}[global antichain density]
@@ -3797,7 +3797,7 @@ If there exists no cube $J \in \mathcal{D}$ with $L \subsetneq J$, then by the d
 \begin{equation}
     \sum_{\fp\in\mathfrak{A}':\scI(\fp)=L}\mu(E(\fp)\cap G\cap L)\,.
 \end{equation}
-Thus in this case \eqref{eqanti0} is a direct consequence of Lemma \ref{stack-density} and $a \ge 4$.
+Thus in this case \eqref{eqanti0} is a direct consequence of \Cref{stack-density} and $a \ge 4$.
 
 We now assume that there exists a cube $J \in \mathcal{D}$ with $L \subsetneq J$.
 By \eqref{coverdyadic}, there is an
@@ -3814,7 +3814,7 @@ We split the left-hand side of \eqref{eqanti0} as
 \end{equation}
 
 We first estimate \eqref{eqanti1}
-with Lemma \ref{stack-density} by
+with \Cref{stack-density} by
 \begin{equation}\label{equanti1.5}
     \le \sum_{\fp\in\mathfrak{A}':\scI(\fp)=L'}\mu(E(\fp)\cap G\cap L')\le 2^{a(N+5)}\dens_1(\mathfrak{A})\mu(L')\, .
 \end{equation}
@@ -3848,7 +3848,7 @@ and as  $\fp'' \in \mathfrak{A}_{\mfa,N}$ that
 \begin{equation}
     \mfa \in B(\fcc(\fp''), 2^{N+1})\, .
 \end{equation}
-By Lemma \ref{tile-reach}, we conclude
+By \Cref{tile-reach}, we conclude
 \begin{equation}
     2^{N+3}\fp''  \lesssim  2^{N+3}\fp_{\mfa} \, .
 \end{equation}
@@ -3864,7 +3864,7 @@ $L\subset \scI(\fp)$ and $L\neq \scI(\fp)$. By the dyadic property \eqref{dyadic
 $s(L)<\ps(\fp)$ and thus $s(L')\le \ps(\fp)$. By the dyadic property
    \eqref{dyadicproperty} again, we have $L'\subset \scI(\fp)$.
 As $L'\neq \scI(\fp)$, we conclude $s(L)<\ps(\fp)$.
-By Lemma \ref{local-antichain-density}, we can thus estimate \eqref{eqanti2} by
+By \Cref{local-antichain-density}, we can thus estimate \eqref{eqanti2} by
 \begin{equation}\label{eqanti0.5}
     \sum_{\fp\in\mathfrak{A}':\scI(\fp)\neq L'}\mu(E(\fp)\cap G\cap L')
     \le  \mu (E_2(2^{N+3},\fp_{\mfa}))\, .
@@ -3892,7 +3892,7 @@ This completes the proof of the lemma.
 
 
 
-We turn to the proof of Lemma \ref{antichain-tile-count}.
+We turn to the proof of \Cref{antichain-tile-count}.
 
 
 
@@ -3908,7 +3908,7 @@ with the triangle inequality by
 \le \sum_{N\ge 0} \left\|\sum_{\fp\in \mathfrak{A}_{\mfa,N}} 2^{-N/(2a^2+a^3)}\mathbf{1}_{E(\fp)} \mathbf{1}_G\right\|_{p}
 \end{equation}
 We consider each individual term in this sum and estimate it's $p$-th power.
-   Using that for each $x\in X$  by Lemma \ref{global-antichain-density} there is at most one $\fp\in \mathfrak{A}$ with $x\in E(\fp)$,
+   Using that for each $x\in X$  by \Cref{global-antichain-density} there is at most one $\fp\in \mathfrak{A}$ with $x\in E(\fp)$,
  we have
  \begin{equation}
      \left\|\sum_{\fp\in \mathfrak{A}_{\mfa,N}} 2^{-N/(2a^2+a^3)}\mathbf{1}_{E(\fp)} \mathbf{1}_G\right\|_{p}^p
@@ -3923,7 +3923,7 @@ We consider each individual term in this sum and estimate it's $p$-th power.
   =   2^{-pN/(2a^2+a^3)} \sum_{\fp\in\mathfrak{A}_{\mfa,N}}\mu(E(\fp)\cap G)
 \end{equation}
 
-Using Lemma \ref{global-antichain-density}, we estimate the last display by
+Using \Cref{global-antichain-density}, we estimate the last display by
 \begin{equation}\label{eqanti21}
     \le  2^{-pN/(2a^2+a^3)+101a^3+Na}\dens_1(\mathfrak{A})\mu\left(\cup_{\fp\in\mathfrak{A}}\scI(\fp)\right)
 \end{equation}
@@ -3960,7 +3960,7 @@ Using that $p = 4a^4$ and $a \ge 4$, this proves the lemma.
 \label{treesection}
 
 \section{The pointwise tree estimate}
-Fix a forest $(\fU, \fT)$. The main result of this subsection is Lemma \ref{pointwise-tree-estimate}, we begin this section with some definitions necessary to state the lemma.
+Fix a forest $(\fU, \fT)$. The main result of this subsection is \Cref{pointwise-tree-estimate}, we begin this section with some definitions necessary to state the lemma.
 
 For $\fu \in \fU$ and $x\in X$, we define
 $$
@@ -4086,7 +4086,7 @@ The following pointwise estimate for operators associated to sets $\fT(\fu)$ is 
         \label{eq-term-C}
         + \Bigg| \sum_{s \in \sigma(\fu, x)} \int K_s(x,y) (f(y) - P_{\mathcal{J}(\fT(\fu))} f(y)) \, \mathrm{d}\mu(y) \Bigg|\,.
     \end{equation}
-    The proof is completed using the bounds for these three terms proven in Lemma \ref{first-tree-pointwise}, Lemma \ref{second-tree-pointwise} and Lemma \ref{third-tree-pointwise}.
+    The proof is completed using the bounds for these three terms proven in \Cref{first-tree-pointwise}, \Cref{second-tree-pointwise} and \Cref{third-tree-pointwise}.
 \end{proof}
 
 \begin{lemma}[first tree pointwise]
@@ -4106,7 +4106,7 @@ The following pointwise estimate for operators associated to sets $\fT(\fu)$ is 
         \leq d_{B(x, 1/2 D^{s})}(\fcc(\fu), \tQ(x))\,.
     \end{multline*}
     Let $\fp_s \in \fT(\fu)$ be a tile with $\ps(\fp_s) = s$ and $x \in E(\fp_s)$, and let $\fp'$ be a tile with $\ps(\fp') = \overline{\sigma}(\fu, x)$ and $x \in E(\fp')$.
-    Using the doubling property \eqref{firstdb}, the definition of $d_{\fp}$ and Lemma \ref{monotone-cube-metrics}, we can bound the previous display by
+    Using the doubling property \eqref{firstdb}, the definition of $d_{\fp}$ and \Cref{monotone-cube-metrics}, we can bound the previous display by
     $$
         2^a d_{\fp_s}(\fcc(\fu), \tQ(x)) \le 2^{a} 2^{s - \overline{\sigma}(\fu, x)} d_{\fp'}(\fcc(\fu), \tQ(x))\,.
     $$
@@ -4229,7 +4229,7 @@ In this subsection we prove the following estimate on $L^2$ for operators associ
     \end{equation}
 \end{lemma}
 
-Below, we deduce Lemma \ref{tree-projection-estimate} from Lemma \ref{pointwise-tree-estimate} and the following estimates for the operators in Lemma \ref{pointwise-tree-estimate}.
+Below, we deduce \Cref{tree-projection-estimate} from \Cref{pointwise-tree-estimate} and the following estimates for the operators in \Cref{pointwise-tree-estimate}.
 
 \begin{lemma}[nontangential operator bound]
     \label{nontangential-operator-bound}
@@ -4250,7 +4250,7 @@ Below, we deduce Lemma \ref{tree-projection-estimate} from Lemma \ref{pointwise-
     \end{equation}
 \end{lemma}
 
-\begin{proof}[Proof of Lemma \ref{tree-projection-estimate}]
+\begin{proof}[Proof of \Cref{tree-projection-estimate}]
     \proves{tree-projection-estimate}
     For each $L \in \mathcal{L}(\fT(\fu))$, choose a point $x'(L) \in L$ such that for all $y \in L$
     $$
@@ -4261,7 +4261,7 @@ Below, we deduce Lemma \ref{tree-projection-estimate} from Lemma \ref{pointwise-
         \le 2 ((M_{\mathcal{B},1}+S_{1,\fu})P_{\mathcal{J}(\fT(\fu))}|f|(y)+|T_{\mathcal{N}}P_{\mathcal{J}(\fT(\fu))}f(y)|)\,.
     \end{equation}
     This point exists since \eqref{eq-x'L-almost-inf} is non-negative for each $y$.
-    Then we have by Lemma \ref{pointwise-tree-estimate} for each $L \in \mathcal{L}(\fT(\fu))$
+    Then we have by \Cref{pointwise-tree-estimate} for each $L \in \mathcal{L}(\fT(\fu))$
     $$
         \int_L |g(y)| \Bigg| \sum_{\fp \in \fT(\fu)} T_{\fp} f(y) \Bigg| \, \mathrm{d}\mu(y)
     $$
@@ -4279,7 +4279,7 @@ Below, we deduce Lemma \ref{tree-projection-estimate} from Lemma \ref{pointwise-
     $$
         \Bigg| \int \bar g(y) \sum_{\fp \in \fT(\fu)} T_{\fp} f(y)  \, \mathrm{d}\mu(y) \Bigg| = \Bigg| \int_{\bigcup_{\fp \in \fT(\fu)} \scI(\fp)} \bar g(y) \sum_{\fp \in \fT(\fu)} T_{\fp} f(y)  \, \mathrm{d}\mu(y) \Bigg|\,.
     $$
-    Since $\mathcal{L}(\fT(\fu))$ partitions $\bigcup_{\fp \in \fT(\fu)} \scI(\fp)$ by Lemma \ref{dyadic-partitions},
+    Since $\mathcal{L}(\fT(\fu))$ partitions $\bigcup_{\fp \in \fT(\fu)} \scI(\fp)$ by \Cref{dyadic-partitions},
     we get from the triangle inequality
     $$
         \le \sum_{L \in \mathcal{L}(\fT(\fu))} \int_L |g(y)| \Bigg| \sum_{\fp \in \fT(\fu)} T_{\fp} f(y) \Bigg| \, \mathrm{d}\mu(y)
@@ -4295,7 +4295,7 @@ Below, we deduce Lemma \ref{tree-projection-estimate} from Lemma \ref{pointwise-
     \begin{multline*}
         2^{151a^3 + 1} \|P_{\mathcal{L}(\fT(\fu))}|g|\|_2 \times \\(\|M_{\mathcal{B},1}P_{\mathcal{J}(\fT(\fu))}|f|\|_2 + \|S_{1,\fu}P_{\mathcal{J}(\fT(\fu))}|f|\|_2 + \|T_{\mathcal{N}}P_{\mathcal{J}(\fT(\fu))}f(y)|\|_2)\,.
     \end{multline*}
-    By Proposition \ref{Hardy-Littlewood}, Lemma \ref{nontangential-operator-bound} and Lemma \ref{boundary-operator-bound}, the second factor is at most
+    By \Cref{Hardy-Littlewood}, \Cref{nontangential-operator-bound} and \Cref{boundary-operator-bound}, the second factor is at most
     $$
         (2^{2a+1} + 2^{12a})\|P_{\mathcal{J}(\fT(\fu))}|f|\|_2 + 2^{103a^3} \|P_{\mathcal{J}(\fT(\fu))}f\|_2\,.
     $$
@@ -4308,7 +4308,7 @@ Below, we deduce Lemma \ref{tree-projection-estimate} from Lemma \ref{pointwise-
 
 Now we prove the two auxiliary lemmas. We begin with the nontangential maximal operator $T_{\mathcal{N}}$.
 
-\begin{proof}[Proof of Lemma \ref{nontangential-operator-bound}]
+\begin{proof}[Proof of \Cref{nontangential-operator-bound}]
     \proves{nontangential-operator-bound}
     Fix $s_1, s_2$. By \eqref{eq-psisum} we have for all $x \in (0, \infty)$
     $$
@@ -4347,7 +4347,7 @@ Now we prove the two auxiliary lemmas. We begin with the nontangential maximal o
     \end{equation}
     The first term \eqref{eq-sharp-trunc-term} is at most $T_* f(x)$.
 
-    The other two terms will be estimated by the finitary maximal function from Proposition \ref{Hardy-Littlewood}.
+    The other two terms will be estimated by the finitary maximal function from \Cref{Hardy-Littlewood}.
     For the second term \eqref{eq-lower-bound-term} we use \eqref{eqkernel-size} which implies that for all $y$ with $\rho(x', y) \ge \frac{1}{4}D^{s_1 - 1}$, we have
     $$
         |K(x', y)| \le \frac{2^{a^3}}{\mu(B(x', \frac{1}{4}D^{s_1 - 1}))}\,.
@@ -4391,7 +4391,7 @@ Now we prove the two auxiliary lemmas. We begin with the nontangential maximal o
     $$
         T_{\mathcal{N}} f(x) \le T_*f(x) + 2^{102a^3}  M_{\mathcal{B},1} f(x)\,.
     $$
-    The lemma now follows from assumption \eqref{nontanbound}, Proposition \ref{Hardy-Littlewood}and $a \ge 4$.
+    The lemma now follows from assumption \eqref{nontanbound}, \Cref{Hardy-Littlewood}and $a \ge 4$.
 \end{proof}
 
 We need the following lemma to prepare the $L^2$-estimate for the auxiliary operators $S_{1, \fu}$.
@@ -4421,7 +4421,7 @@ We need the following lemma to prepare the $L^2$-estimate for the auxiliary oper
 
 Now we can bound the operators $S_{1, \fu}$.
 
-\begin{proof}[Proof of Lemma \ref{boundary-operator-bound}]
+\begin{proof}[Proof of \Cref{boundary-operator-bound}]
     \proves{boundary-operator-bound}
     Note that by definition, $S_{1,\fu}f$ is a finite sum of indicator functions of cubes $I \in \mathcal{D}$ for each locally integrable $f$, and hence is bounded, has bounded support and is integrable. Let $g$ be another function with the same three properties. Then $\bar g S_{1,\fu}f$ is integrable, and we have
     $$
@@ -4439,7 +4439,7 @@ Now we can bound the operators $S_{1, \fu}$.
     \label{eq-boundary-operator-bound-1}
         \le \sum_{J\in\mathcal{J}}\int_J|f(y)|  M_{\mathcal{B},1}|g|(y) \, \mathrm{d}\mu(y) \sum_{I \in \mathcal{D} \, : \, J\subset B(c(I),16 D^{s(I)})} D^{(s(J)-s(I))/a}.
     \end{align}
-    By \eqref{eq-vol-sp-cube} and \eqref{defineD} the condition $J \subset B(c(I), 16 D^{s(I)})$ implies $s(I) \ge s(J)$. By Lemma \ref{boundary-overlap}, there are at most $2^{8a}$ cubes $I$ at each scale with $J \subset B(c(I), D^{s(I)})$.
+    By \eqref{eq-vol-sp-cube} and \eqref{defineD} the condition $J \subset B(c(I), 16 D^{s(I)})$ implies $s(I) \ge s(J)$. By \Cref{boundary-overlap}, there are at most $2^{8a}$ cubes $I$ at each scale with $J \subset B(c(I), D^{s(I)})$.
     By convexity of $t \mapsto D^t$ and since $D \ge 2$, we have for all $-1 \le t \le 0$
     $$
         D^t \le 1 + t\left(1 - \frac{1}{D}\right) \le 1 + \frac{1}{2}t\,,
@@ -4454,7 +4454,7 @@ Now we can bound the operators $S_{1, \fu}$.
     $$
         2^{9a} \int_X|f(y)|  M_{\mathcal{B},1}|g|(y) \, \mathrm{d}\mu(y)\,.
     $$
-    Using Cauchy-Schwarz and Proposition \ref{Hardy-Littlewood}we conclude
+    Using Cauchy-Schwarz and \Cref{Hardy-Littlewood}we conclude
     $$
         \left|\int \bar g S_{1,\fu}f \, \mathrm{d}\mu \right| \le  2^{11a+1} \|g\|_2\|f\|_2\,.
     $$
@@ -4480,7 +4480,7 @@ The main result of this subsection is the following quantitative bound for opera
     \end{equation}
 \end{lemma}
 
-Below, we deduce this lemma from  Lemma \ref{tree-projection-estimate} and the following two estimates controlling the size of support of the operator and its adjoint.
+Below, we deduce this lemma from  \Cref{tree-projection-estimate} and the following two estimates controlling the size of support of the operator and its adjoint.
 
 \begin{lemma}[local dens1 tree bound]
     \label{local-dens1-tree-bound}
@@ -4500,7 +4500,7 @@ Below, we deduce this lemma from  Lemma \ref{tree-projection-estimate} and the f
     $$
 \end{lemma}
 
-\begin{proof}[Proof of Lemma \ref{densities-tree-bound}]
+\begin{proof}[Proof of \Cref{densities-tree-bound}]
     \proves{densities-tree-bound}
     Denote
     $$
@@ -4510,7 +4510,7 @@ Below, we deduce this lemma from  Lemma \ref{tree-projection-estimate} and the f
     $$
         \left| \int_X \bar g \sum_{\fp \in \fT(\fu)} T_{\fp} f \, \mathrm{d}\mu \right|  = \left| \int_X \overline{ g\mathbf{1}_{\mathcal{E}(\fu)}}  \sum_{\fp \in \fT(\fu)} T_{\fp} f \, \mathrm{d}\mu \right|\,.
     $$
-    By Lemma \ref{tree-projection-estimate}, this is bounded by
+    By \Cref{tree-projection-estimate}, this is bounded by
     \begin{equation}
         \label{eq-both-factors-tree}
         \le 2^{104a^3}\|P_{\mathcal{J}(\fT(\fu))}|f|\|_2 \|P_{\mathcal{L}(\fT(\fu))} |\mathbf{1}_{\mathcal{E}(\fu)}g|\|_2\,.
@@ -4520,11 +4520,11 @@ Below, we deduce this lemma from  Lemma \ref{tree-projection-estimate} and the f
     $$
         \|P_{\mathcal{L}(\fT(\fu))} |\mathbf{1}_{\mathcal{E}(\fu)}g|\|_2 = \left( \sum_{L \in \mathcal{L}(\fT(\fu))} \frac{1}{\mu(L)} \left(\int_{L \cap \mathcal{E}(\fu)} |g(y)| \, \mathrm{d}\mu(y)\right)^2 \right)^{1/2}\,.
     $$
-    By Cauchy-Schwarz and Lemma \ref{local-dens1-tree-bound} this is at most
+    By Cauchy-Schwarz and \Cref{local-dens1-tree-bound} this is at most
     $$
         \le \left( \sum_{L \in \mathcal{L}(\fT(\fu))} 2^{101a^3} \dens_1(\fT(\fu)) \int_{L \cap \mathcal{E}(\fu)} |g(y)|^2 \, \mathrm{d}\mu(y) \right)^{1/2}\,.
     $$
-    Since cubes $L \in \mathcal{L}(\fT(\fu))$ are pairwise disjoint by Lemma \ref{dyadic-partitions}, this is
+    Since cubes $L \in \mathcal{L}(\fT(\fu))$ are pairwise disjoint by \Cref{dyadic-partitions}, this is
     \begin{equation}
         \label{eq-factor-L-tree}
          \le 2^{51 a^3} \dens_1(\fT(\fu))^{1/2} \|g\|_2\,.
@@ -4538,7 +4538,7 @@ Below, we deduce this lemma from  Lemma \ref{tree-projection-estimate} and the f
     $$
         \le \left( \sum_{J \in \mathcal{J}(\fT(\fu))} \int_J |f(y)|^2 \, \mathrm{d}\mu(y) \right)^{1/2}\,.
     $$
-    Since cubes in $\mathcal{J}(\fT(\fu))$ are pairwise disjoint by Lemma \ref{dyadic-partitions}, this at most
+    Since cubes in $\mathcal{J}(\fT(\fu))$ are pairwise disjoint by \Cref{dyadic-partitions}, this at most
     \begin{equation}
         \label{eq-factor-J-tree}
         \|f\|_2\,.
@@ -4549,7 +4549,7 @@ Below, we deduce this lemma from  Lemma \ref{tree-projection-estimate} and the f
     $$
         \left( \sum_{J \in \mathcal{J}(\fT(\fu))} \int_J |f(y)|^2 \, \mathrm{d}\mu(y) \right)^{1/2} = \left( \sum_{J \in \mathcal{J}(\fT(\fu))} \int_{J \cap F} |f(y)|^2 \, \mathrm{d}\mu(y) \right)^{1/2}\,.
     $$
-    We estimate as before, using now Lemma \ref{local-dens2-tree-bound} and Cauchy-Schwarz, and obtain that this is
+    We estimate as before, using now \Cref{local-dens2-tree-bound} and Cauchy-Schwarz, and obtain that this is
     $$
         \le 2^{100a^3 + 10} \dens_2(\fT(\fu))^{1/2} \|f\|_2\,.
     $$
@@ -4558,16 +4558,16 @@ Below, we deduce this lemma from  Lemma \ref{tree-projection-estimate} and the f
 
 Now we prove the two auxiliary estimates.
 
-\begin{proof}[Proof of Lemma \ref{local-dens1-tree-bound}]
+\begin{proof}[Proof of \Cref{local-dens1-tree-bound}]
     \proves{local-dens1-tree-bound}
     If the set on the right hand side is empty, then \eqref{eq-1density-estimate-tree} holds. If not, then there exists $\fp \in \fT(\fu)$ with $L \cap \scI(\fp) \ne \emptyset$.
 
-    Suppose first that there exists such $\fp$ with $\ps(\fp) \le s(L)$. Then by \eqref{dyadicproperty} $\scI(\fp) \subset L$, which gives by the definition of $\mathcal{L}(\fT(\fu))$ that $s(L) = -S$ and hence $L = \scI(\fp)$. Let $\fq \in \fT(\fu)$ with $E(\fq) \cap L \ne \emptyset$. Since $s(L) = -S \le \ps(\fq)$ it follows from \eqref{dyadicproperty} that $\scI(\fp) = L \subset \scI(\fq)$. We have then by Lemma \ref{monotone-cube-metrics}
+    Suppose first that there exists such $\fp$ with $\ps(\fp) \le s(L)$. Then by \eqref{dyadicproperty} $\scI(\fp) \subset L$, which gives by the definition of $\mathcal{L}(\fT(\fu))$ that $s(L) = -S$ and hence $L = \scI(\fp)$. Let $\fq \in \fT(\fu)$ with $E(\fq) \cap L \ne \emptyset$. Since $s(L) = -S \le \ps(\fq)$ it follows from \eqref{dyadicproperty} that $\scI(\fp) = L \subset \scI(\fq)$. We have then by \Cref{monotone-cube-metrics}
     \begin{align*}
         d_{\fp}(\fcc(\fp), \fcc(\fq)) &\le d_{\fp}(\fcc(\fp), \fcc(\fu)) + d_{\fp}(\fcc(\fq), \fcc(\fu))\\
         &\le d_{\fp}(\fcc(\fp), \fcc(\fu)) + d_{\fq}(\fcc(\fq), \fcc(\fu))\,.
     \end{align*}
-    Using that $\fp, \fq \in \fT(\fu)$ and \eqref{forest1}, this is at most $8$. Using again the triangle inequality and Lemma \ref{monotone-cube-metrics}, we obtain that for each $q \in B_{\fq}(\fcc(\fq), 1)$
+    Using that $\fp, \fq \in \fT(\fu)$ and \eqref{forest1}, this is at most $8$. Using again the triangle inequality and \Cref{monotone-cube-metrics}, we obtain that for each $q \in B_{\fq}(\fcc(\fq), 1)$
     $$
         d_{\fp}(\fcc(\fp), q) \le d_{\fp}(\fcc(\fp), \fcc(\fq)) + d_{\fq}(\fcc(\fq), q) \le 9\,.
     $$
@@ -4581,7 +4581,7 @@ Now we prove the two auxiliary estimates.
     $$
     Since $a \ge 4$, \eqref{eq-1density-estimate-tree} follows in this case.
 
-    Now suppose that for each $\fp \in \fT(\fu)$ with $L \cap E(\fp) \ne \emptyset$, we have $\ps(\fp) > s(L)$. Since there exists at least one such $\fp$, there exists in particular at least one cube $L'' \in \mathcal{D}$ with $L \subset L''$ and $s(L'') > s(L)$. By \eqref{coverdyadic}, there exists $L' \in \mathcal{D}$ with $L \subset L'$ and $s(L') = s(L) + 1$. By the definition of $\mathcal{L}(\fT(\fu))$ there exists a tile $\fp'' \in \fT(\fu)$ with $\scI(\fp'') \subset L'$. Let $\fp'$ be the unique tile such that $\scI(\fp') = L'$ and such that $\Omega(\fu) \cap \Omega(\fp') \ne \emptyset$. Since by \eqref{forest1} $\ps(\fp') = s(L') \le \ps(\fp) < \ps(\fu)$, we have by \eqref{dyadicproperty} and \eqref{eq-freq-dyadic} that $\Omega(\fu) \subset \Omega(\fp')$. Let $\fq \in \fT(\fu)$ with $L \cap E(\fq) \ne \emptyset$. As shown above, this implies $\ps(\fq) \ge s(L')$, so by \eqref{dyadicproperty} $L' \subset \scI(\fq)$. If $q \in B_{\fq}(\fcc(\fq), 1)$, then by a similar calculation as above, using the triangle inequality, Lemma \ref{monotone-cube-metrics} and \eqref{forest1}, we obtain
+    Now suppose that for each $\fp \in \fT(\fu)$ with $L \cap E(\fp) \ne \emptyset$, we have $\ps(\fp) > s(L)$. Since there exists at least one such $\fp$, there exists in particular at least one cube $L'' \in \mathcal{D}$ with $L \subset L''$ and $s(L'') > s(L)$. By \eqref{coverdyadic}, there exists $L' \in \mathcal{D}$ with $L \subset L'$ and $s(L') = s(L) + 1$. By the definition of $\mathcal{L}(\fT(\fu))$ there exists a tile $\fp'' \in \fT(\fu)$ with $\scI(\fp'') \subset L'$. Let $\fp'$ be the unique tile such that $\scI(\fp') = L'$ and such that $\Omega(\fu) \cap \Omega(\fp') \ne \emptyset$. Since by \eqref{forest1} $\ps(\fp') = s(L') \le \ps(\fp) < \ps(\fu)$, we have by \eqref{dyadicproperty} and \eqref{eq-freq-dyadic} that $\Omega(\fu) \subset \Omega(\fp')$. Let $\fq \in \fT(\fu)$ with $L \cap E(\fq) \ne \emptyset$. As shown above, this implies $\ps(\fq) \ge s(L')$, so by \eqref{dyadicproperty} $L' \subset \scI(\fq)$. If $q \in B_{\fq}(\fcc(\fq), 1)$, then by a similar calculation as above, using the triangle inequality, \Cref{monotone-cube-metrics} and \eqref{forest1}, we obtain
     $$
         d_{\fp'}(\fcc(\fp'), q) \le d_{\fp'}(\fcc(\fp'), \fcc(\fq)) + d_{\fq}(\fcc(\fq), q) \le 6\,.
     $$
@@ -4596,7 +4596,7 @@ Now we prove the two auxiliary estimates.
     This completes the proof.
 \end{proof}
 
-\begin{proof}[Proof of Lemma \ref{local-dens2-tree-bound}]
+\begin{proof}[Proof of \Cref{local-dens2-tree-bound}]
     \proves{local-dens2-tree-bound}
     Suppose first that there exists a tile $\fp \in \fT(\fu)$ with $\scI(\fp) \subset B(c(J), 100 D^{s(J) + 1})$. By the definition of $\mathcal{J}(\fT(\fu))$, this implies that $s(J) = -S$, and in particular $\ps(\fp) \ge s(J)$. Using the triangle inequality and \eqref{eq-vol-sp-cube} it follows that $J \subset B(\pc(\fp), 200 D^{\ps(\fp) + 1})$. From the doubling property \eqref{doublingx}, $D=2^{100a^2}$ and \eqref{eq-vol-sp-cube}, we obtain
     $$
@@ -4650,7 +4650,7 @@ Now we prove the two auxiliary estimates.
 
 \section{Almost orthogonality of separated trees}
 
-The main result of this subsection is the almost orthogonality estimate for operators associated to distinct trees in a forest in Lemma \ref{correlation-separated-trees} below. We will deduce it from Lemmas \ref{correlation-distant-tree-parts} and \ref{correlation-near-tree-parts}, which are proven in Subsections \ref{subsec-big-tiles} and \ref{subsec-rest-tiles}, respectively. Before stating it, we introduce some relevant notation.
+The main result of this subsection is the almost orthogonality estimate for operators associated to distinct trees in a forest in \Cref{correlation-separated-trees} below. We will deduce it from Lemmas \ref{correlation-distant-tree-parts} and \ref{correlation-near-tree-parts}, which are proven in Subsections \ref{subsec-big-tiles} and \ref{subsec-rest-tiles}, respectively. Before stating it, we introduce some relevant notation.
 
 The adjoint of the operator $T_{\fp}$ defined in \eqref{definetp} is given by
 \begin{equation}
@@ -4699,7 +4699,7 @@ The adjoint of the operator $T_{\fp}$ defined in \eqref{definetp} is given by
 \end{lemma}
 
 \begin{proof}
-    By Cauchy-Schwarz and Lemma \ref{densities-tree-bound}, we have for all bounded $f,g$ with bounded support that
+    By Cauchy-Schwarz and \Cref{densities-tree-bound}, we have for all bounded $f,g$ with bounded support that
     $$
         \left| \int_X \overline{\sum_{\fp\in \fT(\fu)} T_{\fp}^* g} f \,\mathrm{d}\mu \right| = \left| \int_X g \sum_{\fp \in \fT(\fu)} T_{\fp} f \,\mathrm{d}\mu \right|
     $$
@@ -4724,7 +4724,7 @@ $$
 \end{lemma}
 
 \begin{proof}
-    This follows immediately from Minkowski's inequality, Proposition \ref{Hardy-Littlewood}and Lemma \ref{adjoint-tree-estimate}, using that $a \ge 4$.
+    This follows immediately from Minkowski's inequality, \Cref{Hardy-Littlewood}and \Cref{adjoint-tree-estimate}, using that $a \ge 4$.
 \end{proof}
 
 
@@ -4744,16 +4744,16 @@ Now we are ready to state the main result of this subsection.
     \end{equation}
 \end{lemma}
 
-\begin{proof}[Proof of Lemma \ref{correlation-separated-trees}]
+\begin{proof}[Proof of \Cref{correlation-separated-trees}]
     \proves{correlation-separated-trees}
-    By Lemma \ref{adjoint-tile-support} and \eqref{dyadicproperty}, the left hand side \eqref{eq-lhs-sep-tree} is $0$ unless $\scI(\fu_1) \subset \scI(\fu_2)$ or $\scI(\fu_2) \subset \scI(\fu_1)$. Without loss of generality we assume that $\scI(\fu_1) \subset \scI(\fu_2)$.
+    By \Cref{adjoint-tile-support} and \eqref{dyadicproperty}, the left hand side \eqref{eq-lhs-sep-tree} is $0$ unless $\scI(\fu_1) \subset \scI(\fu_2)$ or $\scI(\fu_2) \subset \scI(\fu_1)$. Without loss of generality we assume that $\scI(\fu_1) \subset \scI(\fu_2)$.
 
     Define
     \begin{equation}
         \label{def-Tree-S-set}
          \mathfrak{S} := \{\fp \in \fT(\fu_1) \cup \fT(\fu_2) \ : \ d_{\fp}(\fcc(\fu_1), \fcc(\fu_2)) \ge 2^{Zn/2}\,\}.
     \end{equation}
-    Lemma \ref{correlation-separated-trees} follows by combining the definition \eqref{defineZ} of $Z$ with the following two lemmas.
+    \Cref{correlation-separated-trees} follows by combining the definition \eqref{defineZ} of $Z$ with the following two lemmas.
     \begin{lemma}[correlation distant tree parts]
         \label{correlation-distant-tree-parts}
         \uses{Holder-van-der-Corput,Lipschitz-partition-unity,Holder-correlation-tree,lower-oscillation-bound}
@@ -4798,7 +4798,7 @@ In the proofs of both lemmas, we will need the following observation.
     \end{align*}
     using that $Z= 2^{12a}\ge 4$. Hence $\fp \in \mathfrak{S}$.
 
-    Suppose now that $\fp \in \fT(\fu_2)$. If $\scI(\fp) \subset \scI(\fu_1)$, then the same argument as above with $\fu_1$ and $\fu_2$ swapped shows $\fp \in \mathfrak{S}$. If $\scI(\fp) \not \subset \scI(\fu_1)$ then, by \eqref{dyadicproperty}, $\scI(\fu_1) \subset \scI(\fp)$. Pick $\fp' \in \fT(\fu_1)$, we have $\scI(\fp') \subset \scI(\fu_1) \subset \scI(\fp)$. Hence, by Lemma \ref{monotone-cube-metrics} and the first paragraph
+    Suppose now that $\fp \in \fT(\fu_2)$. If $\scI(\fp) \subset \scI(\fu_1)$, then the same argument as above with $\fu_1$ and $\fu_2$ swapped shows $\fp \in \mathfrak{S}$. If $\scI(\fp) \not \subset \scI(\fu_1)$ then, by \eqref{dyadicproperty}, $\scI(\fu_1) \subset \scI(\fp)$. Pick $\fp' \in \fT(\fu_1)$, we have $\scI(\fp') \subset \scI(\fu_1) \subset \scI(\fp)$. Hence, by \Cref{monotone-cube-metrics} and the first paragraph
     $$
         d_{\fp}(\fcc(\fu_1), \fcc(\fu_2)) \ge d_{\fp'}(\fcc(\fu_1), \fcc(\fu_2)) \ge 2^{Zn}\,,
     $$
@@ -4813,7 +4813,7 @@ $$
 \section{Proof of the Tiles with large separation Lemma}
     \label{subsec-big-tiles}
 
-Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estimate in Proposition \ref{Holder-van-der-Corput}. We apply this proposition in Subsubsection \ref{subsubsec-van-der-corput}. To prepare this application, we first, in Subsubsection \ref{subsubsec-pao}, construct a suitable partition of unity, and show then, in Subsubsection \ref{subsubsec-holder-estimates} the H\"older estimates needed to apply Proposition \ref{Holder-van-der-Corput}.
+\Cref{correlation-distant-tree-parts} follows from the van der Corput estimate in \Cref{Holder-van-der-Corput}. We apply this proposition in Subsubsection \ref{subsubsec-van-der-corput}. To prepare this application, we first, in Subsubsection \ref{subsubsec-pao}, construct a suitable partition of unity, and show then, in Subsubsection \ref{subsubsec-holder-estimates} the H\"older estimates needed to apply \Cref{Holder-van-der-Corput}.
 
 \subsection{A partition of unity}
 \label{subsubsec-pao}
@@ -4832,7 +4832,7 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
     \end{lemma}
 
     \begin{proof}
-        By Lemma \ref{dyadic-partitions}, it remains only to show that each $J \in \mathcal{J}(\mathfrak{S})$ with $J \cap \scI(\fu_1) \ne \emptyset$ is in $\mathcal{J}'$. But if $J \notin \mathcal{J}'$, then by \eqref{dyadicproperty} $\scI(\fu_1) \subsetneq J$. Pick $\fp \in \fT(\fu_1) \subset \mathfrak{S}$.  Then $\scI(\fp) \subsetneq J$. This contradicts the definition of $\mathcal{J}(\mathfrak{S})$.
+        By \Cref{dyadic-partitions}, it remains only to show that each $J \in \mathcal{J}(\mathfrak{S})$ with $J \cap \scI(\fu_1) \ne \emptyset$ is in $\mathcal{J}'$. But if $J \notin \mathcal{J}'$, then by \eqref{dyadicproperty} $\scI(\fu_1) \subsetneq J$. Pick $\fp \in \fT(\fu_1) \subset \mathfrak{S}$.  Then $\scI(\fp) \subsetneq J$. This contradicts the definition of $\mathcal{J}(\mathfrak{S})$.
     \end{proof}
 
     For cubes $J \in \mathcal{D}$, denote
@@ -4872,7 +4872,7 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
         then $|s(J) - s(J')| \le 1$.
     \end{lemma}
 
-    \begin{proof}[Proof of Lemma \ref{Lipschitz-partition-unity}]
+    \begin{proof}[Proof of \Cref{Lipschitz-partition-unity}]
         \proves{Lipschitz-partition-unity}
         For each cube $J \in \mathcal{J}$ let
         $$
@@ -4890,7 +4890,7 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
         $$
             |\chi_J(y) - \chi_J(y')| \le \frac{|\tilde \chi_J(y) - \tilde \chi_J(y')|}{a(y)} + \frac{\tilde \chi_J(y')|a(y) - a(y')|}{a(y)a(y')}
         $$
-        Since $\tilde \chi_J(z) \ge 4$ for all $z \in B(c(J), 4) \supset J$ and by Lemma \ref{dyadic-partition-1}, we have that $a(z) \ge 4$ for all $z \in \scI(\fu_1)$. So we can estimate the above further by
+        Since $\tilde \chi_J(z) \ge 4$ for all $z \in B(c(J), 4) \supset J$ and by \Cref{dyadic-partition-1}, we have that $a(z) \ge 4$ for all $z \in \scI(\fu_1)$. So we can estimate the above further by
         $$
             \le 2^{-2}(|\tilde \chi_J(y) - \tilde \chi_J(y')| + \tilde \chi_J(y')|a(y) - a(y')|)\,.
         $$
@@ -4906,11 +4906,11 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
         $$
             |\chi_J(y) - \chi_J(y')| \le \rho(y,y') \Big( \frac{1}{4} D^{-s(J)} + 2 \sum_{\substack{J' \in \mathcal{J}'\\ B(J') \cap B(J) \ne \emptyset}} D^{-s(J')}\Big)\,.
         $$
-        By Lemma \ref{moderate-scale-change}, this is at most
+        By \Cref{moderate-scale-change}, this is at most
         $$
              \frac{\rho(y,y')}{D^{s(J)}} \left( \frac{1}{4} + 2D |\{J' \in \mathcal{J}' \ : \  B(J') \cap B(J) \ne \emptyset\}|\right)\,.
         $$
-        By \eqref{eq-vol-sp-cube} and Lemma \ref{dyadic-partition-1}, the balls $B(c(J'), \frac{1}{4} D^{s(J')})$ are pairwise disjoint, so by Lemma \ref{moderate-scale-change} the balls $B(c(J'), \frac{1}{4} D^{s(J) - 1})$ are also disjoint. By the triangle inequality and Lemma \ref{moderate-scale-change}, each such ball for $J'$ in the set of the last display is contained in
+        By \eqref{eq-vol-sp-cube} and \Cref{dyadic-partition-1}, the balls $B(c(J'), \frac{1}{4} D^{s(J')})$ are pairwise disjoint, so by \Cref{moderate-scale-change} the balls $B(c(J'), \frac{1}{4} D^{s(J) - 1})$ are also disjoint. By the triangle inequality and \Cref{moderate-scale-change}, each such ball for $J'$ in the set of the last display is contained in
         $$
             B(c(J), 9 D^{s(J) + 1})\,.
         $$
@@ -4928,7 +4928,7 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
         Since $a\ge 4$, \eqref{eq-pao-3} follows.
     \end{proof}
 
-    \begin{proof}[Proof of Lemma \ref{moderate-scale-change}]
+    \begin{proof}[Proof of \Cref{moderate-scale-change}]
         \proves{moderate-scale-change}
         Suppose that $s(J') < s(J) - 1$. Then $s(J) > -S$. Thus, by the definition of $\mathcal{J}'$ there exists no $\fp \in \mathfrak{S}$ with
         \begin{equation}
@@ -5047,7 +5047,7 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
             \eqref{T*Holder1b}+\eqref{T*Holder1} \le \frac{2^{151a^3}}{\mu(B(\pc(\fp), 4D^{\ps(\fp)}))} \left(\frac{\rho(y,y')}{D^{\ps(\fp)}}\right)^{1/a} \int_{E(\fp)}|g(x)| \, \mathrm{d}\mu(x)\,.
         $$
 
-        Next, if $y,y' \notin B(\pc(\fp), 5D^{\ps(\fp)})$, then $T_{\fp}^*g(y) = T_{\fp}^*g(y') = 0$, by Lemma \ref{adjoint-tile-support}. Then \eqref{T*Holder2} holds.
+        Next, if $y,y' \notin B(\pc(\fp), 5D^{\ps(\fp)})$, then $T_{\fp}^*g(y) = T_{\fp}^*g(y') = 0$, by \Cref{adjoint-tile-support}. Then \eqref{T*Holder2} holds.
 
         Finally, if $y \in B(\pc(\fp), 5D^{\ps(\fp)})$ and $y' \notin B(\pc(\fp), 5D^{\ps(\fp)})$, then
         $$
@@ -5107,7 +5107,7 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
     \end{lemma}
 
     \begin{proof}
-        For the first estimate, assume that $\ps(\fp) < s(J)$, then in particular $\ps(\fp) \le \ps(\fu_1)$. Since $\fp \notin \mathfrak{S}$, we have by Lemma \ref{overlap-implies-distance} that $\scI(\fp) \cap \scI(\fu_1) = \emptyset$.
+        For the first estimate, assume that $\ps(\fp) < s(J)$, then in particular $\ps(\fp) \le \ps(\fu_1)$. Since $\fp \notin \mathfrak{S}$, we have by \Cref{overlap-implies-distance} that $\scI(\fp) \cap \scI(\fu_1) = \emptyset$.
         Since $B\Big(c(J), \frac{1}{4} D^{s(J)}\Big) \subset \scI(J) \subset \scI(\fu_1)$, this implies
         $$
             \rho(c(J), \pc(\fp)) \ge \frac{1}{4}D^{s(J)}\,.
@@ -5156,7 +5156,7 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
             \sup_{B^\circ{}(J)} |T_{\fT(\fu_2) \setminus\mathfrak{S}}^* g|
             \leq \sup_{B^\circ{}(J)} \sum_{\substack{\fp \in \fT(\fu_2) \setminus \mathfrak{S}\\ B(\scI(\fp)) \cap B^\circ(J)  \ne \emptyset}} |T_{\fp}^*g|\,.
         $$
-        By Lemma \ref{limited-scale-impact}, this is at most
+        By \Cref{limited-scale-impact}, this is at most
         \begin{equation}
             \label{eq-sep-tree-aux-3}
             \sum_{s = s(J)}^{s(J) + 10a^2 + 2} \sum_{\substack{\fp \in \fP, \ps(\fp) = s\\ B(\scI(\fp)) \cap B^\circ(J)  \ne \emptyset}} \sup_{B^\circ{}(J)} |T_{\fp}^* g|\,.
@@ -5190,7 +5190,7 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
     \end{lemma}
 
     \begin{proof}
-        By Lemma \ref{overlap-implies-distance}, we have that in both cases, $\fC \subset \mathfrak{S}$. If $\fp \in \fC$ with $B(\scI(\fp)) \cap B(J) \neq \emptyset$ and $\ps(\fp) < s(J)$, then $\scI(\fp) \subset B(c(J), 100 D^{s(J) + 1})$. Since $\fp \in \mathfrak{S}$, it follows from the definition of $\mathcal{J}'$ that $s(J) = -S$, which contradicts $\ps(\fp) < s(J)$.
+        By \Cref{overlap-implies-distance}, we have that in both cases, $\fC \subset \mathfrak{S}$. If $\fp \in \fC$ with $B(\scI(\fp)) \cap B(J) \neq \emptyset$ and $\ps(\fp) < s(J)$, then $\scI(\fp) \subset B(c(J), 100 D^{s(J) + 1})$. Since $\fp \in \mathfrak{S}$, it follows from the definition of $\mathcal{J}'$ that $s(J) = -S$, which contradicts $\ps(\fp) < s(J)$.
     \end{proof}
 
     \begin{lemma}[global tree control 1]
@@ -5215,7 +5215,7 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
         Note that \eqref{TreeUB} follows from \eqref{TreeHolder}, since for $y'\in B^\circ{}(J)$, by the triangle inequality,
         $$\left(\frac{\rho(y,y')}{D^{s(J)}}\right)^{1/a}\le \Big(8 + \frac{1}8\Big)^{1/a}\le 2^{a^3}.$$
 
-        By the triangle inequality, Lemma \ref{adjoint-tile-support} and Lemma \ref{Holder-correlation-tile}, we have for all $y, y' \in B(J)$
+        By the triangle inequality, \Cref{adjoint-tile-support} and \Cref{Holder-correlation-tile}, we have for all $y, y' \in B(J)$
         \begin{equation}
             \label{eq-C-Lip}
             |e(\fcc(\fu)(y)) T_{\fC}^* g(y) - e(\fcc(\fu)(y')) T_{\fC}^* g(y')|
@@ -5226,7 +5226,7 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
         $$
             \le 2^{151a^3}\rho(y,y')^{1/a}  \sum_{\substack{\fp \in \fC\\ B(\scI(\fp)) \cap B(J) \neq \emptyset}} \frac{D^{- \ps(\fp)/a}}{\mu(B(\pc(\fp), 4D^{\ps(\fp)}))} \int_{E(\fp)} |g| \, \mathrm{d}\mu\,.
         $$
-        By Lemma \ref{scales-impacting-interval}, we have $\ps(\fp) \ge s(J)$ for all $\fp$ occurring in the sum. Further, for each $s \ge s(J)$, the sets $E(\fp)$ for $\fp \in \fP$ with $\ps(\fp) = s$ are pairwise disjoint by \eqref{defineep} and \eqref{eq-dis-freq-cover}, and contained in $B(c(J), 32D^{s})$ by \eqref{eq-vol-sp-cube} and the triangle inequality. Using also the doubling estimate \eqref{doublingx}, we obtain that the expression in the last display can be estimated by
+        By \Cref{scales-impacting-interval}, we have $\ps(\fp) \ge s(J)$ for all $\fp$ occurring in the sum. Further, for each $s \ge s(J)$, the sets $E(\fp)$ for $\fp \in \fP$ with $\ps(\fp) = s$ are pairwise disjoint by \eqref{defineep} and \eqref{eq-dis-freq-cover}, and contained in $B(c(J), 32D^{s})$ by \eqref{eq-vol-sp-cube} and the triangle inequality. Using also the doubling estimate \eqref{doublingx}, we obtain that the expression in the last display can be estimated by
         $$
             2^{151a^3}\rho(y,y')^{1/a} \sum_{S \ge s \ge s(J)}  D^{-s/a}  \frac{2^{3a}}{\mu(B(c(J), 32D^{s}))} \int_{B(c(J), 32D^{s})} |g| \, \mathrm{d}\mu
         $$
@@ -5254,14 +5254,14 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
     \end{lemma}
 
     \begin{proof}
-        By Lemma \ref{global-tree-control-1}
+        By \Cref{global-tree-control-1}
         $$
             \sup_{B(J)} |T^*_{\fT(\fu_2) \cap \mathfrak{S}} g| \le \inf_{B^\circ{}(J)} |T_{\fT(\fu_2) \cap \mathfrak{S}}^* g| +  2^{154a^3} \inf_{J} M_{\mathcal{B}, 1} |g|
         $$
         $$
             \le \inf_{B^\circ{}(J)} |T_{\fT(\fu_2)}^* g| + \sup_{B^\circ{}(J)} |T_{\fT(\fu_2) \setminus \mathfrak{S}}^* g| +  2^{154a^3} \inf_{J} M_{\mathcal{B}, 1} |g|\,,
         $$
-        and by Lemma \ref{local-tree-control}
+        and by \Cref{local-tree-control}
         $$
             \le \inf_{B^\circ{}(J)} |T_{\fT(\fu_2)}^* g| + (2^{104a^3} + 2^{154a^3}) \inf_{J} M_{\mathcal{B}, 1} |g|\,.
         $$
@@ -5270,12 +5270,12 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
 
 
 
-    \begin{proof}[Proof of Lemma \ref{Holder-correlation-tree}]
+    \begin{proof}[Proof of \Cref{Holder-correlation-tree}]
         \proves{Holder-correlation-tree}
         Let $P$ be the product on the right hand side of \eqref{hHolder}, and $h_J$ as defined in \eqref{def-hj}.
 
-        By \eqref{eq-pao-2} and Lemma \ref{adjoint-tile-support}, the function $h_J$ is supported in $B(J) \cap \scI(\fu_1)$.
-        By \eqref{eq-pao-2} and Lemma \ref{global-tree-control-1}, we have for all $y \in B(J)$:
+        By \eqref{eq-pao-2} and \Cref{adjoint-tile-support}, the function $h_J$ is supported in $B(J) \cap \scI(\fu_1)$.
+        By \eqref{eq-pao-2} and \Cref{global-tree-control-1}, we have for all $y \in B(J)$:
         $$
             |h_J(y)| \le 2^{308a^3} P\,.
         $$
@@ -5291,18 +5291,18 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
         \end{align}
 
         As $h_J$ is supported in $\scI(\fu_1)$, we can assume without loss of generality that $y' \in \scI(\fu_1)$.
-        If $y \notin \scI(\fu_1)$, then \eqref{eq-h-Lip-1} vanishes. If $y \in \scI(\fu_1)$ then we have by \eqref{eq-pao-3}, Lemma \ref{global-tree-control-1} and Lemma \ref{global-tree-control-2}
+        If $y \notin \scI(\fu_1)$, then \eqref{eq-h-Lip-1} vanishes. If $y \in \scI(\fu_1)$ then we have by \eqref{eq-pao-3}, \Cref{global-tree-control-1} and \Cref{global-tree-control-2}
         $$
             \eqref{eq-h-Lip-1} \le 2^{534a^3} \frac{\rho(y,y')}{D^{s(J)}} P\,,
         $$
         where $P$ denotes the product on the right hand side of \eqref{hHolder}.
 
-        By \eqref{eq-pao-2}, Lemma \ref{global-tree-control-1} and Lemma \ref{global-tree-control-2}, we have
+        By \eqref{eq-pao-2}, \Cref{global-tree-control-1} and \Cref{global-tree-control-2}, we have
         $$
             \eqref{eq-h-Lip-2} \le  2^{310a^3} P\,.
          $$
 
-        By \eqref{eq-pao-2}, and twice Lemma \ref{global-tree-control-1}, we have
+        By \eqref{eq-pao-2}, and twice \Cref{global-tree-control-1}, we have
         $$
             \eqref{eq-h-Lip-3} \le 2^{308a^3} P\,.
         $$
@@ -5321,7 +5321,7 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
     \end{lemma}
 
     \begin{proof}
-    Since $\emptyset \ne \fT(\fu_1) \subset \mathfrak{S}$ by Lemma \ref{overlap-implies-distance}, there exists at least one tile $\fp \in \mathcal{S}$ with $\scI(\fp) \subsetneq \scI(\fu_1)$. Thus $\scI(\fu_1) \notin \mathcal{J}'$, so $J \subsetneq \scI(\fu_1)$. Thus there exists a cube $J' \in \mathcal{D}$ with $J \subset J'$ and $s(J') = s(J) + 1$, by \eqref{coverdyadic} and \eqref{dyadicproperty}. By definition of $\mathcal{J'}$ and the triangle inequality, there exists $\fp \in \mathfrak{S}$ such that
+    Since $\emptyset \ne \fT(\fu_1) \subset \mathfrak{S}$ by \Cref{overlap-implies-distance}, there exists at least one tile $\fp \in \mathcal{S}$ with $\scI(\fp) \subsetneq \scI(\fu_1)$. Thus $\scI(\fu_1) \notin \mathcal{J}'$, so $J \subsetneq \scI(\fu_1)$. Thus there exists a cube $J' \in \mathcal{D}$ with $J \subset J'$ and $s(J') = s(J) + 1$, by \eqref{coverdyadic} and \eqref{dyadicproperty}. By definition of $\mathcal{J'}$ and the triangle inequality, there exists $\fp \in \mathfrak{S}$ such that
     $$
         \scI(\fp) \subset B(c(J'), 100 D^{s(J') + 1}) \subset B(c(J), 128 D^{s(J)+2})\,.
     $$
@@ -5336,22 +5336,22 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
     which gives the lemma using $a \ge 4$.
     \end{proof}
 
-    Now we are ready to prove Lemma \ref{correlation-distant-tree-parts}.
-    \begin{proof}[Proof of Lemma \ref{correlation-distant-tree-parts}]
+    Now we are ready to prove \Cref{correlation-distant-tree-parts}.
+    \begin{proof}[Proof of \Cref{correlation-distant-tree-parts}]
     \proves{correlation-distant-tree-parts}
     We have
     $$
         \eqref{eq-lhs-big-sep-tree} = \left| \int_{X} T_{\fT(\fu_1)}^* g_1 \overline{T_{\fT(\fu_2) \cap \mathfrak{S}}^* g_2 }\right|\,.
     $$
-    By Lemma \ref{adjoint-tile-support}, the right hand side is supported in $\scI(\fu_1)$. Using \eqref{eq-pao-1} of Lemma \ref{Lipschitz-partition-unity} and the definition \eqref{def-hj} of $h_J$, we thus have
+    By \Cref{adjoint-tile-support}, the right hand side is supported in $\scI(\fu_1)$. Using \eqref{eq-pao-1} of \Cref{Lipschitz-partition-unity} and the definition \eqref{def-hj} of $h_J$, we thus have
     $$
         \le  \sum_{J \in \mathcal{J}'} \left|\int_{B(J)} e(\fcc(\fu_2)(y) - \fcc(\fu_1)(y)) h_J(y) \, \mathrm{d}\mu(y) \right|\,.
     $$
-    Using Proposition \ref{Holder-van-der-Corput} with the ball $B(J)$, we bound this by
+    Using \Cref{Holder-van-der-Corput} with the ball $B(J)$, we bound this by
     $$
         \le 2^{8a} \sum_{J \in \mathcal{J}'} \mu(B(J)) \|h_J\|_{C^{\tau}(B(J))} (1 + d_{B(J)}(\fcc(\fu_1), \fcc(\fu_1)))^{-1/(2a^2+a^3)}\,.
     $$
-    Using Lemma \ref{Holder-correlation-tree}, Lemma \ref{lower-oscillation-bound} and $a \ge 4$, we have that the above is bounded from above by
+    Using \Cref{Holder-correlation-tree}, \Cref{lower-oscillation-bound} and $a \ge 4$, we have that the above is bounded from above by
     \begin{multline}
         \label{eq-big-sep-1}
         \le 2^{540a^3} 2^{-Zn/(4a^2 + 2a^3)} \sum_{J \in \mathcal{J}'} \mu(B(J)) \\
@@ -5375,7 +5375,7 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
     $$
         \eqref{eq-big-sep-1} \le 2^{541a^3} 2^{-Zn/(4a^2 + 2a^3)} \int_X \prod_{j=1}^2 ( |T_{\fT(\fu_j)}^* g_j|(x) +  M_{\mathcal{B},1} g_j(x)) \, \mathrm{d}\mu(x)\,.
     $$
-    Applying the Cauchy-Schwarz inequality, Lemma \ref{correlation-distant-tree-parts} follows.
+    Applying the Cauchy-Schwarz inequality, \Cref{correlation-distant-tree-parts} follows.
     \end{proof}
 
 \section{Proof of The Remaining Tiles Lemma}
@@ -5395,10 +5395,10 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
     \end{lemma}
 
     \begin{proof}
-        By Lemma \ref{dyadic-partitions}, it remains only to show that each $J \in \mathcal{J}(\fT(\fu_1))$ with $J \cap \scI(\fu_1) \ne \emptyset$ is in $\mathcal{J}'$. But if $J \notin \mathcal{J}'$, then by \eqref{dyadicproperty} $\scI(\fu_1) \subsetneq J$. Pick $\fp \in \fT(\fu_1)$.  Then $\scI(\fp) \subsetneq J$. This contradicts the definition of $\mathcal{J}(\fT(\fu_1))$.
+        By \Cref{dyadic-partitions}, it remains only to show that each $J \in \mathcal{J}(\fT(\fu_1))$ with $J \cap \scI(\fu_1) \ne \emptyset$ is in $\mathcal{J}'$. But if $J \notin \mathcal{J}'$, then by \eqref{dyadicproperty} $\scI(\fu_1) \subsetneq J$. Pick $\fp \in \fT(\fu_1)$.  Then $\scI(\fp) \subsetneq J$. This contradicts the definition of $\mathcal{J}(\fT(\fu_1))$.
     \end{proof}
 
-    Lemma \ref{correlation-near-tree-parts} follows from the following key estimate.
+    \Cref{correlation-near-tree-parts} follows from the following key estimate.
 
     \begin{lemma}[bound for tree projection]
         \label{bound-for-tree-projection}
@@ -5410,11 +5410,11 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
         $$
     \end{lemma}
 
-    We prove this lemma below. First, we deduce Lemma \ref{correlation-near-tree-parts}.
+    We prove this lemma below. First, we deduce \Cref{correlation-near-tree-parts}.
 
-    \begin{proof}[Proof of Lemma \ref{correlation-near-tree-parts}]
+    \begin{proof}[Proof of \Cref{correlation-near-tree-parts}]
         \proves{correlation-near-tree-parts}
-        By Lemma \ref{tree-projection-estimate} and Lemma \ref{adjoint-tile-support}, we have
+        By \Cref{tree-projection-estimate} and \Cref{adjoint-tile-support}, we have
         \begin{align*}
             \eqref{eq-lhs-small-sep-tree} \le 2^{104a^3} \|P_{\mathcal{L}(\fT(\fu_1))} |g_1\mathbf{1}_{\scI(\fu_1)}| \|_2 \|\mathbf{1}_{\scI(\fu_1)} P_{\mathcal{J}(\fT(\fu_1) )}|T_{\fT(\fu_2) \setminus \mathfrak{S}}^* g_2|\|_2\,.
         \end{align*}
@@ -5422,14 +5422,14 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
         $$
             \|P_{\mathcal{L}(\fT(\fu_1))} |g_1\mathbf{1}_{\scI(\fu_1)}| \|_2 \le \|g_1 \mathbf{1}_{\scI(\fu_1)}\|_2\,.
         $$
-        Since cubes in $\mathcal{J}'$ are pairwise disjoint and by Lemma \ref{dyadic-partition-2}, a cube $J \in \mathcal{J}'$ intersect $\scI(\fu_1)$ if and only if $J \in \mathcal{J}'$. Thus
+        Since cubes in $\mathcal{J}'$ are pairwise disjoint and by \Cref{dyadic-partition-2}, a cube $J \in \mathcal{J}'$ intersect $\scI(\fu_1)$ if and only if $J \in \mathcal{J}'$. Thus
         $$
             \mathbf{1}_{\scI(\fu_1)} P_{\mathcal{J}(\fT(\fu_1) )}|T_{\fT(\fu_2) \setminus \mathfrak{S}}^* g_2| =  P_{\mathcal{J}'}|T_{\fT(\fu_2) \setminus \mathfrak{S}}^* g_2|\,.
         $$
-        Combining this with Lemma \ref{bound-for-tree-projection}, the definition \eqref{definekappa} and $a \ge 4$ proves the lemma.
+        Combining this with \Cref{bound-for-tree-projection}, the definition \eqref{definekappa} and $a \ge 4$ proves the lemma.
     \end{proof}
 
-    We need two more auxiliary lemmas before we prove Lemma \ref{bound-for-tree-projection}.
+    We need two more auxiliary lemmas before we prove \Cref{bound-for-tree-projection}.
 
     \begin{lemma}[thin scale impact]
         \label{thin-scale-impact}
@@ -5488,7 +5488,7 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
         $$
     \end{lemma}
 
-    \begin{proof}[Proof of Lemma \ref{square-function-count}]
+    \begin{proof}[Proof of \Cref{square-function-count}]
         \proves{square-function-count}
         Since $J \in \mathcal{J}'$ we have $J \subset \scI(\fu_1)$. Thus, if $B(I) \cap J \ne \emptyset$ then
     \begin{equation}
@@ -5514,7 +5514,7 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
 \end{proof}
 
 
-\begin{proof}[Proof of Lemma \ref{bound-for-tree-projection}]
+\begin{proof}[Proof of \Cref{bound-for-tree-projection}]
     \proves{bound-for-tree-projection}
     Expanding the definition of $P_{\mathcal{J}'}$, we have
     $$
@@ -5527,13 +5527,13 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
     $$
         \le \sum_{s = -S}^S \left( \sum_{J \in \mathcal{J}'} \frac{1}{\mu(J)} \left|\int_J \sum_{\substack{\fp \in \fT(\fu_2) \setminus \mathfrak{S}\\ \ps(\fp) = s}} T_{\fp}^* g_2 \, \mathrm{d}\mu(y) \right|^2\right)^{1/2}\,.
     $$
-    By Lemma \ref{adjoint-tile-support}, the integral in the last display is $0$ if $J \cap B(\scI(\fp)) = \emptyset$. By Lemma \ref{thin-scale-impact}, it follows with $s_1 := \frac{Zn}{202a^3} - 2$:
+    By \Cref{adjoint-tile-support}, the integral in the last display is $0$ if $J \cap B(\scI(\fp)) = \emptyset$. By \Cref{thin-scale-impact}, it follows with $s_1 := \frac{Zn}{202a^3} - 2$:
     \begin{equation}
     \label{eq-sep-tree-small-1}
         = \sum_{s = s_1}^{s_1 + 2S} \Bigg( \sum_{J \in \mathcal{J}'} \frac{1}{\mu(J)} \Bigg|\int_J \sum_{\substack{\fp \in \fT(\fu_2) \setminus \mathfrak{S}\\ \ps(\fp) = s(J) - s\\
         J \cap B(\scI(\fp)) \ne \emptyset}} T_{\fp}^* g_2 \, \mathrm{d}\mu(y) \Bigg|^2\Bigg)^{1/2}\,.
     \end{equation}
-    We have by Lemma \ref{adjoint-tile-support} and \eqref{eq-Ks-size}
+    We have by \Cref{adjoint-tile-support} and \eqref{eq-Ks-size}
     $$
         \int |T_{\fp}^* g_2|(y) \, \mathrm{d}\mu(y)
     $$
@@ -5566,7 +5566,7 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
     $$
         \le 2^{103a^3} \int_J M_{\mathcal{B},1} |g_2|(y) \mathbf{1}_{B(I)}(y) \, \mathrm{d}\mu(y)\,.
     $$
-    By Lemma \ref{overlap-implies-distance}, we have $\scI(\fp) \cap \scI(\fu_1) = \emptyset$ for all $\fp \in \fT(\fu_2) \setminus \mathfrak{S}$.
+    By \Cref{overlap-implies-distance}, we have $\scI(\fp) \cap \scI(\fu_1) = \emptyset$ for all $\fp \in \fT(\fu_2) \setminus \mathfrak{S}$.
     Thus we can estimate \eqref{eq-sep-tree-small-1} by
     $$
         2^{103a^3} \sum_{s = s_1}^{s_1 + 2S} \Bigg( \sum_{J \in \mathcal{J}'} \frac{1}{\mu(J)} \Bigg|\int_J \sum_{\substack{I \in \mathcal{D}, s(I) = s(J) - s\\ I \cap \scI(\fu_1) = \emptyset\\
@@ -5578,11 +5578,11 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
         2^{103a^3} \sum_{s = s_1}^{s_1 + 2S} \Bigg( \sum_{J \in \mathcal{J}'} \int_J  ( M_{\mathcal{B},1} |g_2|)^2 \frac{1}{\mu(J)} \int_J \Bigg(\sum_{\substack{I \in \mathcal{D}, s(I) = s(J) - s\\ I \cap \scI(\fu_1) = \emptyset\\
         J \cap B(I) \ne \emptyset}} \mathbf{1}_{B(I)}\bigg)^2 \, \mathrm{d}\mu \Bigg)^{\frac 12}\,.
     \end{equation}
-    Using Lemma \ref{square-function-count}, we bound \eqref{eq-sep-tree-small-2} by
+    Using \Cref{square-function-count}, we bound \eqref{eq-sep-tree-small-2} by
     $$
         2^{103a^3} \sum_{s = s_1}^{s_1 + 2S} \left(\sum_{J \in \mathcal{J}'} \int_J (M_{\mathcal{B},1} |g_2|)^2 2^{104a^2} (8 D^{-s})^\kappa\right)^{\frac 1 2}\,,
     $$
-    and, since dyadic cubes in $\mathcal{J}'$ form a partition of $\scI(\fu_1)$ by Lemma \ref{dyadic-partition-2}, $\kappa \le 1$ by \eqref{definekappa}, and $a \ge 4$
+    and, since dyadic cubes in $\mathcal{J}'$ form a partition of $\scI(\fu_1)$ by \Cref{dyadic-partition-2}, $\kappa \le 1$ by \eqref{definekappa}, and $a \ge 4$
     $$
         \le 2^{116a^3} \sum_{s = s_1}^{s_1 + 2S} D^{-s\kappa/2} \|\mathbf{1}_{\scI(\fu_1)} M_{\mathcal{B},1} |g_2|\|_2
     $$
@@ -5606,7 +5606,7 @@ Lemma \ref{correlation-distant-tree-parts} follows from the van der Corput estim
 
 
 \section{Forests}
-In this subsection, we complete the proof of Proposition \ref{forest-operator} from the results of the previous subsections.
+In this subsection, we complete the proof of \Cref{forest-operator} from the results of the previous subsections.
 
 Define an $n$-row to be an $n$-forest $(\fU, \fT)$, i.e. satisfying conditions \eqref{forest1} - \eqref{forest6}, such that in addition the sets $\scI(\fu), \fu \in \fU$ are pairwise disjoint.
 
@@ -5633,7 +5633,7 @@ We pick a decomposition of the forest $(\fU, \fT)$ into $2^n$ $n$-rows
 \begin{equation*}
 (\fU_j, \fT_j) := (\fU_j, \fT|_{\fU_j})
 \end{equation*}
-as in Lemma \ref{forest-row-decomposition}.
+as in \Cref{forest-row-decomposition}.
 
 \begin{lemma}[row bound]
     \label{row-bound}
@@ -5651,7 +5651,7 @@ as in Lemma \ref{forest-row-decomposition}.
 \end{lemma}
 
 \begin{proof}
-    By Lemma \ref{densities-tree-bound} and the density assumption \eqref{forest4}, we have for each $\fu \in \fU$ and all bounded $f$ of bounded support that
+    By \Cref{densities-tree-bound} and the density assumption \eqref{forest4}, we have for each $\fu \in \fU$ and all bounded $f$ of bounded support that
     \begin{equation}
         \label{eq-explicit-tree-bound-1}
         \left\|\sum_{\fp \in \fT(\fu)} T_{\fp} f \right\|_{2}  \le 2^{155a^3} 2^{(4a+1-n)/2}  \|f\|_2\,
@@ -5661,7 +5661,7 @@ as in Lemma \ref{forest-row-decomposition}.
         \label{eq-explicit-tree-bound-2}
         \left\|\sum_{\fp \in \fT(\fu)} T_{\fp} \mathbf{1}_F f \right\|_{2} \le 2^{256a^3} 2^{(4a + 1-n)/2} \dens_2(\fT(\fu))^{1/2} \|f\|_2\,.
     \end{equation}
-    Since for each $j$ the top cubes $\scI(\fu)$, $\fu \in \fU_j$ are disjoint, we further have for all bounded $g$ of bounded support by Lemma \ref{adjoint-tile-support}
+    Since for each $j$ the top cubes $\scI(\fu)$, $\fu \in \fU_j$ are disjoint, we further have for all bounded $g$ of bounded support by \Cref{adjoint-tile-support}
     $$
         \left\|\mathbf{1}_F \sum_{\fu \in \fU_j} \sum_{\fp \in \fT(\fu)} T_{\fp}^* g\right\|_2^2 = \left\|\mathbf{1}_F \sum_{\fu \in \fU_j} \sum_{\fp \in \fT(\fu)} \mathbf{1}_{\scI(\fu)} T_{\fp}^* \mathbf{1}_{\scI(\fu)} g\right\|_2^2
     $$
@@ -5696,14 +5696,14 @@ as in Lemma \ref{forest-row-decomposition}.
     $$
         T_{\fC}^* = \sum_{\fp \in \fC} T_{\fp}^*\,.
     $$
-    We have by Lemma \ref{adjoint-tile-support} and the triangle inequality that
+    We have by \Cref{adjoint-tile-support} and the triangle inequality that
     $$
         \left| \int \sum_{\fu \in \fU_j} \sum_{\fu' \in \fU_{j'}} \sum_{\fp \in \fT_j(\fu)} \sum_{\fp' \in \fT_{j'}(\fu')} T^*_{\fp} g_1 \overline{T^*_{\fp'} g_2} \, \mathrm{d}\mu \right|
     $$
     $$
         \le   \sum_{\fu \in \fU_j} \sum_{\fu' \in \fU_{j'}} \left| \int   T^*_{\fT_j(\fu)} (\mathbf{1}_{\scI(\fu)} g_1) \overline{T^*_{\fT_{j'}(\fu')} (\mathbf{1}_{\scI(\fu')} g_2)} \, \mathrm{d}\mu \right|\,.
     $$
-    By Lemma \ref{correlation-separated-trees}, this is bounded by
+    By \Cref{correlation-separated-trees}, this is bounded by
     \begin{equation}
         \label{eq-S2uu'}
          2^{550a^3-3n} \sum_{\fu \in \fU_j} \sum_{\fu' \in \fU_{j'}} \|S_{2,\fu} g_1\|_{L^2(\scI(\fu')\cap \scI(\fu)} \|S_{2, \fu'} g_2\|_{L^2(\scI(\fu')\cap\scI(\fu))}\,.
@@ -5730,7 +5730,7 @@ as in Lemma \ref{forest-row-decomposition}.
     $$
         \le 2^{550a^3-3n} \|S_{2,\fu}g_1\|_2 \|S_{2,\fu'} g_2\|_2\,.
     $$
-    The lemma now follows from Lemma \ref{adjoint-tree-control}.
+    The lemma now follows from \Cref{adjoint-tree-control}.
 \end{proof}
 
 Define for $1 \le j \le 2^n$
@@ -5748,7 +5748,7 @@ $$
     $$
         d_{\fp}(\fcc(\fp), \fcc(\fu')) > 2^{Z(n+1)}\,.
     $$
-    By the triangle inequality. Lemma \ref{monotone-cube-metrics} and \eqref{forest1} it follows that
+    By the triangle inequality. \Cref{monotone-cube-metrics} and \eqref{forest1} it follows that
     \begin{align*}
         d_{\fp}(\fcc(\fp), \fcc(\fp')) &\ge d_{\fp}(\fcc(\fp), \fcc(\fu')) - d_{\fp}(\fcc(\fp'), \fcc(\fu'))\\
         &> 2^{Z(n+1)} - d_{\fp'}(\fcc(\fp'), \fcc(\fu'))\\
@@ -5757,9 +5757,9 @@ $$
     Since $Z \ge 3$ by \eqref{defineZ}, it follows that $\fcc(\fp') \notin B_{\fp}(\fcc(\fp), 1)$, so $\Omega(\fp') \not\subset \Omega(\fp)$ by \eqref{eq-freq-comp-ball}. Hence, by \eqref{eq-freq-dyadic}, $\Omega(\fp) \cap \Omega(\fp') = \emptyset$. But if $x \in E(\fp) \cap E(\fp')$ then $Q(x) \in \Omega(\fp) \cap \Omega(\fp')$. This is a contradiction, and the lemma follows.
 \end{proof}
 
-Now we prove Proposition \ref{forest-operator}.
+Now we prove \Cref{forest-operator}.
 
-\begin{proof}[Proof of Proposition \ref{forest-operator}]
+\begin{proof}[Proof of \Cref{forest-operator}]
     \proves{forest-operator}
     To save some space, we will write
     $$
@@ -5769,7 +5769,7 @@ Now we prove Proposition \ref{forest-operator}.
     $$
         T_{\mathfrak{R}_j}^*g = \sum_{\fu \in \fU_j} \sum_{\fp \in \fT(\fu)} T_{\fp}^* g = \sum_{\fu \in \fU_j} \sum_{\fp \in \fT(\fu)} T_{\fp}^* \mathbf{1}_{E_j} g = T_{\mathfrak{R}_j}^* \mathbf{1}_{E_j} g\,.
     $$
-    Hence, by Lemma \ref{forest-row-decomposition},
+    Hence, by \Cref{forest-row-decomposition},
     $$
         \left\|\sum_{\fu \in \fU} \sum_{\fp \in \fT(\fu)} T^*_{\fp} g\right\|_2^2 = \left\|\sum_{j = 1}^{2^n} T^*_{\mathfrak{R}_{j}} g\right\|_2^2  =  \left\|\sum_{j=1}^{2^n} T^*_{\mathfrak{R}_{j}} \mathbf{1}_{E_j} g\right\|_2^2
     $$
@@ -5779,7 +5779,7 @@ Now we prove Proposition \ref{forest-operator}.
     $$
         = \sum_{j=1}^{2^n} \int_X |T_{\mathfrak{R}_j}^* \mathbf{1}_{E_j} g|^2 + \sum_{j =1}^{2^n} \sum_{\substack{j' = 1\\j' \ne j}}^{2^n} \int_X \overline{ T_{\mathfrak{R}_j}^* \mathbf{1}_{E_j} g} T_{\mathfrak{R}_{j'}}^* \mathbf{1}_{E_{j'}} g \, \mathrm{d}\mu\,.
     $$
-    We use Lemma \ref{row-bound} to estimate each term in the first sum, and Lemma \ref{row-correlation} to bound each term in the second sum:
+    We use \Cref{row-bound} to estimate each term in the first sum, and \Cref{row-correlation} to bound each term in the second sum:
     $$
         \le 2^{312a^3-n} \sum_{j = 1}^{2^n} \|\mathbf{1}_{E_j} g\|_2^2 +  2^{862a^3-3 n}\sum_{j=1}^{2^n}\sum_{j' = 1}^{2^n} \|\mathbf{1}_{E_j} g\|_2 \|\mathbf{1}_{E_{j'}}g\|_2\,.
     $$
@@ -5797,11 +5797,11 @@ Now we prove Proposition \ref{forest-operator}.
         \left\|\sum_{\fu \in \fU} \sum_{\fp \in \fT(\fu)} T_{\fp} f\right\|_2 \le 2^{432a^3-\frac{n}{2}} \|f\|_2\,.
     \end{equation}
     On the other hand, we have by disjointedness of the sets $E_j$
-    from Lemma \ref{disjoint-row-support}
+    from \Cref{disjoint-row-support}
     $$
         \left\|\sum_{\fu \in \fU} \sum_{\fp \in \fT(\fu)} T_{\fp} f\right\|_2^2 =  \left\|\sum_{j=1}^{2^n} \mathbf{1}_{E_j} T_{\mathfrak{R}_{j}} f\right\|_2^2 = \sum_{j = 1}^{2^n} \|\mathbf{1}_{E_j} T_{\mathfrak{R}_{j}} f\|_2^2\,.
     $$
-    If $|f| \le \mathbf{1}_F$ then we obtain from Lemma \ref{row-bound} and taking square roots that
+    If $|f| \le \mathbf{1}_F$ then we obtain from \Cref{row-bound} and taking square roots that
     $$
         \le 2^{257a^3} \dens_2(\bigcup_{\fu\in \fU}\fT(\fu))^{\frac{1}{2}} 2^{-\frac{n}{2}} (\sum_{j = 1}^{2^n} \|f\|_2^2)^{\frac{1}{2}}
     $$
@@ -5809,7 +5809,7 @@ Now we prove Proposition \ref{forest-operator}.
         \label{eq-forest-bound-2}
         = 2^{257a^3} \dens_2(\bigcup_{\fu\in \fU}\fT(\fu))^{\frac{1}{2}} \|f\|_2\,.
     \end{equation}
-    Proposition \ref{forest-operator} follows by taking the product of the $(2 - \frac{2}{q})$-th power of \eqref{eq-forest-bound-1} and the $(\frac{2}{q} - 1)$-st power of \eqref{eq-forest-bound-2}.
+    \Cref{forest-operator} follows by taking the product of the $(2 - \frac{2}{q})$-th power of \eqref{eq-forest-bound-1} and the $(\frac{2}{q} - 1)$-st power of \eqref{eq-forest-bound-2}.
 \end{proof}
 
 \chapter{Proof of the H\"older cancellative condition}
@@ -5957,18 +5957,18 @@ Dividing by the integral over $L$ and using \eqref{eql32} and \eqref{2nt1}, we o
 \end{equation}
 Combining \eqref{eql52} and  \eqref{eql226} using $a\ge 4$ and $t\le 1$ and
 adding \eqref{eql42} proves \eqref{eq-secondt} and completes the proof
-of Lemma \ref{Lipschitz-Holder-approximation}.
+of \Cref{Lipschitz-Holder-approximation}.
 \end{proof}
 
 
-We turn to the proof of Proposition \ref{Holder-van-der-Corput}.
+We turn to the proof of \Cref{Holder-van-der-Corput}.
 Let $z\in X$ and $R>0$ and set $B=B(z,R)$. Let $\varphi$
-be given as in Proposition \ref{Holder-van-der-Corput}.
+be given as in \Cref{Holder-van-der-Corput}.
 Set
 \begin{equation}\label{eql69}
     t:=(1+d_B(\mfa,\mfb))^{-\frac{\tau}{2+a}}
 \end{equation}
-and define $\tilde{\varphi}$ as in Lemma \ref{Lipschitz-Holder-approximation}. Let $\mfa$ and $\mfb$ be in $\Mf$.
+and define $\tilde{\varphi}$ as in \Cref{Lipschitz-Holder-approximation}. Let $\mfa$ and $\mfb$ be in $\Mf$.
 Then
    \begin{equation}\label{eql60}
        \left|\int e(\mfa(x)-{\mfb(x)}) \varphi (x)\, \mathrm{d}\mu(x)\right|
@@ -6022,7 +6022,7 @@ Using the definition \eqref{eql69} of $t$ and adding
        (1 + d_{B}(\mfa,\mfb))^{-\frac{\tau^2}{2+a}}  \, ,
  \end{equation}
 where we used $\tau\le 1$.
-This completes the proof of Proposition \ref{Holder-van-der-Corput}.
+This completes the proof of \Cref{Holder-van-der-Corput}.
 
 
 \chapter{Proof of Vitali covering and Hardy--Littlewood}
@@ -6054,7 +6054,7 @@ we have
 This proves the lemma.
 \end{proof}
 
-We turn to the proof of Proposition \ref{Hardy-Littlewood}.
+We turn to the proof of \Cref{Hardy-Littlewood}.
 Let the collection $\mathcal{B}$ be given.
 We first show \eqref{eq-besico}.
 
@@ -6124,7 +6124,7 @@ With \eqref{eqbes1} and \eqref{eqbes2} we conclude
 
 We turn to the proof of \eqref{eq-hlm}. We first consider the case $p_1=1$ and recall $M_{\mathcal{B}}=M_{\mathcal{B},1}$.
 We write for the $p_2$-th power of left-hand side of \eqref{eq-hlm}
-with Lemma \ref{layer-cake-representation}
+with \Cref{layer-cake-representation}
 and a change of variables
 \begin{equation}
     \|M_{\mathcal{B}}u(x)\|_{p_2}^{p_2}
@@ -6180,7 +6180,7 @@ gives
    2^{2a}
     \int u_\lambda (x)\, dx\, .
 \end{equation}
-With Lemma \ref{layer-cake-representation},
+With \Cref{layer-cake-representation},
 \begin{equation}\label{eqbesi12}
     \lambda \mu(\{x: M_{\mathcal{B}}u(x)\ge 2\lambda\})\le
    2^{2a}
@@ -6207,7 +6207,7 @@ We obtain with \eqref{eqbesi11},
 We split the integral  into $\lambda\ge \lambda'$ and $\lambda<\lambda'$ and resolve the
 maximum correspondingly.
 We have for $\lambda\ge \lambda'$
-with Lemma \ref{layer-cake-representation}
+with \Cref{layer-cake-representation}
 \begin{equation}
     \int_0^\infty \lambda^{p_2-2}
    \int_0^\lambda
@@ -6223,7 +6223,7 @@ d\lambda.
    =p_2^{-1} \|u\|_{p_2}^{p_2}\, .
 \end{equation}
 We have for $\lambda< \lambda'$
-with Fubini and Lemma \ref{layer-cake-representation}
+with Fubini and \Cref{layer-cake-representation}
 \begin{equation}
     \int_0^\infty \lambda^{p_2-2}
    \int_\lambda^\infty
@@ -6305,7 +6305,7 @@ Define
 $$
     \mathcal{B}_\infty = \{B(c, 2^k) \ : \ c \in C(2^k), k \in \mathbb{N}\}\,.
 $$
-By Lemma \ref{covering-separable-space}, this is a countable collection of balls. We choose an enumeration $\mathcal{B}_\infty = \{B_1, \dotsc\}$ and define
+By \Cref{covering-separable-space}, this is a countable collection of balls. We choose an enumeration $\mathcal{B}_\infty = \{B_1, \dotsc\}$ and define
 $$
     \mathcal{B}_n = \{B_1, \dotsc, B_n\}\,.
 $$
@@ -6333,23 +6333,23 @@ This completes the proof.
 
 The convergence of partial Fourier sums is proved in
 Subsection \ref{10classical} in two steps. In the first step,
-we establish convergence on a suitable dense subclass of functions. We choose piece-wise constant functions as subclass, the convergence is stated in Lemma \ref{convergence-for-piecewise-constant} and proved in Subsection \ref{10piecewise}.
+we establish convergence on a suitable dense subclass of functions. We choose piece-wise constant functions as subclass, the convergence is stated in \Cref{convergence-for-piecewise-constant} and proved in Subsection \ref{10piecewise}.
 In the second step, one controls the relevant error of approximating a general function by a function in
-the subclass. This is stated in Lemma \ref{control-approximation-effect} and proved
+the subclass. This is stated in \Cref{control-approximation-effect} and proved
 in Subsection \ref{10difference}.
-The proof relies on a bound on the real Carleson maximal operator stated in Lemma \ref{real-Carleson} and proved in Subsection \ref{10carleson}.
-This latter proof refers to the main Carleson Theorem \ref{metric-space-Carleson}. Two assumptions in Theorem \ref{metric-space-Carleson} require more work. The boundedness of the nontangential maximal operator $T^*$ defined in \eqref{def-tang-unm-op} is established in Lemma \ref{nontangential-Hilbert} using $L^2$ and weak $L^1$ bounds for the Hilbert transform, Lemmas
+The proof relies on a bound on the real Carleson maximal operator stated in \Cref{real-Carleson} and proved in Subsection \ref{10carleson}.
+This latter proof refers to the main Carleson \Cref{metric-space-Carleson}. Two assumptions in \Cref{metric-space-Carleson} require more work. The boundedness of the nontangential maximal operator $T^*$ defined in \eqref{def-tang-unm-op} is established in \Cref{nontangential-Hilbert} using $L^2$ and weak $L^1$ bounds for the Hilbert transform, Lemmas
 \ref{Hilbert-strong-2-2} and \ref{Hilbert-weak-1-1}. These lemmas are proved in Subsections \ref{subsec-cotlar},
 \ref{10hilbert} and \ref{subsec-CZD}.
-The cancellative property is verified by Lemma \ref{van-der-Corput}, which is proved in Subsection \ref{10vandercorput}.
+The cancellative property is verified by \Cref{van-der-Corput}, which is proved in Subsection \ref{10vandercorput}.
 Several further auxiliary lemmas are stated
 and proved in Subsection
-\ref{10classical}, the proof of one of these auxiliary lemmas, Lemma \ref{spectral-projection-bound}, is done in Subsection \ref{10projection}.
+\ref{10classical}, the proof of one of these auxiliary lemmas, \Cref{spectral-projection-bound}, is done in Subsection \ref{10projection}.
 
 All subsections past Subsection \ref{10classical} are mutually independent.
 
  Subsections \ref{subsec-cotlar} uses bounds for the Hardy--Littlewood maximal function on the real line. There may be a better path through Lean than we choose here.
- We refer to Proposition \ref{Hardy-Littlewood}, the assumptions of it,
+ We refer to \Cref{Hardy-Littlewood}, the assumptions of it,
  namely that the real line fits into the setting of Section \ref{overviewsection},
  is done in Subsection \ref{10carleson}.
 
@@ -6515,7 +6515,7 @@ and \ref{control-approximation-effect}, we estimate \eqref{epsilonthird} by
     \le 2^{-2^{50}} \epsilon^2 +\frac \epsilon 4 +\frac \epsilon 4\le \epsilon\, .
 \end{equation}
 This shows  \eqref{aeconv} for the given $E$ and $N_0$
-and completes the proof of Theorem \ref{classical-Carleson}.
+and completes the proof of \Cref{classical-Carleson}.
 
 
 Let  $\kappa:\R\to \R$ be the function defined by
@@ -6529,10 +6529,10 @@ and for $|x|\ge 1$
 \end{equation}
 Note that this function is continuous at every point $x$ with $|x|>0$.
 
-The proof of Lemma \ref{control-approximation-effect} will
-use the following Lemma \ref{real-Carleson}, which itself is proven
+The proof of \Cref{control-approximation-effect} will
+use the following \Cref{real-Carleson}, which itself is proven
  in Subsection \ref{10carleson} as an application of
- Theorem \ref{metric-space-Carleson}.
+ \Cref{metric-space-Carleson}.
 \begin{lemma}[real Carleson]\label{real-Carleson}
 \uses{metric-space-Carleson,real-line-metric,real-line-measure,real-line-doubling,oscillation-control,frequency-monotone,frequency-ball-doubling,frequency-ball-growth,integer-ball-cover,real-van-der-Corput,nontangential-Hilbert}
     Let $F,G$ be Borel subsets of $\R$ with finite measure. Let $f$ be a bounded measurable function on $\R$ with $|f|\le \mathbf{1}_F$. Then
@@ -6548,7 +6548,7 @@ where
 \end{lemma}
 
 
-One of the main assumption of Theorem \ref{metric-space-Carleson}, concerning the operator $T_*$ defined in \eqref{def-tang-unm-op}, is verified by the following lemma, which is proved in Subsection \ref{subsec-cotlar}.
+One of the main assumption of \Cref{metric-space-Carleson}, concerning the operator $T_*$ defined in \eqref{def-tang-unm-op}, is verified by the following lemma, which is proved in Subsection \ref{subsec-cotlar}.
 
 
 \begin{lemma}[nontangential Hilbert]\label{nontangential-Hilbert}
@@ -6563,7 +6563,7 @@ where
 g(y) \kappa(x'-y)\, dy\right|\, .
 \end{equation}
 \end{lemma}
-The proof of Lemma \ref{nontangential-Hilbert} relies on the next two auxiliary Lemmas.
+The proof of \Cref{nontangential-Hilbert} relies on the next two auxiliary Lemmas.
 
 For $r\in (0,1)$, $x\in \mathbb{R}$ and a bounded, measurable function $g$ on $\mathbb{R}$ with bounded support, we define
 \begin{equation}
@@ -6597,7 +6597,7 @@ The following Lemma is proved in Subsection \ref{subsec-CZD}
     \end{equation}
 \end{lemma}
 
-The next lemma will be used to verify that the collection $\Mf$ of modulation functions in our application of Theorem \ref{metric-space-Carleson} satisfies the condition \eqref{eq-vdc-cond}.
+The next lemma will be used to verify that the collection $\Mf$ of modulation functions in our application of \Cref{metric-space-Carleson} satisfies the condition \eqref{eq-vdc-cond}.
 It is proved in Subsection \ref{10vandercorput}.
 
 \begin{lemma}[van der Corput]
@@ -6728,7 +6728,7 @@ The following lemma will be proved in Subsection \ref{10projection}.
 |\kappa(x-y)|=\left|\frac {1-|x-y|}{1-e^{i(x-y)}}\right|\, .
 \end{equation}
 We estimate
-with Lemma \ref{lower-secant-bound}
+with \Cref{lower-secant-bound}
 \begin{equation}\label{eqcarl311}
 |\kappa(x-y)|\le \frac {1}{|1-e^{i(x-y)}|}\le \frac 8{|x-y|}\, .
 \end{equation}
@@ -6762,7 +6762,7 @@ This proves \eqref{eqcarl30} in the given case and completes the proof of the le
     $$
         = \left| \int_{y'}^{y} \frac{-1 + e^{-it} + i(1-t)e^{it}}{(1 - e^{-it})^2} \,dt \right|\,.
     $$
-    Using $y' \ge \frac{y}{2}$ and Lemma \ref{lower-secant-bound}, we bound this by
+    Using $y' \ge \frac{y}{2}$ and \Cref{lower-secant-bound}, we bound this by
     $$
         \le |y - y'| \sup_{\frac{y}{2} \le t \le 1} \frac{3}{|1 - e^{-it}|^2}  \le 3 |y-y'| (8 \frac{2}{y})^2 \le 2^{10} \frac{|y-y'|}{|y|^2}\,.
     $$
@@ -6808,7 +6808,7 @@ We first compute the partial Fourier sums for constant functions.
 If $h$ satisfies $h(x)=h(0)$ for all $x\in \R$, then for all $N\ge 0$ we have $S_Nh=h$.
  \end{lemma}
 \begin{proof}
-    We compute with Lemma \ref{mean-zero-oscillation} for $n\in \mathbb{Z}$ with $n\neq 0$,
+    We compute with \Cref{mean-zero-oscillation} for $n\in \mathbb{Z}$ with $n\neq 0$,
     \begin{equation}
         \widehat{h}_n=\frac 1{2\pi}\int_0^{2\pi}h(y)e^{-iny}\, dy=\frac {h(0)}{2\pi}\int_0^{2\pi}e^{-iny}\, dy=0\, .
     \end{equation}
@@ -6840,7 +6840,7 @@ dx\right| \le \frac{64}N(\frac{|\beta-\alpha|}{\eta^2}+\frac 1{\eta}).
 \end{lemma}
 \begin{proof}
  Note first that the integral in \eqref{dirichletint}
-    is well defined as the denominator of the integrand is bounded away from zero by Lemma \ref{lower-secant-bound}
+    is well defined as the denominator of the integrand is bounded away from zero by \Cref{lower-secant-bound}
     and thus the integrand is continuous.
     We have with partial integration
 \begin{equation*}
@@ -6857,7 +6857,7 @@ dx
 We estimate the two summands in
 \eqref{eq-part-int} separately. We have
 for the first summand in \eqref{eq-part-int}
-with Lemma \ref{lower-secant-bound},
+with \Cref{lower-secant-bound},
 \begin{equation*}
 \left|   \frac 1 {-iN}\int_\alpha^\beta
 {e^{-iNx}}\frac{ie^{ix}}
@@ -6871,7 +6871,7 @@ dx \right|
     \le  \frac {64|\beta-\alpha|}{\eta^2N}
 \end{equation}
 We have for the second summand in \eqref{eq-part-int}
-with Lemma \ref{lower-secant-bound} again
+with \Cref{lower-secant-bound} again
 \begin{equation*}
    \left|\left[ \frac 1{-iN}
     \frac {e^{-iNx}} {1-e^{ix}}\right]_\alpha^\beta\right|
@@ -6914,7 +6914,7 @@ Then for all $N>\frac {2^{25} K^2}{\epsilon^3}$
 
 
 
-   With Lemma \ref{dirichlet-kernel}, breaking up the domain of integration into a
+   With \Cref{dirichlet-kernel}, breaking up the domain of integration into a
    partition of subintervals,
    \begin{equation*}
       |S_N(g)|= \frac{1}{2\pi} \left|\int_{-\pi}^{\pi} g(y)K_N(x-y)\, dy\right|
@@ -6962,7 +6962,7 @@ $0<\alpha$. In both cases, we have seen
 
 
 
-With Lemma \ref{dirichlet-kernel} and the triangle inequality,
+With \Cref{dirichlet-kernel} and the triangle inequality,
 it follows that
 \begin{equation}
    \left|\int_{x-2\pi (k+1)/K}^{x-2\pi k/K} K_N(y)\, dy\right|
@@ -6971,7 +6971,7 @@ it follows that
    \left|\int_{\alpha}^{\beta}
    \frac{e^{-iNy}}{1-e^{iy}}\, dy\right|
 \end{equation}
-Using that the two integrals on the right-hand side are complex conjugates of each other, and using Lemma \ref{dirichlet-kernel-bound} and $\epsilon <2\pi$, this is bounded by
+Using that the two integrals on the right-hand side are complex conjugates of each other, and using \Cref{dirichlet-kernel-bound} and $\epsilon <2\pi$, this is bounded by
 \begin{equation}
    \le 2\left|\int_{\alpha}^{\beta}
    \frac{e^{iNy}}{1-e^{-iy}}\, dy\right|
@@ -6982,18 +6982,18 @@ Inserting this in \eqref{eqcf3} and adding up proves
 the lemma.
 \end{proof}
 
-We now prove  Lemma \ref{convergence-for-piecewise-constant}.
+We now prove  \Cref{convergence-for-piecewise-constant}.
 
 Let $x\in [0,2\pi)\setminus E_1 $ and $N>\frac {2^{25} K^2}{\epsilon ^3}$.
 Let $h$ be the function which is constant equal to $f_0(x)$ and let $g=f_0-h$.
 By the bound on $f$ and the triangle inequality,
 $|g|$ is bounded by $2$. Hence $g$ is in the class $\mathcal{G}$. We also have $g(x)=0$.
-Using Lemma \ref{constant-function}, we obtain
+Using \Cref{constant-function}, we obtain
 \begin{equation}
     S_Nf_0(x)- f_0(x)=S_N(g+h)(x)- S_Nh(x)=S_Ng(x)\, .
 \end{equation}
-Lemma \ref{convergence-for-piecewise-constant}
-now follows by Lemma \ref{flat-interval-partial-sum}.
+\Cref{convergence-for-piecewise-constant}
+now follows by \Cref{flat-interval-partial-sum}.
 
 \section{Proof of Cotlar's Inequality}
 \label{subsec-cotlar}
@@ -7053,7 +7053,7 @@ g(y) (\kappa(x'-y)-\kappa(x-y))\, dy
 |g(y) \kappa(x'-y)|\, dy
 \right|
 \end{equation}
-Using the bound on $\kappa$ in Lemma \ref{Hilbert-kernel-bound}, we estimate
+Using the bound on $\kappa$ in \Cref{Hilbert-kernel-bound}, we estimate
 \eqref{firstxx'} by
 \begin{equation}
 \label{firstxx'b}
@@ -7087,7 +7087,7 @@ with the triangle inequality by
  \sum_{j=1}^\nu  \int_{2^jr<|x-y|\le 2^{j+1}r}
 |g(y)| |\kappa(x'-y)-\kappa(x-y)|\, dy\,.
 \end{equation}
-Using Lemma \ref{Hilbert-kernel-regularity}, we estimate  \eqref{secondxx'b}
+Using \Cref{Hilbert-kernel-regularity}, we estimate  \eqref{secondxx'b}
 by
 \begin{equation*}
  2^{10}\sum_{j=1}^\nu  \int_{2^jr<|x-y|\le 2^{j+1}r}
@@ -7135,7 +7135,7 @@ Then for all $x'\in \R$ with $|x'-x|<\frac {r_1}4$ we have
 
 \begin{proof}
 Let $x$ and $x'$ be given with $|x'-x|<\frac {r_1}4$.
-By an application of Lemma \ref{estimate-x-shift}, we estimate
+By an application of \Cref{estimate-x-shift}, we estimate
 the left-hand-side of
 \eqref{eq-cotlar-control} by
 \begin{equation}\label{eqcotlar0}
@@ -7174,7 +7174,7 @@ We  have
 \end{equation}
 Assume first $r\ge \frac {r_1} 4$.
 Then we estimate \eqref{eqcotlar2} with
-Lemma \ref{Hilbert-kernel-bound} by
+\Cref{Hilbert-kernel-bound} by
 \begin{equation*}
 \int_{\frac {r_1}4<|x'-y|<r_1}
 |g(y)k(x'-y)|\, dy
@@ -7240,7 +7240,7 @@ Dividing by $M(H_{r}g)(x)$ gives
 This gives the desired bound for the measure of $F_1$.
 
 We turn to the set $F_2$. Similarly as above we may assume $Mg(x)>0$.
-The set $F_2$ is then estimated with Lemma \ref{Hilbert-weak-1-1}
+The set $F_2$ is then estimated with \Cref{Hilbert-weak-1-1}
 by
 \begin{equation}
    \frac {2^{19}}{2^{22}Mg(x)}\int |g\mathbf{1}_{[x-\frac {r_1}2, x+\frac {r_1}2]}|(y)\, dy
@@ -7272,7 +7272,7 @@ g(y) \kappa(x-y)\, dy
 
 
 \begin{proof}
-By Lemma \ref{Cotlar-control}, the measure of the set
+By \Cref{Cotlar-control}, the measure of the set
 of all $x'\in
 [x-\frac{r_1}4,x+\frac{r_1}4]$
 such that at least one of the conditions
@@ -7282,7 +7282,7 @@ such that at least one of the conditions
 [x-\frac{r_1}4,x+\frac{r_1}4]$. Pick an
 $x'\in
 [x-\frac{r_1}4,x+\frac{r_1}4]$ such that both conditions are not satisfied.
-Applying Lemma \ref{Cotlar-control}
+Applying \Cref{Cotlar-control}
 for this $x'$ and using the triangle inequality
 estimates the left-hand side of \eqref{eq-cotlar-estimate}
 by
@@ -7305,7 +7305,7 @@ g(y) \kappa(x'-y)\, dy\right|\, .
 \end{equation}
 \end{lemma}
 \begin{proof}
-With Lemma \ref{estimate-x-shift}
+With \Cref{estimate-x-shift}
 and the triangle inequality, we estimate
 for every $x\in \R$
 \begin{equation}
@@ -7314,14 +7314,14 @@ for every $x\in \R$
      \frac 1{2\pi} \left|\int_{r_1<|x-y|<1}
 g(y) \kappa(x-y)\, dy\right|\, .
 \end{equation}
-Using further Lemma \ref{Cotlar-estimate},
+Using further \Cref{Cotlar-estimate},
 we estimate
 \begin{equation}
       T_{r} g(x)
      \le 2^{13} Mg(x)+2^{23}
      Mg(x)+2^{2}M(H_{r}g)(x)\, .
 \end{equation}
-Taking the $L^2$ norm and using Proposition \ref{Hardy-Littlewood}with $a=4$  and $p_2=2$ and $p_1=1$ , we obtain
+Taking the $L^2$ norm and using \Cref{Hardy-Littlewood}with $a=4$  and $p_2=2$ and $p_1=1$ , we obtain
 \begin{equation}
       \|T_{r} g\|_2
      \le 2^{24} \|Mg\|_2+2^{2}\|M(H_{r}g)\|_2
@@ -7329,17 +7329,17 @@ Taking the $L^2$ norm and using Proposition \ref{Hardy-Littlewood}with $a=4$  an
 \begin{equation}
      \le 2^{41} \|g\|_2+2^{19}\|H_{r}(g)\|_2\, .
 \end{equation}
-Applying Lemma \ref{Hilbert-strong-2-2}, gives
+Applying \Cref{Hilbert-strong-2-2}, gives
 \begin{equation}
       \|T_{r} g\|_2\le 2^{41} \|g\|_2+2^{32}\|g\|_2\, .
 \end{equation}
 This shows \eqref{trzerobound} and completes the proof of the lemma.
 \end{proof}
 
-\begin{proof}[Proof of Lemma \ref{nontangential-Hilbert}]
+\begin{proof}[Proof of \Cref{nontangential-Hilbert}]
     \proves{nontangential-Hilbert}
 Fix $g$ as in the Lemma.
-Applying Lemma \ref{simple-nontangential-Hilbert} with a
+Applying \Cref{simple-nontangential-Hilbert} with a
 sequence of $r$ tending to $0$ and using Lebesgue monotone convergence shows
 \begin{equation}\label{tzerobound}
     \|T_{0}g\|_2\le 2^{42}\|g\|_2,
@@ -7369,7 +7369,7 @@ $|x-x'|<r_2$, at which time the integral does not depend on $r_1$, we estimate \
     of \eqref{concretetstarbound} and applying
      \eqref{tzerobound} twice
     proves \eqref{concretetstarbound}.
-    This completes the proof of Lemma \ref{nontangential-Hilbert}.
+    This completes the proof of \Cref{nontangential-Hilbert}.
 \end{proof}
 
 
@@ -7410,7 +7410,7 @@ We have for every bounded measurable $2\pi$-periodic function $g$
         \|M_ng\|_{L^2[-\pi, \pi]}^2=\int_{-\pi}^{\pi} |e^{inx}g(x)|^2\, dx
         =\int_{-\pi}^{\pi} |g(x)|^2\, dx=\|g\|_{L^2[-\pi, \pi]}^2\, .
     \end{equation}
-     We have by the triangle inequality, the square root of the identity in \eqref{mnbound}, and Lemma \ref{spectral-projection-bound}
+     We have by the triangle inequality, the square root of the identity in \eqref{mnbound}, and \Cref{spectral-projection-bound}
     \begin{equation*}
         \|L_ng\|_{L^2[-\pi, \pi]}=\|\frac 1N\sum_{n=0}^{N-1}
        M_{-n-N} S_{N+n}M_{N+n}g\|_{L^2[-\pi, \pi]}
@@ -7470,7 +7470,7 @@ This proves the first identity of the lemma. The second identity follows by subs
     \end{equation}
     \end{lemma}
 \begin{proof}
-Using Fubini and Lemma \ref{periodic-domain-shift}, we observe
+Using Fubini and \Cref{periodic-domain-shift}, we observe
 \begin{equation*}
   \int_{-\pi}^{\pi}\int_{-\pi}^{\pi}f(y)^2g(x-y)\, dy
     \, dx=\int_{-\pi}^{\pi}f(y)^2\int_{-\pi}^{\pi}g(x-y)\, dx
@@ -7529,7 +7529,7 @@ From monotonicity of the integral and \eqref{ebump1},
     \|g\|_{L^1[-\pi, \pi]} \le  \int_{-\pi}^{\pi}k_r(x)\, dx\,.
 \end{equation}
 Using the symmetry
-$k_r(x)=k_r(-x)$, the assumption, and Lemma \ref{lower-secant-bound},  the last display
+$k_r(x)=k_r(-x)$, the assumption, and \Cref{lower-secant-bound},  the last display
 is equal to
 \begin{equation*}
     =  2 \int_0^\pi \min\left(\frac 1r, 1+\frac r{|1-e^{ix}|^2}\right)\, dx
@@ -7541,7 +7541,7 @@ is equal to
     \le 2+2\pi + 2\left(\frac {64r}r-\frac {64r}{\pi}\right)
     \le 2^{5}\, .
 \end{equation}
-    Together with Lemma \ref{Young-convolution}, this proves the lemma.
+    Together with \Cref{Young-convolution}, this proves the lemma.
 \end{proof}
 
 \begin{lemma}[dirichlet approximation]\label{dirichlet-approximation}
@@ -7562,7 +7562,7 @@ and
 
 
 \begin{proof}
-We have by definition and Lemma \ref{dirichlet-kernel}
+We have by definition and \Cref{dirichlet-kernel}
 \begin{equation}
     L_Ng(x)=
     \frac 1N\sum_{n=0}^{N-1}
@@ -7574,7 +7574,7 @@ the continuous function
     {L'}(x)=  \frac 1N\sum_{n=0}^{N-1}
       K_{N+n}(x) e^{-i(N+n)x}\, .
 \end{equation}
-With \eqref{eqksumexp} of Lemma \ref{dirichlet-kernel}
+With \eqref{eqksumexp} of \Cref{dirichlet-kernel}
 we have $|K_N(x)|\le N$ for every $x$ and thus
 \begin{equation}\label{eqhil13}
     |{L'}(x)|\le  \frac 1N\sum_{n=0}^{N-1}
@@ -7590,7 +7590,7 @@ This proves \eqref{eqdifflhil} for $|x|\in [0, r)$ since $k_r(x)=r^{-1}$ in this
 For $e^{ix'}\neq 1$
 and may use the expression
 \eqref{eqksumhil} for $K_N$
-in Lemma \ref{dirichlet-kernel} to obtain
+in \Cref{dirichlet-kernel} to obtain
 \begin{equation*}
     {L'}(x)=  \frac 1N\sum_{n=0}^{N-1}
      \left(\frac{e^{i(N+n)x}}{1-e^{-ix}}
@@ -7616,7 +7616,7 @@ where
 $$L''(x):=\frac 1N \frac {e^{-i2Nx}}{1-e^{ix}}
      \sum_{n=0}^{N-1}
     {e^{-i2nx}}.$$
-For $x\in [-\pi, r]\cup [r, \pi]$, we have using Lemma \ref{lower-secant-bound} that
+For $x\in [-\pi, r]\cup [r, \pi]$, we have using \Cref{lower-secant-bound} that
 \begin{equation*}
    \left|\frac{1-\mathbf{1}_{{\{y:\, r<|y|<1\}}}(x)(1-|x|)}{1-e^{-ix}} \right|=\left|\frac{\min(|x|, 1)}{1-e^{-ix}} \right|\leq \frac{8\min(|x|, 1)}{|x|}
 \end{equation*}
@@ -7649,7 +7649,7 @@ As $e^{-2ix}\neq 1$, we may divide by $1-e^{-2ix}$ and insert this into
            \frac 1N \frac {e^{-i2Nx}}{1-e^{ix}}
      \frac{1-e^{-i2Nx}}{1-e^{-2ix}}\, .
 \end{equation}
-Hence, with Lemma \ref{lower-secant-bound} and nonnegativity of the real part of $e^{ix}$
+Hence, with \Cref{lower-secant-bound} and nonnegativity of the real part of $e^{ix}$
 \begin{equation*}
     |L''(x)|
  \le \frac 2 N \frac {1}{|1-e^{ix}|}
@@ -7664,9 +7664,9 @@ Inequalities \eqref{eqhil13}, \eqref{eqdiffzero}, \eqref{eq-L'L''}, \eqref{eq-di
 \end{proof}
 
 
-We now prove Lemma \ref{Hilbert-strong-2-2}.
+We now prove \Cref{Hilbert-strong-2-2}.
 
-\begin{proof}[Proof of Lemma \ref{Hilbert-strong-2-2}]
+\begin{proof}[Proof of \Cref{Hilbert-strong-2-2}]
     \proves{Hilbert-strong-2-2}
     We first show that if $f$ is supported in $[-3/2, 3/2]$, then
     \begin{equation}
@@ -7674,7 +7674,7 @@ We now prove Lemma \ref{Hilbert-strong-2-2}.
         \|H_r f\|_{L^2(\R)} \le 2^{16} \|f\|_{L^2(\R)}\,.
     \end{equation}
     Let $\tilde{f}$ be the $2\pi$-periodic extension of $f$ to $\mathbb{R}$. Let $N$ be the smallest
-    integer larger than $\frac 1r$. Then, by Lemma \ref{dirichlet-approximation} and the triangle inequality, for $x\in [-\pi, \pi]$ we have
+    integer larger than $\frac 1r$. Then, by \Cref{dirichlet-approximation} and the triangle inequality, for $x\in [-\pi, \pi]$ we have
     \begin{equation*}
         |H_r \tilde{f}(x)|\leq 2\pi |L_N \tilde{f}(x)|+2^{5}\left|\int_{-\pi}^{\pi}k_r(x-y)\tilde{f}(y)\, dy\right|.
     \end{equation*}
@@ -7686,7 +7686,7 @@ We now prove Lemma \ref{Hilbert-strong-2-2}.
        \leq 2\pi \|L_N \tilde{f}\|_{L^2([-\pi, \pi])}\, + 2^{5}\left(\int_{-\pi}^{\pi} \left|\int_{-\pi}^{\pi}k_r(x-y)\tilde{f}(y)\, dy\right|^2\, dx\right)^{\frac{1}{2}}.
     \end{equation*}
     Since $k_r$ is supported in $[-1,1]$, we have that $H_rf$ is supported in $[-5/2, 5/2]$ and agrees there with $H_r \tilde f(x)$.
-    Using Lemma \ref{modulated-averaged-projection} and Lemma \ref{integrable-bump-convolution},  we conclude
+    Using \Cref{modulated-averaged-projection} and \Cref{integrable-bump-convolution},  we conclude
     \begin{equation}
         \|H_r f\|_{L^2(\R)} \le \|H_r \tilde f\|_{L^2([-\pi, \pi])} \leq 2\pi \|f\|_{L^2(\R)} + 2^{10}\|f\|_{L^2(\R)}\,,
     \end{equation}
@@ -7778,7 +7778,7 @@ For a bounded interval $I=[a, b)\subset \mathbb{R}$ and a non-negative integer $
     \end{equation}
 \end{lemma}
 \begin{proof}
-This follows by induction on $n$, using Lemma \ref{interval-bisection}.
+This follows by induction on $n$, using \Cref{interval-bisection}.
 \end{proof}
 
 
@@ -7847,7 +7847,7 @@ Finally, let
 
 For each $n$ we have
 $$\mathcal{Q}_n\subseteq \textrm{ch}_n(I_0).$$
-Therefore, by Lemma \ref{bisection-children},
+Therefore, by \Cref{bisection-children},
 $$|\mathcal{Q}_n|\leq \frac{\mu(I_0)}{2^n}= 2^{\ell+1-n}.$$
 It follows that $\mathcal{Q}$ is a countable union of finite sets and hence, is countable itself. Let $\{I_j\}_{j\geq 1}$ be an enumeration of this set, with
 $$I_j:=[s_j, t_j),$$
@@ -7856,14 +7856,14 @@ We set
 \begin{equation*}
     A:=\mathbb{R}\setminus \cup_{j\geq 1} [s_j, t_j).
 \end{equation*}
-Then \eqref{eq-CZ-good-set-comp} holds by definition. We next show \eqref{eq-CZ-bad-sets-1}. Let $I_j, I_{j'}\in \mathcal{Q}$. Then, there exist $1\leq n, n'$ such that $I_j\in \mathcal{Q}_n$ and $I_{j'}\in \mathcal{Q}_{n'}$. If $n=n'$, \eqref{eq-CZ-bad-sets-1} follows from Lemma \ref{bisection-children} since $\mathcal{Q}_n\subseteq \textrm{ch}_n(I_0).$ Otherwise, assume without loss of generality that $n<n'$. Then by construction, there exists $J\in \Tilde{\mathcal{Q}}_{n}\setminus {\mathcal{Q}_n}$ such that $I_{j'} \subset J$. Since $I_{j}\in \mathcal{Q}_n$, it follows that $I_j\neq J$. Since $I_j, J\in \Tilde{\mathcal{Q}}_{n}\subset \textrm{ch}_n(I_0)$, by Lemma \ref{bisection-children}, we deduce that they are disjoint. Since $I_{j'}\subset J$, we conclude that $I_j$ and
+Then \eqref{eq-CZ-good-set-comp} holds by definition. We next show \eqref{eq-CZ-bad-sets-1}. Let $I_j, I_{j'}\in \mathcal{Q}$. Then, there exist $1\leq n, n'$ such that $I_j\in \mathcal{Q}_n$ and $I_{j'}\in \mathcal{Q}_{n'}$. If $n=n'$, \eqref{eq-CZ-bad-sets-1} follows from \Cref{bisection-children} since $\mathcal{Q}_n\subseteq \textrm{ch}_n(I_0).$ Otherwise, assume without loss of generality that $n<n'$. Then by construction, there exists $J\in \Tilde{\mathcal{Q}}_{n}\setminus {\mathcal{Q}_n}$ such that $I_{j'} \subset J$. Since $I_{j}\in \mathcal{Q}_n$, it follows that $I_j\neq J$. Since $I_j, J\in \Tilde{\mathcal{Q}}_{n}\subset \textrm{ch}_n(I_0)$, by \Cref{bisection-children}, we deduce that they are disjoint. Since $I_{j'}\subset J$, we conclude that $I_j$ and
 $I_{j'}$ are disjoint as well. This proves \eqref{eq-CZ-bad-sets-1}.
 
 To see \eqref{eq-CZ-bad-sets-2}, let $I_j=(s_j, t_j)\in \mathcal{Q}$. Then $I_j\in \mathcal{Q}_n$ for some $n\geq 1$. By definition of $\mathcal{Q}_n$, we have
 $$\frac{\alpha}{2}<\frac{1}{\mu(I)}\int_{I} |f(y)|\, dy=\frac{1}{t_j-s_j}\int_{s_j}^{t_j} |f(y)|\, dy.$$
 As $I_j\in \mathcal{Q}_n\subseteq \Tilde{\mathcal{Q}_{n}}$, by definition of the latter set, there exists $J\in \Tilde{\mathcal{Q}}_{n-1}\setminus \mathcal{Q}_{n-1}$ with $I\in \textrm{bi} (J)$. Since $J\not\in \mathcal{Q}_{n-1}$, we conclude that
 $$\frac{1}{\mu(J)}\int_J |f(y)|\, dy\leq \frac{\alpha}{2}.$$
-Using Lemma \ref{interval-bisection} and the above, we get
+Using \Cref{interval-bisection} and the above, we get
 $$\frac{1}{t_j-s_j}\int_{s_j}^{t_j} |f(y)|\, dy=\frac{1}{\mu(I)}\int_I |f(y)|\, dy\leq \frac{2}{\mu(J)} \int_J |f(y)|\, dy\leq \alpha.$$
 This establishes \eqref{eq-CZ-bad-sets-2}. Using this, we see that for each $j$, we have
 $$t_j-s_j\leq \frac{2}{\alpha}\int_{s_j}^{t_j} |f(y)|\, dy.$$
@@ -7877,7 +7877,7 @@ Finally, we show $\eqref{eq-CZ-good-set}$. Let $x\in A$. If $x\not \in [-2^{\ell
 \end{equation}
 Since $\mu(I(n))=2^{\ell+1-n}$, we have
 $$\lim_{n\to \infty} \mu(I(n))=0.$$
-By Lemma \ref{Lebesgue-differentiation}, we also have
+By \Cref{Lebesgue-differentiation}, we also have
 \begin{equation*}
  \lim_{n\to \infty}\frac{1}{\mu(I(n))}\int_{I(n)} |f(y)| dy= |f(x)|
 \end{equation*}
@@ -7936,7 +7936,7 @@ It is classical and can be found in \cite{stein-book}.
 \end{lemma}
 
 \begin{proof}
-    Applying Lemma \ref{stopping-time} to $f$ and $\gamma\alpha$, we obtain a collection $I_j$ of intervals such that the conditions \eqref{eq-CZ-good-set}-\eqref{eq-CZ-meas-b-set} are satisfied. We set $A = \R \setminus \cup_j I_j$ and
+    Applying \Cref{stopping-time} to $f$ and $\gamma\alpha$, we obtain a collection $I_j$ of intervals such that the conditions \eqref{eq-CZ-good-set}-\eqref{eq-CZ-meas-b-set} are satisfied. We set $A = \R \setminus \cup_j I_j$ and
 \begin{equation}
     \label{eq-g-def}
     g(x):=\begin{cases}
@@ -7952,7 +7952,7 @@ and, for each $j$,
         0, & x\not\in (s_j, t_j).
     \end{cases}
 \end{equation}
-Then \eqref{eq-supp-bj} and \eqref{eq-bset-length-sum} are true by construction and Lemma \ref{stopping-time}.
+Then \eqref{eq-supp-bj} and \eqref{eq-bset-length-sum} are true by construction and \Cref{stopping-time}.
 Further, let $b(x)=\sum_{j} b_j(x).$
 Then
 \begin{equation*}
@@ -8001,9 +8001,9 @@ Using the disjointedness of $(s_j, t_j)$, we get
 This proves \eqref{eq-b-L1}, and completes the proof.
 \end{proof}
 
-\begin{proof}[Proof of Lemma \ref{Hilbert-weak-1-1}]
+\begin{proof}[Proof of \Cref{Hilbert-weak-1-1}]
 \proves{Hilbert-weak-1-1}
-Using Lemma \ref{Calderon-Zygmund-decomposition} for $f$ and $2^{-10}\alpha$, we obtain the decomposition
+Using \Cref{Calderon-Zygmund-decomposition} for $f$ and $2^{-10}\alpha$, we obtain the decomposition
 $$f=g+b=g+\sum_j b_j$$
 such that the properties \eqref{eq-gb-dec}-\eqref{eq-b-L1} are satisfied with $\gamma=2^{-10}$. For each $j$, let
 \begin{equation}
@@ -8044,7 +8044,7 @@ $$ \mu\left(\{x\in \mathbb{R}: |H_r f(x)|>\alpha\}\right) $$
 We estimate using monotonicity of the integral
 $$ \mu\left(\{x\in \mathbb{R}: |H_r g(x)|>{\alpha}/2\}\right)\leq
 \frac{4}{\alpha^2} \int |H_r g(y)|^2\, dy. $$
-Using Lemma \ref{Hilbert-strong-2-2} followed by \eqref{eq-g-max} and \eqref{eq-g-L1-norm}, we estimate the right hand side above by
+Using \Cref{Hilbert-strong-2-2} followed by \eqref{eq-g-max} and \eqref{eq-g-L1-norm}, we estimate the right hand side above by
 $$\leq 2^{26}\frac{4}{\alpha^2} \int |g(y)|^2\, dy\leq \frac{2^{18}}{\alpha} \int |g(y)|\, dy\leq \frac{2^{18}}{\alpha} \int |f(y)|\, dy.$$
 Thus, we conclude
 \begin{equation}
@@ -8080,7 +8080,7 @@ Further, for $j\in \mathcal{J}_1(x)$, we have
 $$H_rb_j(x)=\int_{I_j} \kappa (x-y)\mathbf{1}_{\{z:\, r<|z|<1\}}(x-y) b_j(y)\,dy=\int_{I_j} \kappa (x-y) b_j(y)\,dy\,.$$
 Using \eqref{eq-bad-mean-zero}, the above is equal to
 $$\int_{I_j} (\kappa (x-y)-\kappa(x-c_j)) b_j(y).$$
-Thus, using the triangle inequality, \eqref{eq-Om-cj}, \eqref{eq-Om-y} and Lemma \ref{Hilbert-kernel-regularity}, we can estimate
+Thus, using the triangle inequality, \eqref{eq-Om-cj}, \eqref{eq-Om-y} and \Cref{Hilbert-kernel-regularity}, we can estimate
 $$\sum_{j\in \mathcal{J}_1(x)} |H_rb_j(x)|\leq \sum_{j\in \mathcal{J}_1(x)}2^{10}\int_{I_j}\frac{|y-c_j|}{|x-c_j|^2} |b_j(y)|\, dy$$
 \begin{equation}
     \label{eq-J1-diff-est}
@@ -8106,7 +8106,7 @@ $$|H_r b_j(x)|\leq $$
     \label{eq-J2-diff-est}
     \int_{I_j} |(\kappa(x-y)-\kappa(x-c_j)) \left(|b_j(y)|+2^{-9}\alpha\right)\, dy +2^{-9}\alpha \int_{I_j}  |\kappa(x-y)| \, dy.
 \end{equation}
-Using \eqref{eq-Om-cj}, \eqref{eq-Om-y} and Lemma \ref{Hilbert-kernel-regularity}, and arguing as in \eqref{eq-J1-diff-est}, we get the the first term above can be estimated by
+Using \eqref{eq-Om-cj}, \eqref{eq-Om-y} and \Cref{Hilbert-kernel-regularity}, and arguing as in \eqref{eq-J1-diff-est}, we get the the first term above can be estimated by
 \begin{equation}
     \label{eq-J2-diff-est-2}
     2^{10}\sum_{j} \frac{(t_j-s_j)}{|x-c_j|^2}\left(\int_{I_j} |b_j(y)|+2^{-9} \alpha (t_j-s_j)\right)=F_1(x)+F_2(x),
@@ -8125,7 +8125,7 @@ and
 $$|x-y|\geq |x-y_j|-|y-y_j|\geq r-(t_j-s_j)>\frac{r}{2}.$$
 We conclude that
 $$[s_j, t_j)\subset \left\{y\,: \frac{r}{2}<|x-y|<\frac{3r}{2}\right\}.$$
-Using this and Lemma \ref{Hilbert-kernel-bound}, we get
+Using this and \Cref{Hilbert-kernel-bound}, we get
 \begin{equation}
     \label{eq-J2-diff-est-4}
     \int_{I_j}|\kappa(x-y)|\,dy \leq \int_{\{y\,: \frac{r}{2}<|x-y|<\frac{3r}{2}\}}\frac{8}{|x-y|}\, dy\leq 32\,.
@@ -8219,7 +8219,7 @@ Combining estimates \eqref{eq-set-dec-1}, \eqref{eq-g-func-bd}, \eqref{eq-omega-
 \section{The proof of the van der Corput Lemma}
 \label{10vandercorput}
 
-\begin{proof}[Proof of Lemma \ref{van-der-Corput}]
+\begin{proof}[Proof of \Cref{van-der-Corput}]
 \proves{van-der-Corput}
 Let $g$ be a Lipschitz continuous function as in the lemma. We have
 $$
@@ -8268,7 +8268,7 @@ $$
 \section{Partial sums as orthogonal projections}
 \label{10projection}
 
-This subsection proves Lemma \ref{spectral-projection-bound}
+This subsection proves \Cref{spectral-projection-bound}
 
 
 
@@ -8284,7 +8284,7 @@ This subsection proves Lemma \ref{spectral-projection-bound}
    \end{equation}
    \end{lemma}
 \begin{proof}
-Let $N>0$ be given. With $K_N$ as in Lemma \ref{dirichlet-kernel},
+Let $N>0$ be given. With $K_N$ as in \Cref{dirichlet-kernel},
 \begin{equation*}
 S_N (S_Nf) (x)=
 \frac{1}{2\pi} \int_0^{2\pi} S_Nf(y)K_N(x-y)\, dy
@@ -8293,7 +8293,7 @@ S_N (S_Nf) (x)=
 =
 \frac{1}{(2\pi)^2}\int_0^{2\pi} \int_0^{2\pi} f(y')K_N(y-y') K_N(x-y)\, \, dy' dy\, .
 \end{equation}
-We have by Lemma \ref{dirichlet-kernel}
+We have by \Cref{dirichlet-kernel}
 \begin{equation*}
 \frac{1}{2\pi}\int_0^{2\pi} K_N(y-y') K_N(x-y)\,  dy
 \end{equation*}
@@ -8305,7 +8305,7 @@ We have by Lemma \ref{dirichlet-kernel}
 =\frac{1}{2\pi}\sum_{n=-N}^N\sum_{n'=-N}^N
 e^{i(n'x-ny')}\int_0^{2\pi} e^{i(n-n')y}\,  dy\, .
 \end{equation}
-By Lemma \ref{mean-zero-oscillation}, the summands for $n\neq n'$ vanish.
+By \Cref{mean-zero-oscillation}, the summands for $n\neq n'$ vanish.
 We obtain for \eqref{eqhil6}
 \begin{equation}\label{eqhil2}
 =\frac{1}{2\pi}\sum_{n=-N}^N
@@ -8328,12 +8328,12 @@ This proves the lemma.
     \end{equation}
 \end{lemma}
 \begin{proof}
-  We have with $K_N$ as in Lemma \ref{dirichlet-kernel} for every $x$
+  We have with $K_N$ as in \Cref{dirichlet-kernel} for every $x$
   \begin{equation}
       \overline{K_N(x)}=\sum_{n=-N}^N\overline{ e^{in x}}=
       {\sum_{n=-N}^N e^{-in x}}=K_N(-x)\, .
   \end{equation}
- Further, with Lemma \ref{dirichlet-kernel} and Fubini
+ Further, with \Cref{dirichlet-kernel} and Fubini
 \begin{equation*}
 \int_0^{2\pi} \overline{S_Nf(x)} g(x)
 = \frac 1{2\pi} \int_0^{2\pi} \int_{-\pi}^{\pi}\overline{f(y) K_N(x-y)} g(x)\, dy dx
@@ -8352,7 +8352,7 @@ g(x)\, dx dy
 We turn to the proof of Lemma
 \ref{spectral-projection-bound}.
 
-We have with Lemma \ref{partial-sum-selfadjoint}, then Lemma \ref{partial-sum-projection} and the Lemma \ref{partial-sum-selfadjoint} again
+We have with \Cref{partial-sum-selfadjoint}, then \Cref{partial-sum-projection} and the \Cref{partial-sum-selfadjoint} again
 \begin{equation*}
  \int_0^{2\pi}  S_Nf(x)\overline{S_Nf(x)}\, dx
  \int_0^{2\pi}  f(x)\overline{S_N(S_Nf)(x)}\, dx
@@ -8392,17 +8392,17 @@ This completes the proof of the lemma.
 
 \section{The error bound}
 \label{10difference}
-We prove Lemma \ref{control-approximation-effect}. Define
+We prove \Cref{control-approximation-effect}. Define
 $$
     E_2 := \{x \in [0, 2\pi) \ : \ \sup_{N > 0} |S_N f(x) - S_N f_0(x)| > \frac{\epsilon}{4} \}\,.
 $$
-Then \eqref{eq-max-partial-sum-diff} clearly holds, and it remains to show that $|E_2| \le \frac{\epsilon}{2}$. This will follow from Lemma \ref{real-Carleson}.
+Then \eqref{eq-max-partial-sum-diff} clearly holds, and it remains to show that $|E_2| \le \frac{\epsilon}{2}$. This will follow from \Cref{real-Carleson}.
 
 Let $x \in E_2$. Then there exists $N > 0$ with
 $$
     |S_N f(x) - S_N f_0(x)| > \frac{\epsilon}{4}\,,
 $$
-pick such $N$. We have with Lemma \ref{dirichlet-kernel}
+pick such $N$. We have with \Cref{dirichlet-kernel}
 $$
     \frac{\epsilon}{4} < |S_N f(x) - S_N f_0(x)| = \frac{1}{2\pi} \left| \int_0^{2\pi} (f(y) - f_0(y)) K_N(x-y) \, dy\right|\,.
 $$
@@ -8427,11 +8427,11 @@ Using \eqref{eqksumhil} and the definition \eqref{eq-hilker} of $\kappa$, we rew
     \label{eq-diff-integrable}
     + \frac{1}{2\pi} \left|\int_{-\pi}^{\pi} (f(x-y) - f_0(x-y)) ( e^{iNy} \frac{\min\{|y|, 1\} }{1 - e^{-iy}} + e^{-iNy} \frac{\min\{|y|, 1\} }{1 - e^{iy}}) \, dy \right|\,.
 \end{equation}
-By Lemma \ref{lower-secant-bound} with $\eta = |y|$, we have for $-1 \le y \le 1$
+By \Cref{lower-secant-bound} with $\eta = |y|$, we have for $-1 \le y \le 1$
 $$
     |e^{iNy}\frac{\min\{|y|, 1\} }{1 - e^{-iy}}| = \frac{|y|}{|1 - e^{iy}|} \le 8\,.
 $$
-By Lemma \ref{lower-secant-bound} with $\eta = 1$, we have for $1 \le |y| \le \pi$
+By \Cref{lower-secant-bound} with $\eta = 1$, we have for $1 \le |y| \le \pi$
 $$
     |e^{iNy}\frac{\min\{|y|, 1\} }{1 - e^{-iy}}| = \frac{1}{|1 - e^{iy}|} \le 8\,.
 $$
@@ -8459,7 +8459,7 @@ $$
     \le \frac{1}{2\pi} (Th(x) + T\bar{h}(x))\,.
 $$
 Thus for each $x \in E_2$, at least one of $Th(x)$ and $T\bar h(x)$ is larger than $\frac{\epsilon}{16}$.
-Thus at least one of $Th$ and $T\bar h$ is $\ge \frac{\epsilon}{16}$ on a subset $E_2'$ of $E_2$ with $2|E_2'| \ge |E_2|$. Without loss of generality this is $Th$. By assumption \eqref{eq-ffzero}, we have $|2^{2^{50}}\epsilon^{-2} h| \le \mathbf{1}_{[-\pi, 3\pi]}$. Applying Lemma \ref{real-Carleson} with $F = [-\pi, 3\pi]$ and $G = E_2'$, it follows that
+Thus at least one of $Th$ and $T\bar h$ is $\ge \frac{\epsilon}{16}$ on a subset $E_2'$ of $E_2$ with $2|E_2'| \ge |E_2|$. Without loss of generality this is $Th$. By assumption \eqref{eq-ffzero}, we have $|2^{2^{50}}\epsilon^{-2} h| \le \mathbf{1}_{[-\pi, 3\pi]}$. Applying \Cref{real-Carleson} with $F = [-\pi, 3\pi]$ and $G = E_2'$, it follows that
 $$
     \frac{\epsilon}{16} |E_2'| \le \int_{E_2'} Th(x) \, dx = 2^{-2^{50}}\epsilon^2 \int_{E_2'} T(2^{2^{50}}\epsilon^{-2} h)(x) \, dx
 $$
@@ -8479,7 +8479,7 @@ This completes the proof using $|E_2| \le 2|E_2'|$.
 \section{Carleson on the real line}
 \label{10carleson}
 
-We prove Lemma \ref{real-Carleson}.
+We prove \Cref{real-Carleson}.
 
 Consider the standard distance function
 \begin{equation}
@@ -8532,7 +8532,7 @@ We consider the Lebesgue measure $\mu$ on $\R$.
 \end{lemma}
 \begin{proof}
 \leanok
-We have with Lemma \ref{real-line-ball}
+We have with \Cref{real-line-ball}
 \begin{equation}
     \mu(B(x,R))=\mu((x-R,x+R))=2R\, .
 \end{equation}
@@ -8547,7 +8547,7 @@ We have with Lemma \ref{real-line-ball}
     \end{equation}
 \end{lemma}
 \begin{proof}
-    We have with Lemma \ref{real-line-ball-measure}
+    We have with \Cref{real-line-ball-measure}
 \begin{equation}
     \mu(B(x,2R)=4R=2\mu(B(x,R)\, .
 \end{equation}
@@ -8556,7 +8556,7 @@ This proves the lemma.
 
 
 The preceding four lemmas show that $(\R, \rho, \mu, 4)$ is a doubling metric measure space. Indeed, we even show
-that $(\R, \rho, \mu, 1)$ is a doubling metric measure space, but we may relax the estimate in Lemma \ref{real-line-doubling} to conclude that $(\R, \rho, \mu, 4)$
+that $(\R, \rho, \mu, 1)$ is a doubling metric measure space, but we may relax the estimate in \Cref{real-line-doubling} to conclude that $(\R, \rho, \mu, 4)$
 is a doubling metric measure space.
 
 
@@ -8725,7 +8725,7 @@ Set $n'=n-m$. Then we have to prove
     \left|\int_{x-R}^{x+R} e^{in'y}\varphi(y) dy\right|\le 4\pi  R\|\varphi\|_{\Lip(B')}
 (1+2R|n'|)^{-1}\, .
 \end{equation}
-This follows from Lemma \ref{van-der-Corput} with $\alpha = x - R$ and $\beta = x + R$.
+This follows from \Cref{van-der-Corput} with $\alpha = x - R$ and $\beta = x + R$.
 \end{proof}
 
 The preceding chain of lemmas establish that $\Mf$ is a cancellative, compatible collection of functions on $(\R, \rho, \mu, 4)$. Again, some of the statements in these lemmas are stronger than what is needed for $a=4$, but can be relaxed to give the desired conclusion for $a=4$.
@@ -8746,11 +8746,11 @@ $x=y$ and vanishes on the diagonal. Hence it is measurable.
 By the Lemmas \ref{Hilbert-kernel-bound} and \ref{Hilbert-kernel-regularity}, it follows that $K$ is a one-sided Calder\'on--Zygmund kernel on $(\R,\rho,\mu,4)$.
 
 
-The operator $T^*$ defined in \eqref{def-tang-unm-op} coincides in our setting with the operator $T^*$ defined in \eqref{concretetstar}. By  Lemma \ref{nontangential-Hilbert}, this operator satisfies the bound \eqref{nontanbound}.
+The operator $T^*$ defined in \eqref{def-tang-unm-op} coincides in our setting with the operator $T^*$ defined in \eqref{concretetstar}. By  \Cref{nontangential-Hilbert}, this operator satisfies the bound \eqref{nontanbound}.
 
 
 
 
-Thus the assumptions of Theorem \ref{metric-space-Carleson} are all satisfied. Applying the Theorem, Lemma \ref{real-Carleson} follows.
+Thus the assumptions of \Cref{metric-space-Carleson} are all satisfied. Applying the Theorem, \Cref{real-Carleson} follows.
 
 \printbibliography


### PR DESCRIPTION
- [x] Substitute `Theorem \ref` with `\Cref`
- [x] Substitute `Lemma \ref` with `\Cref`
- [x] Substitute `Chapter \ref` with `\Cref`
- [x] Substitute `Section \ref` with `\Cref`
- [x] Substitute `Subsection \ref` with `\Cref`