### PR TITLE
Fix label error

### DIFF
--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -772,7 +772,7 @@ We apply the triangle inequality and estimate the versions of \eqref{Rcut} separ
 
 \begin{lemma}[S truncation]
 \label{S-truncation}
-\uses{-Hardy-Littlewood,kernel-summand,finitary-S-truncation}
+\uses{Hardy-Littlewood,kernel-summand,finitary-S-truncation}
 For all integers $S>0$
 $$
     \int \mathbf{1}_{G}(x)


### PR DESCRIPTION
This PR fixes the following error: 

> ERROR: Label '-Hardy-Littlewood' could not be resolved