### PR TITLE
Fix abstract location (blueprint web)

### DIFF
--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -12,14 +12,14 @@
 
 \date{\today}
 
-\begin{abstract}
-  We prove a new generalization of a theorem of Carleson, namely bounds for a generalized Carleson operator on doubling metric measure spaces.
-  Additionally, we explicitly reduce Carleson's classical result on pointwise convergence of Fourier series to this new theorem.
-  Both proofs are presented in great detail, suitable as a blueprint for computer verification using the current capabilities of the software package Lean.
-Note  that even Carleson's classical result has not yet been computer-verified.
-\end{abstract}
-
 \maketitle
+
+\begin{abstract}
+    We prove a new generalization of a theorem of Carleson, namely bounds for a generalized Carleson operator on doubling metric measure spaces.
+    Additionally, we explicitly reduce Carleson's classical result on pointwise convergence of Fourier series to this new theorem.
+    Both proofs are presented in great detail, suitable as a blueprint for computer verification using the current capabilities of the software package Lean.
+  Note  that even Carleson's classical result has not yet been computer-verified.
+  \end{abstract}
 
 \tableofcontents
 


### PR DESCRIPTION
This PR moves the abstract under `\maketitle` to display it correctly in the blueprint website. 