### PR TITLE
Lemma 2.1.2 and wiggle order lemmas

### DIFF
--- a/Carleson/AntichainOperator.lean
+++ b/Carleson/AntichainOperator.lean
@@ -36,7 +36,7 @@ open ENNReal NNReal Real
 /-- Constant appearing in Lemma 6.1.2. -/
 noncomputable def C_6_1_2 (a : ℕ) : ℕ := 2 ^ (107 * a ^ 3)
 
-lemma C_6_1_2_ne_zero (a : ℕ) : C_6_1_2 a ≠ 0 := by rw [C_6_1_2]; positivity
+lemma C_6_1_2_ne_zero (a : ℕ) : (C_6_1_2 a : ℝ≥0∞) ≠ 0 := by rw [C_6_1_2]; positivity
 
 open MeasureTheory Metric Bornology Set
 
@@ -115,13 +115,13 @@ lemma MaximalBoundAntichain {𝔄 : Finset (𝔓 X)} (h𝔄 : IsAntichain (·≤
         _ ≤ 107 * a ^ 3 := by gcongr; norm_num
       · exact lt_of_le_of_lt hdist_cp
           (mul_lt_mul_of_nonneg_of_pos (by linarith) (le_refl _) (by linarith)
-          (zpow_pos_of_pos (by exact_mod_cast defaultD_pos a) _))
+          (zpow_pos_of_pos (defaultD_pos a) _))
     _ ≤ (C_6_1_2 a) * MB volume ((fun (𝔭 : 𝔓 X) ↦ (𝔠 𝔭, 8*D ^ 𝔰 𝔭)) '' (𝔄 : Set (𝔓 X))) f x := by
       rw [mul_le_mul_left _ _, MB, maximalFunction, inv_one, ENNReal.rpow_one, le_iSup_iff]
       simp only [mem_image, Finset.mem_coe, iSup_exists, iSup_le_iff,
         and_imp, forall_apply_eq_imp_iff₂, ENNReal.rpow_one]
       exact (fun _ hc ↦ hc p.1 p.2)
-      · exact_mod_cast C_6_1_2_ne_zero a
+      · exact C_6_1_2_ne_zero a
       · exact coe_ne_top
   · simp only [ne_eq, Subtype.exists, exists_prop, not_exists, not_and, Decidable.not_not] at hx
     have h0 : (∑ (p ∈ 𝔄), T p f x) = (∑ (p ∈ 𝔄), 0) := Finset.sum_congr rfl (fun  p hp ↦ hx p hp)

--- a/Carleson/Defs.lean
+++ b/Carleson/Defs.lean
@@ -125,20 +125,20 @@ notation3 "ball_{" x " ," r "}" => @ball (WithFunctionDistance x r) _ in
 class CompatibleFunctions (𝕜 : outParam Type*) (X : Type u) (A : outParam ℕ)
   [RCLike 𝕜] [PseudoMetricSpace X] extends FunctionDistances 𝕜 X where
   eq_zero : ∃ o : X, ∀ f : Θ, f o = 0
-  /-- The distance is bounded below by the local oscillation. -/
+  /-- The distance is bounded below by the local oscillation. (1.0.7) -/
   localOscillation_le_cdist {x : X} {r : ℝ} {f g : Θ} :
     localOscillation (ball x r) (coeΘ f) (coeΘ g) ≤ dist_{x, r} f g
-  /-- The distance is monotone in the ball. -/
+  /-- The distance is monotone in the ball. (1.0.9) -/
   cdist_mono {x₁ x₂ : X} {r₁ r₂ : ℝ} {f g : Θ}
-    (h : ball x₁ r₁ ⊆ ball x₂ r₂) : dist_{x₁, r₂} f g ≤ dist_{x₂, r₂} f g
-  /-- The distance of a ball with large radius is bounded above. -/
+    (h : ball x₁ r₁ ⊆ ball x₂ r₂) : dist_{x₁, r₁} f g ≤ dist_{x₂, r₂} f g
+  /-- The distance of a ball with large radius is bounded above. (1.0.8) -/
   cdist_le {x₁ x₂ : X} {r : ℝ} {f g : Θ} (h : dist x₁ x₂ < 2 * r) :
     dist_{x₂, 2 * r} f g ≤ A * dist_{x₁, r} f g
-  /-- The distance of a ball with large radius is bounded below. -/
-  le_cdist {x₁ x₂ : X} {r : ℝ} {f g : Θ} (h1 : ball x₁ r ⊆ ball x₂ (A * r))
-    /-(h2 : A * r ≤ Metric.diam (univ : Set X))-/ :
+  /-- The distance of a ball with large radius is bounded below. (1.0.10) -/
+  le_cdist {x₁ x₂ : X} {r : ℝ} {f g : Θ} (h1 : ball x₁ r ⊆ ball x₂ (A * r)) :
+    /-(h2 : A * r ≤ Metric.diam (univ : Set X))-/
     2 * dist_{x₁, r} f g ≤ dist_{x₂, A * r} f g
-  /-- The distance of a ball with large radius is bounded below. -/
+  /-- The distance of a ball with large radius is bounded below. (1.0.11) -/
   ballsCoverBalls {x : X} {r R : ℝ} :
     BallsCoverBalls (X := WithFunctionDistance x r) (2 * R) R A
 
@@ -246,7 +246,7 @@ and `CompatibleFunctions` -/
 @[simp] def defaultZ (a : ℕ) : ℝ := 2 ^ (12 * a)
 @[simp] def defaultτ (a : ℕ) : ℝ := a⁻¹
 
-lemma defaultD_pos (a : ℕ) : 0 < defaultD a := by rw [defaultD]; positivity
+lemma defaultD_pos (a : ℕ) : 0 < (defaultD a : ℝ) := by rw [defaultD]; positivity
 
 /- A constant used on the boundedness of `T_*`. We generally assume
 `HasBoundedStrongType (ANCZOperator K) volume volume 2 2 (C_Ts a)`
@@ -332,15 +332,15 @@ open scoped ShortVariables
 variable {X : Type*} {a : ℕ} {q : ℝ} {K : X → X → ℂ} {σ₁ σ₂ : X → ℤ} {F G : Set X}
   [MetricSpace X] [ProofData a q K σ₁ σ₂ F G]
 
-lemma one_le_D : 1 ≤ D := by
-  rw [defaultD, ← pow_zero 2]
+lemma one_le_D : 1 ≤ (D : ℝ) := by
+  rw [← Nat.cast_one, Nat.cast_le, defaultD, ← pow_zero 2]
   exact pow_le_pow_right' one_le_two (by positivity)
 
-lemma D_nonneg : 0 ≤ D := zero_le_one.trans one_le_D
+lemma D_nonneg : 0 ≤ (D : ℝ) := zero_le_one.trans one_le_D
 
 variable (a) in
 /-- `D` as an element of `ℝ≥0`. -/
-def nnD : ℝ≥0 := ⟨D, by exact_mod_cast D_nonneg⟩
+def nnD : ℝ≥0 := ⟨D, by simp [D_nonneg]⟩
 
 namespace ShortVariables
 

--- a/Carleson/DiscreteCarleson.lean
+++ b/Carleson/DiscreteCarleson.lean
@@ -14,18 +14,17 @@ variable {X : Type*} {a : ℕ} {q : ℝ} {K : X → X → ℂ} {σ₁ σ₂ : X 
 
 section WiggleOrder
 
-variable {p p' : 𝔓 X} {m m' n n' : ℝ}
+variable {p p' : 𝔓 X}
 
 /-- Lemma 5.3.1 -/
-lemma smul_mono (hp : smul n p ≤ smul m p') (hm : m' ≤ m) (hn : n ≤ n') :
+lemma smul_mono {m m' n n' : ℝ} (hp : smul n p ≤ smul m p') (hm : m' ≤ m) (hn : n ≤ n') :
     smul n' p ≤ smul m' p' := by
   change 𝓘 p ≤ 𝓘 p' ∧ ball_(p') (𝒬 p') m ⊆ ball_(p) (𝒬 p) n at hp
   change 𝓘 p ≤ 𝓘 p' ∧ ball_(p') (𝒬 p') m' ⊆ ball_(p) (𝒬 p) n'
   exact ⟨hp.1, (ball_subset_ball hm).trans (hp.2.trans (ball_subset_ball hn))⟩
 
-variable (m) in
 /-- Lemma 5.3.2 -/
-lemma smul_C2_1_2 (hp : 𝓘 p ≠ 𝓘 p') (hl : smul n p ≤ smul 1 p') :
+lemma smul_C2_1_2 (m : ℝ) {n : ℝ} (hp : 𝓘 p ≠ 𝓘 p') (hl : smul n p ≤ smul 1 p') :
     smul (n + C2_1_2 a * m) p ≤ smul m p' := by
   replace hp : 𝓘 p < 𝓘 p' := lt_of_le_of_ne hl.1 hp
   have : ball_(p') (𝒬 p') m ⊆ ball_(p) (𝒬 p) (n + C2_1_2 a * m) := fun x hx ↦ by
@@ -41,33 +40,23 @@ lemma smul_C2_1_2 (hp : 𝓘 p ≠ 𝓘 p') (hl : smul n p ≤ smul 1 p') :
   exact ⟨hl.1, this⟩
 
 /-- Lemma 5.3.3, Equation (5.3.3) -/
-lemma wiggle_order_11_10 (hp : p ≤ p') (hn : 11 / 10 ≤ n) : smul n p ≤ smul n p' := by
+lemma wiggle_order_11_10 {n : ℝ} (hp : p ≤ p') (hn : 11 / 10 ≤ n) : smul n p ≤ smul n p' := by
   sorry
 
 /-- Lemma 5.3.3, Equation (5.3.4) -/
 lemma wiggle_order_100 (hp : smul 10 p ≤ smul 1 p') (hn : 𝓘 p ≠ 𝓘 p') :
     smul 100 p ≤ smul 100 p' := by
   calc
-    _ ≤ smul (10 + C2_1_2 a * 100) p := by
-      refine smul_mono le_rfl le_rfl ?_
-      have : C2_1_2 a ≤ 1 / 2 := by
-        rw [C2_1_2, show (1 / 2 : ℝ) = 2 ^ (-1 : ℝ) by norm_num,
-          Real.rpow_le_rpow_left_iff one_lt_two, neg_mul, neg_le_neg_iff]
-        norm_cast; linarith [four_le_a X]
-      linarith
+    _ ≤ smul (10 + C2_1_2 a * 100) p :=
+      smul_mono le_rfl le_rfl (by linarith [C2_1_2_le_inv_512 (X := X)])
     _ ≤ _ := smul_C2_1_2 100 hn hp
 
 /-- Lemma 5.3.3, Equation (5.3.5) -/
 lemma wiggle_order_500 (hp : smul 2 p ≤ smul 1 p') (hn : 𝓘 p ≠ 𝓘 p') :
     smul 4 p ≤ smul 500 p' := by
   calc
-    _ ≤ smul (2 + C2_1_2 a * 500) p := by
-      refine smul_mono le_rfl le_rfl ?_
-      have : C2_1_2 a ≤ 1 / 512 := by
-        rw [C2_1_2, show (1 / 512 : ℝ) = 2 ^ (-9 : ℝ) by norm_num,
-          Real.rpow_le_rpow_left_iff one_lt_two, neg_mul, neg_le_neg_iff]
-        norm_cast; linarith [four_le_a X]
-      linarith
+    _ ≤ smul (2 + C2_1_2 a * 500) p :=
+      smul_mono le_rfl le_rfl (by linarith [C2_1_2_le_inv_512 (X := X)])
     _ ≤ _ := smul_C2_1_2 500 hn hp
 
 end WiggleOrder

--- a/Carleson/DiscreteCarleson.lean
+++ b/Carleson/DiscreteCarleson.lean
@@ -12,15 +12,20 @@ open scoped ShortVariables
 variable {X : Type*} {a : ℕ} {q : ℝ} {K : X → X → ℂ} {σ₁ σ₂ : X → ℤ} {F G : Set X}
   [MetricSpace X] [ProofData a q K σ₁ σ₂ F G] [TileStructure Q D κ S o]
 
+section WiggleOrder
+
+variable {p p' : 𝔓 X} {m m' n n' : ℝ}
+
 /-- Lemma 5.3.1 -/
-lemma smul_mono {p p' : 𝔓 X} {m m' n n' : ℝ} (hp : smul n p ≤ smul m p')
-    (hm : m' ≤ m) (hn : n ≤ n') : smul n' p ≤ smul m' p' := by
+lemma smul_mono (hp : smul n p ≤ smul m p') (hm : m' ≤ m) (hn : n ≤ n') :
+    smul n' p ≤ smul m' p' := by
   change 𝓘 p ≤ 𝓘 p' ∧ ball_(p') (𝒬 p') m ⊆ ball_(p) (𝒬 p) n at hp
   change 𝓘 p ≤ 𝓘 p' ∧ ball_(p') (𝒬 p') m' ⊆ ball_(p) (𝒬 p) n'
   exact ⟨hp.1, (ball_subset_ball hm).trans (hp.2.trans (ball_subset_ball hn))⟩
 
+variable (m) in
 /-- Lemma 5.3.2 -/
-lemma smul_C2_1_2 {p p' : 𝔓 X} {m n : ℝ} (hp : 𝓘 p ≠ 𝓘 p') (hl : smul n p ≤ smul 1 p') :
+lemma smul_C2_1_2 (hp : 𝓘 p ≠ 𝓘 p') (hl : smul n p ≤ smul 1 p') :
     smul (n + C2_1_2 a * m) p ≤ smul m p' := by
   replace hp : 𝓘 p < 𝓘 p' := lt_of_le_of_ne hl.1 hp
   have : ball_(p') (𝒬 p') m ⊆ ball_(p) (𝒬 p) (n + C2_1_2 a * m) := fun x hx ↦ by
@@ -34,6 +39,38 @@ lemma smul_C2_1_2 {p p' : 𝔓 X} {m n : ℝ} (hp : 𝓘 p ≠ 𝓘 p') (hl : sm
         rw [add_comm]; gcongr
         exact mem_ball.mp <| mem_of_mem_of_subset (by convert mem_ball_self zero_lt_one) hl.2
   exact ⟨hl.1, this⟩
+
+/-- Lemma 5.3.3, Equation (5.3.3) -/
+lemma wiggle_order_11_10 (hp : p ≤ p') (hn : 11 / 10 ≤ n) : smul n p ≤ smul n p' := by
+  sorry
+
+/-- Lemma 5.3.3, Equation (5.3.4) -/
+lemma wiggle_order_100 (hp : smul 10 p ≤ smul 1 p') (hn : 𝓘 p ≠ 𝓘 p') :
+    smul 100 p ≤ smul 100 p' := by
+  calc
+    _ ≤ smul (10 + C2_1_2 a * 100) p := by
+      refine smul_mono le_rfl le_rfl ?_
+      have : C2_1_2 a ≤ 1 / 2 := by
+        rw [C2_1_2, show (1 / 2 : ℝ) = 2 ^ (-1 : ℝ) by norm_num,
+          Real.rpow_le_rpow_left_iff one_lt_two, neg_mul, neg_le_neg_iff]
+        norm_cast; linarith [four_le_a X]
+      linarith
+    _ ≤ _ := smul_C2_1_2 100 hn hp
+
+/-- Lemma 5.3.3, Equation (5.3.5) -/
+lemma wiggle_order_500 (hp : smul 2 p ≤ smul 1 p') (hn : 𝓘 p ≠ 𝓘 p') :
+    smul 4 p ≤ smul 500 p' := by
+  calc
+    _ ≤ smul (2 + C2_1_2 a * 500) p := by
+      refine smul_mono le_rfl le_rfl ?_
+      have : C2_1_2 a ≤ 1 / 512 := by
+        rw [C2_1_2, show (1 / 512 : ℝ) = 2 ^ (-9 : ℝ) by norm_num,
+          Real.rpow_le_rpow_left_iff one_lt_two, neg_mul, neg_le_neg_iff]
+        norm_cast; linarith [four_le_a X]
+      linarith
+    _ ≤ _ := smul_C2_1_2 500 hn hp
+
+end WiggleOrder
 
 /- The constant used in Proposition 2.0.2 -/
 def C2_0_2 (a : ℝ) (q : ℝ) : ℝ := 2 ^ (440 * a ^ 3) / (q - 1) ^ 5

--- a/Carleson/DiscreteCarleson.lean
+++ b/Carleson/DiscreteCarleson.lean
@@ -45,7 +45,7 @@ lemma wiggle_order_11_10 {n : ℝ} (hp : p ≤ p') (hn : 11 / 10 ≤ n) : smul n
 
 /-- Lemma 5.3.3, Equation (5.3.4) -/
 lemma wiggle_order_100 (hp : smul 10 p ≤ smul 1 p') (hn : 𝓘 p ≠ 𝓘 p') :
-    smul 100 p ≤ smul 100 p' := by
+    smul 100 p ≤ smul 100 p' :=
   calc
     _ ≤ smul (10 + C2_1_2 a * 100) p :=
       smul_mono le_rfl le_rfl (by linarith [C2_1_2_le_inv_512 (X := X)])
@@ -53,7 +53,7 @@ lemma wiggle_order_100 (hp : smul 10 p ≤ smul 1 p') (hn : 𝓘 p ≠ 𝓘 p') 
 
 /-- Lemma 5.3.3, Equation (5.3.5) -/
 lemma wiggle_order_500 (hp : smul 2 p ≤ smul 1 p') (hn : 𝓘 p ≠ 𝓘 p') :
-    smul 4 p ≤ smul 500 p' := by
+    smul 4 p ≤ smul 500 p' :=
   calc
     _ ≤ smul (2 + C2_1_2 a * 500) p :=
       smul_mono le_rfl le_rfl (by linarith [C2_1_2_le_inv_512 (X := X)])

--- a/Carleson/DiscreteCarleson.lean
+++ b/Carleson/DiscreteCarleson.lean
@@ -10,14 +10,37 @@ noncomputable section
 
 open scoped ShortVariables
 variable {X : Type*} {a : ℕ} {q : ℝ} {K : X → X → ℂ} {σ₁ σ₂ : X → ℤ} {F G : Set X}
-  [MetricSpace X]
+  [MetricSpace X] [ProofData a q K σ₁ σ₂ F G] [TileStructure Q D κ S o]
+
+/-- Lemma 5.3.1 -/
+lemma smul_mono {p p' : 𝔓 X} {m m' n n' : ℝ} (hp : smul n p ≤ smul m p')
+    (hm : m' ≤ m) (hn : n ≤ n') : smul n' p ≤ smul m' p' := by
+  change 𝓘 p ≤ 𝓘 p' ∧ ball_(p') (𝒬 p') m ⊆ ball_(p) (𝒬 p) n at hp
+  change 𝓘 p ≤ 𝓘 p' ∧ ball_(p') (𝒬 p') m' ⊆ ball_(p) (𝒬 p) n'
+  exact ⟨hp.1, (ball_subset_ball hm).trans (hp.2.trans (ball_subset_ball hn))⟩
+
+/-- Lemma 5.3.2 -/
+lemma smul_C2_1_2 {p p' : 𝔓 X} {m n : ℝ} (hp : 𝓘 p ≠ 𝓘 p') (hl : smul n p ≤ smul 1 p') :
+    smul (n + C2_1_2 a * m) p ≤ smul m p' := by
+  replace hp : 𝓘 p < 𝓘 p' := lt_of_le_of_ne hl.1 hp
+  have : ball_(p') (𝒬 p') m ⊆ ball_(p) (𝒬 p) (n + C2_1_2 a * m) := fun x hx ↦ by
+    rw [@mem_ball] at hx ⊢
+    calc
+      _ ≤ dist_(p) x (𝒬 p') + dist_(p) (𝒬 p') (𝒬 p) := dist_triangle ..
+      _ ≤ C2_1_2 a * dist_(p') x (𝒬 p') + dist_(p) (𝒬 p') (𝒬 p) := by
+        gcongr; exact Grid.dist_strictMono hp
+      _ < C2_1_2 a * m + dist_(p) (𝒬 p') (𝒬 p) := by gcongr; rw [C2_1_2]; positivity
+      _ < _ := by
+        rw [add_comm]; gcongr
+        exact mem_ball.mp <| mem_of_mem_of_subset (by convert mem_ball_self zero_lt_one) hl.2
+  exact ⟨hl.1, this⟩
 
 /- The constant used in Proposition 2.0.2 -/
 def C2_0_2 (a : ℝ) (q : ℝ) : ℝ := 2 ^ (440 * a ^ 3) / (q - 1) ^ 5
 
-lemma C2_0_2_pos [ProofData a q K σ₁ σ₂ F G] : C2_0_2 a q > 0 := sorry
+lemma C2_0_2_pos : C2_0_2 a q > 0 := sorry
 
-theorem discrete_carleson [ProofData a q K σ₁ σ₂ F G] [TileStructure Q D κ S o] :
+theorem discrete_carleson :
     ∃ G', Measurable G' ∧ 2 * volume G' ≤ volume G ∧
     ∀ f : X → ℂ, Measurable f → (∀ x, ‖f x‖ ≤ F.indicator 1 x) →
     ‖∫ x in G \ G', ∑' p, T p f x‖₊ ≤

--- a/Carleson/GridStructure.lean
+++ b/Carleson/GridStructure.lean
@@ -83,11 +83,11 @@ namespace Grid
 
 protected lemma inj : Injective (fun i : Grid X ↦ ((i : Set X), s i)) := GridStructure.inj
 
-lemma nonempty (i : Grid X) : (i : Set X).Nonempty := by
-  apply Set.Nonempty.mono ball_subset_Grid
-  rw [nonempty_ball]
-  obtain ⟨z⟩ := ‹NeZero D›
-  positivity
+lemma c_mem_Grid {i : Grid X} : c i ∈ (i : Set X) := by
+  obtain ⟨_⟩ := ‹NeZero D›
+  exact mem_of_mem_of_subset (Metric.mem_ball_self (by positivity)) ball_subset_Grid
+
+lemma nonempty (i : Grid X) : (i : Set X).Nonempty := ⟨c i, c_mem_Grid⟩
 
 @[simp] lemma lt_def {i j : Grid X} : i < j ↔ (i : Set X) ⊆ (j : Set X) ∧ s i < s j := by
   constructor <;> intro h
@@ -305,28 +305,77 @@ notation "dist_(" 𝔭 ")" => @dist (WithFunctionDistance (𝔠 𝔭) (D ^ 𝔰 
 notation "nndist_(" 𝔭 ")" => @nndist (WithFunctionDistance (𝔠 𝔭) (D ^ 𝔰 𝔭 / 4)) _
 notation "ball_(" 𝔭 ")" => @ball (WithFunctionDistance (𝔠 𝔭) (D ^ 𝔰 𝔭 / 4)) _
 
-/-- Lemma 2.1.2, part 1. -/
-lemma Grid.dist_mono {I J : Grid X} (hpq : I ≤ J) {f g : Θ X} :
-    dist_{I} f g ≤ dist_{J} f g := by
-  rw [Grid.le_def] at hpq
-  obtain ⟨hpq, h'⟩ := hpq
-  obtain h|h := h'.eq_or_lt
-  · suffices I = J by
-      rw [this]
-    simp_rw [← Grid.inj.eq_iff, Prod.ext_iff, h, and_true]
-    apply subset_antisymm hpq
-    apply (fundamental_dyadic h.symm.le).resolve_right
-    rw [Set.not_disjoint_iff_nonempty_inter, inter_eq_self_of_subset_right hpq]
-    exact Grid.nonempty _
-  simp only [not_le, ← Int.add_one_le_iff] at h
-  sorry
+lemma dist_congr {x₁ x₂ : X} {r₁ r₂ : ℝ} {f g : Θ X} (e₁ : x₁ = x₂) (e₂ : r₁ = r₂) :
+    dist_{x₁, r₁} f g = dist_{x₂, r₂} f g := by congr
 
-def C2_1_2 (a : ℝ) : ℝ := 2 ^ (-95 * a)
+lemma le_cdist_iterate {x : X} {r : ℝ} (hr : 0 ≤ r) (f g : Θ X) (k : ℕ) :
+    2 ^ k * dist_{x, r} f g ≤ dist_{x, (defaultA a) ^ k * r} f g := by
+  induction k with
+  | zero => rw [pow_zero, one_mul]; congr! <;> simp
+  | succ k ih =>
+    trans 2 * dist_{x, (defaultA a) ^ k * r} f g
+    · rw [pow_succ', mul_assoc]
+      exact (mul_le_mul_left zero_lt_two).mpr ih
+    · convert le_cdist (ball_subset_ball _) using 1
+      · exact dist_congr rfl (by rw [← mul_assoc, pow_succ'])
+      · nth_rw 1 [← one_mul ((defaultA a) ^ k * r)]; gcongr
+        rw [← Nat.cast_one, Nat.cast_le]; exact Nat.one_le_two_pow
 
-/-- Lemma 2.1.2, part 2. -/
+lemma cdist_le_iterate {x : X} {r : ℝ} (hr : 0 < r) (f g : Θ X) (k : ℕ) :
+    dist_{x, 2 ^ k * r} f g ≤ (defaultA a) ^ k * dist_{x, r} f g := by
+  induction k with
+  | zero => simp_rw [pow_zero, one_mul]; congr! <;> simp
+  | succ k ih =>
+    trans defaultA a * dist_{x, 2 ^ k * r} f g
+    · convert cdist_le _ using 1
+      · exact dist_congr rfl (by ring)
+      · rw [dist_self]; positivity
+    · replace ih := (mul_le_mul_left (show 0 < (defaultA a : ℝ) by positivity)).mpr ih
+      rwa [← mul_assoc, ← pow_succ'] at ih
+
+def C2_1_2 (a : ℕ) : ℝ := 2 ^ (-95 * (a : ℝ))
+
+/-- Stronger version of Lemma 2.1.2. -/
 lemma Grid.dist_strictMono {I J : Grid X} (hpq : I < J) {f g : Θ X} :
     dist_{I} f g ≤ C2_1_2 a * dist_{J} f g := by
-  sorry
+  calc
+    _ ≤ dist_{c I, 4 * D ^ s I} f g :=
+      cdist_mono (ball_subset_ball (by simp_rw [div_eq_inv_mul, defaultD]; gcongr; norm_num))
+    _ ≤ 2 ^ (-100 * (a : ℝ)) * dist_{c I, 4 * D ^ (s I + 1)} f g := by
+      rw [← div_le_iff' (by positivity), neg_mul, Real.rpow_neg zero_le_two, div_inv_eq_mul, mul_comm]
+      convert le_cdist_iterate (x := c I) (r := 4 * D ^ s I) (by positivity) f g (100 * a) using 1
+      · norm_cast
+      · apply dist_congr rfl
+        have : (defaultA a : ℝ) ^ (100 * a) = D := by
+          simp only [defaultD, Nat.cast_pow, Nat.cast_ofNat]
+          rw [← pow_mul]; congr 1; ring
+        rw [this, zpow_add_one₀ (defaultD_pos a).ne']; ring
+    _ ≤ 2 ^ (-100 * (a : ℝ)) * dist_{c I, 4 * D ^ s J} f g := by
+      gcongr
+      have : s I < s J := (Grid.lt_def.mp hpq).2
+      exact cdist_mono (ball_subset_ball (mul_le_mul_of_nonneg_left
+        (zpow_le_of_le one_le_D (by omega)) zero_le_four))
+    _ ≤ 2 ^ (-100 * (a : ℝ)) * dist_{c J, 8 * D ^ s J} f g := by
+      gcongr
+      have : c I ∈ ball (c J) (4 * D ^ s J) :=
+        mem_of_mem_of_subset c_mem_Grid ((Grid.lt_def.mp hpq).1.trans Grid_subset_ball)
+      rw [mem_ball] at this
+      exact cdist_mono (ball_subset_ball' (by linarith))
+    _ ≤ 2 ^ (-100 * (a : ℝ) + 5 * a) * dist_{J} f g := by
+      rw [Real.rpow_add zero_lt_two, mul_assoc]
+      refine mul_le_mul_of_nonneg_left ?_ (by positivity)
+      rw [show (2 : ℝ) ^ (5 * (a : ℝ)) = (defaultA a) ^ 5 by norm_cast; ring]
+      convert cdist_le_iterate _ f g 5 using 1
+      · exact dist_congr rfl (by ring)
+      · have := @one_le_D a; positivity
+    _ = _ := by congr 1; rw [C2_1_2, ← add_mul]; norm_num
+
+/-- Weaker version of Lemma 2.1.2. -/
+lemma Grid.dist_mono {I J : Grid X} (hpq : I ≤ J) {f g : Θ X} : dist_{I} f g ≤ dist_{J} f g := by
+  rcases hpq.eq_or_lt with h | h
+  · subst h; rfl
+  · exact (Grid.dist_strictMono h).trans (mul_le_of_le_one_left dist_nonneg <|
+      Real.rpow_le_one_of_one_le_of_nonpos one_le_two (by linarith))
 
 end GridStructure
 

--- a/Carleson/GridStructure.lean
+++ b/Carleson/GridStructure.lean
@@ -379,8 +379,8 @@ lemma Grid.dist_strictMono {I J : Grid X} (hpq : I < J) {f g : Θ X} :
 lemma Grid.dist_mono {I J : Grid X} (hpq : I ≤ J) {f g : Θ X} : dist_{I} f g ≤ dist_{J} f g := by
   rcases hpq.eq_or_lt with h | h
   · subst h; rfl
-  · exact (Grid.dist_strictMono h).trans (mul_le_of_le_one_left dist_nonneg <|
-      Real.rpow_le_one_of_one_le_of_nonpos one_le_two (by linarith))
+  · exact (Grid.dist_strictMono h).trans
+      (mul_le_of_le_one_left dist_nonneg (by linarith [C2_1_2_le_inv_512 (X := X)]))
 
 end GridStructure
 

--- a/Carleson/GridStructure.lean
+++ b/Carleson/GridStructure.lean
@@ -335,6 +335,11 @@ lemma cdist_le_iterate {x : X} {r : ℝ} (hr : 0 < r) (f g : Θ X) (k : ℕ) :
 
 def C2_1_2 (a : ℕ) : ℝ := 2 ^ (-95 * (a : ℝ))
 
+lemma C2_1_2_le_inv_512 : C2_1_2 a ≤ 1 / 512 := by
+  rw [C2_1_2, show (1 / 512 : ℝ) = 2 ^ (-9 : ℝ) by norm_num,
+    Real.rpow_le_rpow_left_iff one_lt_two, neg_mul, neg_le_neg_iff]
+  norm_cast; linarith [four_le_a X]
+
 /-- Stronger version of Lemma 2.1.2. -/
 lemma Grid.dist_strictMono {I J : Grid X} (hpq : I < J) {f g : Θ X} :
     dist_{I} f g ≤ C2_1_2 a * dist_{J} f g := by

--- a/Carleson/Psi.lean
+++ b/Carleson/Psi.lean
@@ -25,7 +25,7 @@ variable (D) in def nonzeroS (x : ℝ) : Finset ℤ :=
 
 lemma sum_ψ : ∑ s in nonzeroS D x, ψ D (D ^ s * x) = 1 := sorry
 
-lemma mem_nonzeroS_iff {i : ℤ} {x : ℝ} (hx : 0 < x) (hD : 1 < D) :
+lemma mem_nonzeroS_iff {i : ℤ} {x : ℝ} (hx : 0 < x) (hD : 1 < (D : ℝ)) :
     i ∈ nonzeroS D x ↔ (D ^ i * x) ∈ Ioo (4 * D : ℝ)⁻¹ 2⁻¹ := by
   rw [Set.mem_Ioo, nonzeroS, Finset.mem_Icc]
   simp only [Int.floor_le_iff, neg_add_rev, Int.le_ceil_iff, lt_add_neg_iff_add_lt, sub_add_cancel,
@@ -33,19 +33,18 @@ lemma mem_nonzeroS_iff {i : ℤ} {x : ℝ} (hx : 0 < x) (hD : 1 < D) :
   rw [← lt_div_iff hx, mul_comm (D : ℝ)⁻¹, ← div_lt_div_iff hx (by positivity), ← Real.logb_inv,
     ← Real.logb_inv, div_inv_eq_mul, ← zpow_add_one₀ (by positivity)]
   simp_rw [← Real.rpow_intCast]
-  rw [Real.lt_logb_iff_rpow_lt (by exact_mod_cast hD) (by positivity),
-    Real.logb_lt_iff_lt_rpow (by exact_mod_cast hD) (by positivity)]
+  rw [Real.lt_logb_iff_rpow_lt hD (by positivity), Real.logb_lt_iff_lt_rpow hD (by positivity)]
   simp [div_eq_mul_inv, mul_comm]
 
 lemma psi_zero : ψ D 0 = 0 := by
   simp only [ψ, mul_zero, zero_sub, sub_zero, ge_iff_le, min_le_iff, neg_le_self_iff, zero_le_one,
     Nat.not_ofNat_le_one, or_false, min_eq_right, Left.neg_nonpos_iff, true_or, max_eq_left]
 
-lemma psi_ne_zero_iff {x : ℝ} (hx : 0 < x) (hD : 1 < D) :
+lemma psi_ne_zero_iff {x : ℝ} (hx : 0 < x) (hD : 1 < (D : ℝ)) :
     ψ D (D ^ s * x) ≠ 0 ↔ s ∈ nonzeroS D x := by
   rw [← mem_support, support_ψ, mem_nonzeroS_iff hx hD]
 
-lemma psi_eq_zero_iff {x : ℝ} (hx : 0 < x) (hD : 1 < D) :
+lemma psi_eq_zero_iff {x : ℝ} (hx : 0 < x) (hD : 1 < (D : ℝ)) :
     ψ D (D ^ s * x) = 0 ↔ s ∉ nonzeroS D x := by
   rw [← iff_not_comm, ← psi_ne_zero_iff hx hD]
 
@@ -64,7 +63,7 @@ def Ks [ProofData a q K σ₁ σ₂ F G] (s : ℤ) (x y : X) : ℂ :=
 lemma Ks_def [ProofData a q K σ₁ σ₂ F G] (s : ℤ) (x y : X) :
   Ks s x y = K x y * ψ (D ^ s * dist x y) := rfl
 
-lemma sum_Ks {t : Finset ℤ} (hs : nonzeroS D (dist x y) ⊆ t) (hD : 1 < D) (h : 0 < dist x y) :
+lemma sum_Ks {t : Finset ℤ} (hs : nonzeroS D (dist x y) ⊆ t) (hD : 1 < (D : ℝ)) (h : 0 < dist x y) :
     ∑ i in t, Ks i x y = K x y := by
   simp_rw [Ks, ← Finset.mul_sum]
   norm_cast

--- a/Carleson/TileExistence.lean
+++ b/Carleson/TileExistence.lean
@@ -36,8 +36,8 @@ lemma ball_bound {Y : Set X} (k : ℝ) (hk_lower : -S ≤ k)
         apply ball_subset_ball
         rw [mul_assoc]
         apply mul_le_mul_of_nonneg_left _ (by norm_num)
-        rw [← Real.rpow_natCast, ← Real.rpow_natCast, ← Real.rpow_add (by exact_mod_cast defaultD_pos a)]
-        apply Real.rpow_le_rpow_of_exponent_le (by exact_mod_cast one_le_D)
+        rw [← Real.rpow_natCast, ← Real.rpow_natCast, ← Real.rpow_add (defaultD_pos a)]
+        apply Real.rpow_le_rpow_of_exponent_le one_le_D
         rw [Nat.cast_mul, Nat.cast_two]
         linarith
 
@@ -97,7 +97,7 @@ lemma counting_balls (k : ℝ) (hk_lower : -S ≤ k) (Y : Set X) (hY : Y ⊆ bal
         intro y _
         use y
         rw [mem_ball, dist_self]
-        exact Real.rpow_pos_of_pos (by exact_mod_cast defaultD_pos a) _
+        exact Real.rpow_pos_of_pos (defaultD_pos a) _
     _ ≤ (As (2 ^ a) (2 ^ J' X)) * volume (ball o (4 * D ^ S)) := by
         rw [ENNReal.mul_le_mul_left val_ne_zero ENNReal.coe_ne_top]
         apply volume.mono _
@@ -177,7 +177,7 @@ lemma cover_big_ball (k : ℝ) : ball o (4 * D^S - D^k) ⊆ ⋃ y ∈ Yk X k, ba
     suffices hmem : y ∈ Yk X k by
       use y, hmem
       rw [disjoint_self, bot_eq_empty, ball_eq_empty, not_le]
-      apply Real.rpow_pos_of_pos (by exact_mod_cast defaultD_pos a) k
+      apply Real.rpow_pos_of_pos (defaultD_pos a) k
     suffices (Yk X k) ∪ {y} = Yk X k by
       rw [union_singleton, insert_eq_self] at this
       exact this

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -2347,7 +2347,8 @@ Before proving \Cref{forest-union} and \Cref{forest-complement}, we collect some
 
 \begin{lemma}[wiggle order 1]
     \label{wiggle-order-1}
-
+    \leanok
+    \lean{smul_mono}
     If $n\fp \lesssim m\fp'$ and
     $n' \ge n$ and $m \ge m'$ then $n'\fp \lesssim m'\fp'$.
 \end{lemma}
@@ -2358,6 +2359,8 @@ Before proving \Cref{forest-union} and \Cref{forest-complement}, we collect some
 
 \begin{lemma}[wiggle order 2]
     \label{wiggle-order-2}
+    \leanok
+    \lean{smul_C2_1_2}
     \uses{monotone-cube-metrics}
 
     Let $n, m \ge 1$.

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -645,7 +645,7 @@ The next lemma concerns monotonicity of the metrics $d_{B(c(I), \frac 14 D^{s(I)
 \begin{lemma}[monotone cube metrics]
     \label{monotone-cube-metrics}
     \leanok
-    \lean{Grid.dist_mono, Grid.dist_strictMono} % Overleaf might scramble these characters (`\MCD`)
+    \lean{Grid.dist_mono, Grid.dist_strictMono}
     Let $(\mathcal{D}, c, s)$ be a grid structure. Denote for cubes $I \in \mathcal{D}$
     $$
         I^\circ := B(c(I), \frac{1}{4} D^{s(I)})\,.
@@ -662,6 +662,7 @@ The next lemma concerns monotonicity of the metrics $d_{B(c(I), \frac 14 D^{s(I)
 \end{lemma}
 
 \begin{proof}
+    \leanok
     If $s(I) \ge s(J)$ then \eqref{dyadicproperty} and the assumption $I\subset J$ imply $I = J$. Then the lemma holds by reflexivity.
 
     If $s(J) \ge s(I)+1$, then using the monotonicity property \eqref{monotonedb}, \eqref{defineD} and \eqref{seconddb}, we get

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -2354,6 +2354,7 @@ Before proving \Cref{forest-union} and \Cref{forest-complement}, we collect some
 \end{lemma}
 
 \begin{proof}
+    \leanok
     This follows immediately from the definition \eqref{wiggleorder} of $\lesssim$ and the two inclusions $B_{\fp}(\fcc(\fp), n) \subset B_{\fp}(\fcc(\fp), n')$ and $B_{\fp'}(\fcc(\fp'), m') \subset B_{\fp'}(\fcc(\fp'), m)$.
 \end{proof}
 
@@ -2377,6 +2378,7 @@ Before proving \Cref{forest-union} and \Cref{forest-complement}, we collect some
 \end{lemma}
 
 \begin{proof}
+    \leanok
     The assumption \eqref{eq-wiggle1} together with the definition \eqref{wiggleorder} of $\lesssim$ implies that $\scI(\fp) \subsetneq \scI(\fp')$. Let $\mfa \in B_{\fp'}(\fcc(\fp'), m)$. Then we have by the triangle inequality
     $$
         d_{\fp}(\fcc(\fp), \mfa) \le d_{\fp}(\fcc(\fp), \fcc(\fp')) + d_{\fp}(\fcc(\fp'), \mfa)


### PR DESCRIPTION
This also removes all but one of the `exact_mod_cast`s left over from the naturalisation of `a, A, D, S`.