### PR TITLE
Lemma 5.2.2

### DIFF
--- a/Carleson/DiscreteCarleson.lean
+++ b/Carleson/DiscreteCarleson.lean
@@ -148,20 +148,9 @@ lemma dense_cover (k : ℕ) : volume (⋃ i ∈ 𝓒 (X := X) k, (i : Set X)) �
     rw [aux𝓒, mem_diff, mem_setOf] at hi; obtain ⟨j, hj, mj⟩ := hi.1
     use j, ?_, mem_of_mem_of_subset mi hj.1
     simpa [M] using mj
-  let M' : Finset (Grid X) := M.filter fun i ↦ ∀ j ∈ M, i ≤ j → i = j
-  have t₁ : ∀ i ∈ M, ∃ j ∈ M', i ≤ j := fun i hi ↦ by
-    let C : Finset (Grid X) := M.filter (i ≤ ·)
-    have Cn : C.Nonempty := ⟨i, by simp only [C, Finset.mem_filter, hi, le_rfl, true_and]⟩
-    obtain ⟨j, hj, maxj⟩ := C.exists_maximal Cn
-    simp_rw [C, M', Finset.mem_filter] at hj maxj ⊢; refine ⟨j, ?_, hj.2⟩
-    exact ⟨hj.1, fun k hk lk ↦ eq_of_le_of_not_lt lk (maxj k ⟨hk, hj.2.trans lk⟩)⟩
+  let M' : Finset (Grid X) := Grid.maxCubes M
   have s₂ : ⋃ i ∈ M, (i : Set X) ⊆ ⋃ i ∈ M', ↑i := iUnion₂_mono' fun i mi ↦ by
-    obtain ⟨j, mj, hj⟩ := t₁ i mi; use j, mj, hj.1
-  have t₂ : M'.toSet.PairwiseDisjoint fun j ↦ G ∩ ↑j := fun i mi j mj hn ↦ by
-    refine ((?_ : Disjoint (i : Set X) j).inter_right' G).inter_left' G
-    simp only [M', and_imp, Finset.coe_filter, mem_setOf_eq] at mi mj
-    exact le_or_ge_or_disjoint.resolve_left ((mi.2 j mj.1).mt hn)
-      |>.resolve_left ((mj.2 i mi.1).mt hn.symm)
+    obtain ⟨j, mj, hj⟩ := (Grid.exists_maximal_supercube M) i mi; use j, mj, hj.1
   calc
     _ ≤ volume (⋃ i ∈ M', (i : Set X)) := measure_mono (s₁.trans s₂)
     _ ≤ ∑ i ∈ M', volume (i : Set X) := measure_biUnion_finset_le M' _
@@ -174,8 +163,9 @@ lemma dense_cover (k : ℕ) : volume (⋃ i ∈ 𝓒 (X := X) k, (i : Set X)) �
         ← ENNReal.rpow_neg, neg_neg] at hi
       exact_mod_cast hi.le
     _ = 2 ^ (k + 1) * volume (⋃ j ∈ M', G ∩ j) := by
-      congr; refine (measure_biUnion_finset t₂ (fun _ _ ↦ ?_)).symm
-      exact measurableSet_G.inter coeGrid_measurable
+      congr; refine (measure_biUnion_finset (fun _ mi _ mj hn ↦ ?_) (fun _ _ ↦ ?_)).symm
+      · exact ((Grid.maxCubes_pairwiseDisjoint M mi mj hn).inter_right' G).inter_left' G
+      · exact measurableSet_G.inter coeGrid_measurable
     _ ≤ _ := mul_le_mul_left' (measure_mono (iUnion₂_subset fun _ _ ↦ inter_subset_left)) _
 
 /-- Lemma 5.2.3 -/
@@ -205,7 +195,7 @@ lemma dyadic_union (hx : x ∈ setA l k n) : ∃ i : Grid X, x ∈ i ∧ (i : Se
 
 /-- Lemma 5.2.5 -/
 lemma john_nirenberg : volume (setA (X := X) l k n) ≤ 2 ^ (k + 1 - l : ℤ) * volume G := by
-  sorry
+    sorry
 
 /-- Lemma 5.2.6 -/
 lemma second_exception : volume (G₂ (X := X)) ≤ 2 ^ (- 4 : ℤ) * volume G := by

--- a/Carleson/DiscreteCarleson.lean
+++ b/Carleson/DiscreteCarleson.lean
@@ -151,19 +151,17 @@ lemma dense_cover (k : ℕ) : volume (⋃ i ∈ 𝓒 (X := X) k, (i : Set X)) �
   let M' : Finset (Grid X) := M.filter fun i ↦ ∀ j ∈ M, i ≤ j → i = j
   have t₁ : ∀ i ∈ M, ∃ j ∈ M', i ≤ j := fun i hi ↦ by
     let C : Finset (Grid X) := M.filter (i ≤ ·)
-    have Cn : C.Nonempty := ⟨i, by simp only [C, Finset.mem_filter]; exact ⟨hi, by rfl⟩⟩
+    have Cn : C.Nonempty := ⟨i, by simp only [C, Finset.mem_filter, hi, le_rfl, true_and]⟩
     obtain ⟨j, hj, maxj⟩ := C.exists_maximal Cn
     simp_rw [C, M', Finset.mem_filter] at hj maxj ⊢; refine ⟨j, ?_, hj.2⟩
     exact ⟨hj.1, fun k hk lk ↦ eq_of_le_of_not_lt lk (maxj k ⟨hk, hj.2.trans lk⟩)⟩
   have s₂ : ⋃ i ∈ M, (i : Set X) ⊆ ⋃ i ∈ M', ↑i := iUnion₂_mono' fun i mi ↦ by
     obtain ⟨j, mj, hj⟩ := t₁ i mi; use j, mj, hj.1
   have t₂ : M'.toSet.PairwiseDisjoint fun j ↦ G ∩ ↑j := fun i mi j mj hn ↦ by
-    refine Disjoint.inter_left' G (Disjoint.inter_right' G ?_)
+    refine ((?_ : Disjoint (i : Set X) j).inter_right' G).inter_left' G
     simp only [M', and_imp, Finset.coe_filter, mem_setOf_eq] at mi mj
-    rcases le_or_lt (s i) (s j) with c | c
-    · exact (le_or_disjoint c).resolve_left ((mi.2 j mj.1).mt hn)
-    · rw [disjoint_comm]
-      exact (le_or_disjoint c.le).resolve_left ((mj.2 i mi.1).mt hn.symm)
+    exact le_or_ge_or_disjoint.resolve_left ((mi.2 j mj.1).mt hn)
+      |>.resolve_left ((mj.2 i mi.1).mt hn.symm)
   calc
     _ ≤ volume (⋃ i ∈ M', (i : Set X)) := measure_mono (s₁.trans s₂)
     _ ≤ ∑ i ∈ M', volume (i : Set X) := measure_biUnion_finset_le M' _
@@ -177,7 +175,7 @@ lemma dense_cover (k : ℕ) : volume (⋃ i ∈ 𝓒 (X := X) k, (i : Set X)) �
       exact_mod_cast hi.le
     _ = 2 ^ (k + 1) * volume (⋃ j ∈ M', G ∩ j) := by
       congr; refine (measure_biUnion_finset t₂ (fun _ _ ↦ ?_)).symm
-      exact measurableSet_G.inter GridStructure.coeGrid_measurable
+      exact measurableSet_G.inter coeGrid_measurable
     _ ≤ _ := mul_le_mul_left' (measure_mono (iUnion₂_subset fun _ _ ↦ inter_subset_left)) _
 
 /-- Lemma 5.2.3 -/

--- a/Carleson/DiscreteCarleson.lean
+++ b/Carleson/DiscreteCarleson.lean
@@ -148,7 +148,7 @@ lemma dense_cover (k : ℕ) : volume (⋃ i ∈ 𝓒 (X := X) k, (i : Set X)) �
     rw [aux𝓒, mem_diff, mem_setOf] at hi; obtain ⟨j, hj, mj⟩ := hi.1
     use j, ?_, mem_of_mem_of_subset mi hj.1
     simpa [M] using mj
-  let M' : Finset (Grid X) := Grid.maxCubes M
+  let M' := Grid.maxCubes M
   have s₂ : ⋃ i ∈ M, (i : Set X) ⊆ ⋃ i ∈ M', ↑i := iUnion₂_mono' fun i mi ↦ by
     obtain ⟨j, mj, hj⟩ := (Grid.exists_maximal_supercube M) i mi; use j, mj, hj.1
   calc

--- a/Carleson/DiscreteCarleson.lean
+++ b/Carleson/DiscreteCarleson.lean
@@ -140,9 +140,45 @@ lemma first_exception : volume (G₁ : Set X) ≤ 2 ^ (- 4 : ℤ) * volume G := 
   sorry
 
 /-- Lemma 5.2.2 -/
-lemma dense_cover (k : ℕ) :
-    volume (⋃ p ∈ 𝓒 (X := X) k, (p : Set X)) ≤ 2 ^ (k + 1) * volume G := by
-  sorry
+lemma dense_cover (k : ℕ) : volume (⋃ i ∈ 𝓒 (X := X) k, (i : Set X)) ≤ 2 ^ (k + 1) * volume G := by
+  let M : Finset (Grid X) :=
+    Finset.univ.filter fun j ↦ (2 ^ (-(k + 1 : ℕ) : ℤ) * volume (j : Set X) < volume (G ∩ j))
+  have s₁ : ⋃ i ∈ 𝓒 (X := X) k, (i : Set X) ⊆ ⋃ i ∈ M, ↑i := by
+    simp_rw [𝓒]; intro q mq; rw [mem_iUnion₂] at mq ⊢; obtain ⟨i, hi, mi⟩ := mq
+    rw [aux𝓒, mem_diff, mem_setOf] at hi; obtain ⟨j, hj, mj⟩ := hi.1
+    use j, ?_, mem_of_mem_of_subset mi hj.1
+    simpa [M] using mj
+  let M' : Finset (Grid X) := M.filter fun i ↦ ∀ j ∈ M, i ≤ j → i = j
+  have t₁ : ∀ i ∈ M, ∃ j ∈ M', i ≤ j := fun i hi ↦ by
+    let C : Finset (Grid X) := M.filter (i ≤ ·)
+    have Cn : C.Nonempty := ⟨i, by simp only [C, Finset.mem_filter]; exact ⟨hi, by rfl⟩⟩
+    obtain ⟨j, hj, maxj⟩ := C.exists_maximal Cn
+    simp_rw [C, M', Finset.mem_filter] at hj maxj ⊢; refine ⟨j, ?_, hj.2⟩
+    exact ⟨hj.1, fun k hk lk ↦ eq_of_le_of_not_lt lk (maxj k ⟨hk, hj.2.trans lk⟩)⟩
+  have s₂ : ⋃ i ∈ M, (i : Set X) ⊆ ⋃ i ∈ M', ↑i := iUnion₂_mono' fun i mi ↦ by
+    obtain ⟨j, mj, hj⟩ := t₁ i mi; use j, mj, hj.1
+  have t₂ : M'.toSet.PairwiseDisjoint fun j ↦ G ∩ ↑j := fun i mi j mj hn ↦ by
+    refine Disjoint.inter_left' G (Disjoint.inter_right' G ?_)
+    simp only [M', and_imp, Finset.coe_filter, mem_setOf_eq] at mi mj
+    rcases le_or_lt (s i) (s j) with c | c
+    · exact (le_or_disjoint c).resolve_left ((mi.2 j mj.1).mt hn)
+    · rw [disjoint_comm]
+      exact (le_or_disjoint c.le).resolve_left ((mj.2 i mi.1).mt hn.symm)
+  calc
+    _ ≤ volume (⋃ i ∈ M', (i : Set X)) := measure_mono (s₁.trans s₂)
+    _ ≤ ∑ i ∈ M', volume (i : Set X) := measure_biUnion_finset_le M' _
+    _ ≤ 2 ^ (k + 1) * ∑ j ∈ M', volume (G ∩ j) := by
+      rw [Finset.mul_sum]; refine Finset.sum_le_sum fun i hi ↦ ?_
+      replace hi : i ∈ M := Finset.mem_of_subset (Finset.filter_subset _ M) hi
+      simp_rw [M, Finset.mem_filter, Finset.mem_univ, true_and] at hi
+      rw [← ENNReal.rpow_intCast, show (-(k + 1 : ℕ) : ℤ) = (-(k + 1) : ℝ) by simp,
+        mul_comm, ← ENNReal.lt_div_iff_mul_lt (by simp) (by simp), ENNReal.div_eq_inv_mul,
+        ← ENNReal.rpow_neg, neg_neg] at hi
+      exact_mod_cast hi.le
+    _ = 2 ^ (k + 1) * volume (⋃ j ∈ M', G ∩ j) := by
+      congr; refine (measure_biUnion_finset t₂ (fun _ _ ↦ ?_)).symm
+      exact measurableSet_G.inter GridStructure.coeGrid_measurable
+    _ ≤ _ := mul_le_mul_left' (measure_mono (iUnion₂_subset fun _ _ ↦ inter_subset_left)) _
 
 /-- Lemma 5.2.3 -/
 lemma pairwiseDisjoint_E1 : (𝔐 (X := X) k n).PairwiseDisjoint E₁ := fun p mp p' mp' h ↦ by

--- a/Carleson/GridStructure.lean
+++ b/Carleson/GridStructure.lean
@@ -327,4 +327,25 @@ lemma dist_mono {I J : Grid X} (hpq : I ≤ J) {f g : Θ X} : dist_{I} f g ≤ d
   · subst h; rfl
   · exact (Grid.dist_strictMono h).trans (mul_le_of_le_one_left dist_nonneg (C2_1_2_le_one X))
 
+/-! Maximal elements of finsets of dyadic cubes -/
+
+variable (s : Finset (Grid X))
+
+open Classical in
+def maxCubes : Finset (Grid X) := s.filter fun i ↦ ∀ j ∈ s, i ≤ j → i = j
+
+lemma exists_maximal_supercube : ∀ i ∈ s, ∃ j ∈ maxCubes s, i ≤ j := fun i hi ↦ by
+  classical let C : Finset (Grid X) := s.filter (i ≤ ·)
+  have Cn : C.Nonempty := ⟨i, by simp only [C, Finset.mem_filter, hi, le_rfl, true_and]⟩
+  obtain ⟨j, hj, maxj⟩ := C.exists_maximal Cn
+  simp_rw [C, maxCubes, Finset.mem_filter] at hj maxj ⊢
+  refine ⟨j, ?_, hj.2⟩
+  exact ⟨hj.1, fun k hk lk ↦ eq_of_le_of_not_lt lk (maxj k ⟨hk, hj.2.trans lk⟩)⟩
+
+lemma maxCubes_pairwiseDisjoint :
+    (maxCubes s).toSet.PairwiseDisjoint fun i ↦ (i : Set X) := fun i mi j mj hn ↦ by
+  simp only [maxCubes, and_imp, Finset.coe_filter, mem_setOf_eq] at mi mj
+  exact le_or_ge_or_disjoint.resolve_left ((mi.2 j mj.1).mt hn)
+    |>.resolve_left ((mj.2 i mi.1).mt hn.symm)
+
 end Grid

--- a/Carleson/GridStructure.lean
+++ b/Carleson/GridStructure.lean
@@ -37,9 +37,10 @@ class GridStructure
   Grid_subset_ball {i} : coeGrid i ⊆ ball (c i) (4 * D ^ s i) --2.0.10
   small_boundary {i} {t : ℝ} (ht : D ^ (- S - s i) ≤ t) :
     volume.real { x ∈ coeGrid i | infDist x (coeGrid i)ᶜ ≤ t * D ^ s i } ≤ 2 * t ^ κ * volume.real (coeGrid i)
+  coeGrid_measurable {i} : MeasurableSet (coeGrid i)
 
 export GridStructure (range_s_subset Grid_subset_biUnion ball_subset_Grid Grid_subset_ball small_boundary
-  topCube s_topCube c_topCube subset_topCube) -- should `X` be explicit in topCube?
+  topCube s_topCube c_topCube subset_topCube coeGrid_measurable) -- should `X` be explicit in topCube?
 
 attribute [coe] GridStructure.coeGrid
 

--- a/Carleson/GridStructure.lean
+++ b/Carleson/GridStructure.lean
@@ -75,6 +75,11 @@ lemma fundamental_dyadic :
 lemma le_or_disjoint (h : s i ≤ s j) : i ≤ j ∨ Disjoint (i : Set X) (j : Set X) :=
   fundamental_dyadic h |>.imp (⟨·, h⟩) id
 
+lemma le_or_ge_or_disjoint : i ≤ j ∨ j ≤ i ∨ Disjoint (i : Set X) (j : Set X) := by
+  rcases le_or_lt (s i) (s j) with h | h
+  · have := le_or_disjoint h; tauto
+  · have := le_or_disjoint h.le; tauto
+
 namespace Grid
 
 /- not sure whether these should be simp lemmas, but that might be required if we want to

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -1978,6 +1978,7 @@ For each $k\ge 0$, the union of all dyadic cubes
 in $\mathcal{C}(G,k)$ has measure at most $2^{k+1} \mu(G)$ .
 \end{lemma}
 \begin{proof}
+\leanok
 The union of dyadic cubes in $\mathcal{C}(G,k)$
 is contained the union of elements of the set $\mathcal{M}(k)$
 of all dyadic cubes $J$ with


### PR DESCRIPTION
I had to add the property `coeGrid_measurable` of `GridStructure` in order to use `measure_biUnion_finset`, but this property is specified in the blueprint:

> A grid structure $(\mathcal{D}, c, s)$ on $X$ consists of a finite collection $\mathcal{D}$ of pairs $(I, k)$ of **Borel sets** in $X$...