### PR TITLE
Proposition 2.0.1

### DIFF
--- a/Carleson/DiscreteCarleson.lean
+++ b/Carleson/DiscreteCarleson.lean
@@ -10,7 +10,7 @@ noncomputable section
 
 open scoped ShortVariables
 variable {X : Type*} {a : ℕ} {q : ℝ} {K : X → X → ℂ} {σ₁ σ₂ : X → ℤ} {F G : Set X}
-  [MetricSpace X] [ProofData a q K σ₁ σ₂ F G] [TileStructure Q D κ S o]
+  [MetricSpace X] [ProofData a q K σ₁ σ₂ F G] [ts : TileStructure Q D κ S o]
 
 def aux𝓒 (k : ℕ) : Set (Grid X) :=
   {i : Grid X | ∃ j : Grid X, i ≤ j ∧ 2 ^ (- (k : ℤ)) * volume (j : Set X) < volume (G ∩ j) }
@@ -312,12 +312,12 @@ Related, but not quite useful: `Setoid.IsPartition`. -/
 
 /-- The constant used in Proposition 2.0.2,
 which has value `2 ^ (440 * a ^ 3) / (q - 1) ^ 5` in the blueprint. -/
-def C2_0_2 (a : ℝ) (q : ℝ≥0) : ℝ≥0 := C5_1_2 a q + C5_1_2 a q
+def C2_0_2 (a : ℝ) (q : ℝ≥0) : ℝ≥0 := C5_1_2 a q + C5_1_3 a q
 
 lemma C2_0_2_pos : C2_0_2 a nnq > 0 := sorry
 
 theorem discrete_carleson :
-    ∃ G', Measurable G' ∧ 2 * volume G' ≤ volume G ∧
+    ∃ G', MeasurableSet G' ∧ 2 * volume G' ≤ volume G ∧
     ∀ f : X → ℂ, Measurable f → (∀ x, ‖f x‖ ≤ F.indicator 1 x) →
     ∫⁻ x in G \ G', ‖∑ p, T p f x‖₊ ≤
     C2_0_2 a nnq * volume G ^ (1 - q⁻¹) * volume F ^ q⁻¹ := by sorry

--- a/Carleson/FinitaryCarleson.lean
+++ b/Carleson/FinitaryCarleson.lean
@@ -7,10 +7,10 @@ noncomputable section
 
 open scoped ShortVariables
 variable {X : Type*} {a : ℕ} {q : ℝ} {K : X → X → ℂ} {σ₁ σ₂ : X → ℤ} {F G : Set X}
-  [MetricSpace X] [ProofData a q K σ₁ σ₂ F G] [TileStructure Q D κ S o]
+  [MetricSpace X] [ProofData a q K σ₁ σ₂ F G] [ts : TileStructure Q D κ S o]
 
 theorem integrable_tile_sum_operator [ProofData a q K σ₁ σ₂ F G] [TileStructure Q D κ S o]
-    {G' : Set X} (hG' : Measurable G') (h2G' : 2 * volume G' ≤ volume G)
+    {G' : Set X} (hG' : MeasurableSet G') (h2G' : 2 * volume G' ≤ volume G)
     {f : X → ℂ} (hf : Measurable f) (h2f : ∀ x, ‖f x‖ ≤ F.indicator 1 x)
     (hfg' : ∫⁻ x in G \ G', ‖∑' p, T p f x‖₊ ≤
       C2_0_2 a nnq * volume G ^ (1 - q⁻¹) * volume F ^ q⁻¹) {x : X}
@@ -20,7 +20,7 @@ theorem integrable_tile_sum_operator [ProofData a q K σ₁ σ₂ F G] [TileStru
 
 /-- Lemma 4.0.3 -/
 theorem tile_sum_operator [ProofData a q K σ₁ σ₂ F G] [TileStructure Q D κ S o]
-    {G' : Set X} (hG' : Measurable G') (h2G' : 2 * volume G' ≤ volume G)
+    {G' : Set X} (hG' : MeasurableSet G') (h2G' : 2 * volume G' ≤ volume G)
     {f : X → ℂ} (hf : Measurable f) (h2f : ∀ x, ‖f x‖ ≤ F.indicator 1 x)
     (hfg' : ∫⁻ x in G \ G', ‖∑' p, T p f x‖₊ ≤
       C2_0_2 a nnq * volume G ^ (1 - q⁻¹) * volume F ^ q⁻¹) {x : X}
@@ -30,12 +30,23 @@ theorem tile_sum_operator [ProofData a q K σ₁ σ₂ F G] [TileStructure Q D �
   sorry
 
 /- The constant used in Proposition 2.0.1 -/
-def C2_0_1 (a : ℝ) (q : ℝ≥0) : ℝ≥0 := 2 ^ (440 * a ^ 3) / (q - 1) ^ 5
+def C2_0_1 (a : ℝ) (q : ℝ≥0) : ℝ≥0 := C2_0_2 a q
 
-lemma C2_0_1_pos {a : ℝ} {q : ℝ≥0} : C2_0_1 a q > 0 := sorry
+lemma C2_0_1_pos : C2_0_1 a nnq > 0 := C2_0_2_pos
 
-theorem finitary_carleson [ProofData a q K σ₁ σ₂ F G] :
-    ∃ G', Measurable G' ∧ 2 * volume G' ≤ volume G ∧
+theorem finitary_carleson : ∃ G', MeasurableSet G' ∧ 2 * volume G' ≤ volume G ∧
     ∀ f : X → ℂ, Measurable f → (∀ x, ‖f x‖ ≤ F.indicator 1 x) →
     ∫⁻ x in G \ G', ‖∑ s in Icc (σ₁ x) (σ₂ x), ∫ y, Ks s x y * f y * exp (I * Q x y)‖₊ ≤
-    C2_0_1 a nnq * (volume G) ^ (1 - 1 / q) * (volume F) ^ (1 / q) := by sorry
+    C2_0_1 a nnq * (volume G) ^ (1 - q⁻¹) * (volume F) ^ q⁻¹ := by
+  rcases discrete_carleson (ts := ts) with ⟨G', meas_G', h2G', hG'⟩
+  refine ⟨G', meas_G', h2G', fun f meas_f h2f ↦ le_of_eq_of_le ?_ (hG' f meas_f h2f)⟩
+  refine setLIntegral_congr_fun (measurableSet_G.diff meas_G') (ae_of_all volume fun x hx ↦ ?_)
+  have : ∫⁻ (x : X) in G \ G', ‖∑' p : 𝔓 X, T p f x‖₊ ≤
+      (C2_0_2 a nnq) * volume G ^ (1 - q⁻¹) * volume F ^ q⁻¹ := by
+    convert (hG' f meas_f h2f) using 5
+    apply tsum_eq_sum
+    simp_rw [Finset.mem_univ, not_true_eq_false, false_implies, implies_true]
+  simp_rw [tile_sum_operator (X := X) meas_G' h2G' meas_f h2f this hx, mul_sub, exp_sub, mul_div,
+    div_eq_mul_inv, ← smul_eq_mul (a' := _⁻¹), integral_smul_const, ← Finset.sum_smul, nnnorm_smul]
+  suffices ‖(cexp (I * ((Q x) x : ℂ)))⁻¹‖₊ = 1 by rw [this, mul_one]
+  simp [← coe_eq_one, mul_comm I]

--- a/Carleson/FinitaryCarleson.lean
+++ b/Carleson/FinitaryCarleson.lean
@@ -38,15 +38,15 @@ theorem finitary_carleson : ∃ G', MeasurableSet G' ∧ 2 * volume G' ≤ volum
     ∀ f : X → ℂ, Measurable f → (∀ x, ‖f x‖ ≤ F.indicator 1 x) →
     ∫⁻ x in G \ G', ‖∑ s in Icc (σ₁ x) (σ₂ x), ∫ y, Ks s x y * f y * exp (I * Q x y)‖₊ ≤
     C2_0_1 a nnq * (volume G) ^ (1 - q⁻¹) * (volume F) ^ q⁻¹ := by
-  rcases discrete_carleson (ts := ts) with ⟨G', meas_G', h2G', hG'⟩
-  refine ⟨G', meas_G', h2G', fun f meas_f h2f ↦ le_of_eq_of_le ?_ (hG' f meas_f h2f)⟩
-  refine setLIntegral_congr_fun (measurableSet_G.diff meas_G') (ae_of_all volume fun x hx ↦ ?_)
+  rcases discrete_carleson (ts := ts) with ⟨G', hG', h2G', hfG'⟩
+  refine ⟨G', hG', h2G', fun f meas_f h2f ↦ le_of_eq_of_le ?_ (hfG' f meas_f h2f)⟩
+  refine setLIntegral_congr_fun (measurableSet_G.diff hG') (ae_of_all volume fun x hx ↦ ?_)
   have : ∫⁻ (x : X) in G \ G', ‖∑' p : 𝔓 X, T p f x‖₊ ≤
       (C2_0_2 a nnq) * volume G ^ (1 - q⁻¹) * volume F ^ q⁻¹ := by
-    convert (hG' f meas_f h2f) using 5
+    convert (hfG' f meas_f h2f) using 5
     apply tsum_eq_sum
     simp_rw [Finset.mem_univ, not_true_eq_false, false_implies, implies_true]
-  simp_rw [tile_sum_operator (X := X) meas_G' h2G' meas_f h2f this hx, mul_sub, exp_sub, mul_div,
-    div_eq_mul_inv, ← smul_eq_mul (a' := _⁻¹), integral_smul_const, ← Finset.sum_smul, nnnorm_smul]
+  simp_rw [tile_sum_operator hG' h2G' meas_f h2f this hx, mul_sub, exp_sub, mul_div, div_eq_mul_inv,
+    ← smul_eq_mul (a' := _⁻¹), integral_smul_const, ← Finset.sum_smul, nnnorm_smul]
   suffices ‖(cexp (I * ((Q x) x : ℂ)))⁻¹‖₊ = 1 by rw [this, mul_one]
   simp [← coe_eq_one, mul_comm I]


### PR DESCRIPTION
Prove `finitary_carleson` (Proposition 2.0.1).

Also clean up a few apparent typos:

* There were several instances of `Measurable G'` which I changed to `MeasurableSet G'`.
* I changed the definition of `C2_0_1` so that it's defined to be equal to `C2_0_2`. (The constants in the blueprint are not equal, but this appears to be a typo.)
* I changed the definition of `C2_0_2` from `C5_1_2 a q + C5_1_2 a q` to `C5_1_2 a q + C5_1_3 a q`.
* I changed `1/q` in the statement of `finitary_carleson` to `q⁻¹` for consistency with `discrete_carleson`.