### PR TITLE
Prove integrable_tile_sum_operator

### DIFF
--- a/Carleson/Defs.lean
+++ b/Carleson/Defs.lean
@@ -239,6 +239,8 @@ open Function
 /-- The constant used twice in the definition of the Calderon-Zygmund kernel. -/
 @[simp] def C_K (a : ℝ) : ℝ := 2 ^ a ^ 3
 
+lemma C_K_pos (a : ℝ) : 0 < C_K a := by unfold C_K; positivity
+
 /-- `K` is a one-sided Calderon-Zygmund kernel
 In the formalization `K x y` is defined everywhere, even for `x = y`. The assumptions on `K` show
 that `K x x = 0`. -/
@@ -340,6 +342,10 @@ end ShortVariables
 open scoped ShortVariables
 variable {X : Type*} {a : ℕ} {q : ℝ} {K : X → X → ℂ} {σ₁ σ₂ : X → ℤ} {F G : Set X}
   [MetricSpace X] [ProofData a q K σ₁ σ₂ F G]
+
+lemma one_lt_D : 1 < (D : ℝ) := by
+  unfold defaultD
+  exact_mod_cast one_lt_pow Nat.one_lt_two (by nlinarith [four_le_a X])
 
 lemma one_le_D : 1 ≤ (D : ℝ) := by
   rw [← Nat.cast_one, Nat.cast_le, defaultD, ← pow_zero 2]

--- a/Carleson/FinitaryCarleson.lean
+++ b/Carleson/FinitaryCarleson.lean
@@ -9,14 +9,17 @@ open scoped ShortVariables
 variable {X : Type*} {a : ℕ} {q : ℝ} {K : X → X → ℂ} {σ₁ σ₂ : X → ℤ} {F G : Set X}
   [MetricSpace X] [ProofData a q K σ₁ σ₂ F G] [TileStructure Q D κ S o]
 
-theorem integrable_tile_sum_operator [ProofData a q K σ₁ σ₂ F G] [TileStructure Q D κ S o]
-    {G' : Set X} (hG' : MeasurableSet G') (h2G' : 2 * volume G' ≤ volume G)
-    {f : X → ℂ} (hf : Measurable f) (h2f : ∀ x, ‖f x‖ ≤ F.indicator 1 x)
-    (hfg' : ∫⁻ x in G \ G', ‖∑' p, T p f x‖₊ ≤
-      C2_0_2 a nnq * volume G ^ (1 - q⁻¹) * volume F ^ q⁻¹) {x : X}
-    (hx : x ∈ G \ G') {s : ℤ} (hs : Icc (σ₁ x) (σ₂ x)) :
+theorem integrable_tile_sum_operator
+    {f : X → ℂ} (hf : Measurable f) (h2f : ∀ x, ‖f x‖ ≤ F.indicator 1 x) {x : X} {s : ℤ} :
     Integrable fun y ↦ Ks s x y * f y * exp (I * (Q x y - Q x x)) := by
-  sorry
+  simp_rw [mul_assoc, mul_comm (Ks s x _)]
+  refine integrable_Ks_x (one_lt_D (X := X)) |>.bdd_mul ?_ ⟨1, fun y ↦ ?_⟩
+  · exact hf.mul ((measurable_ofReal.comp (map_continuous (Q x)).measurable |>.sub
+      measurable_const).const_mul I).cexp |>.aestronglyMeasurable
+  · rw [norm_mul, ← one_mul 1]
+    gcongr
+    · exact le_trans (h2f y) (F.indicator_le_self' (by simp) y)
+    · rw_mod_cast [mul_comm, norm_eq_abs, abs_exp_ofReal_mul_I]
 
 /-- Lemma 4.0.3 -/
 theorem tile_sum_operator [ProofData a q K σ₁ σ₂ F G] [TileStructure Q D κ S o]

--- a/Carleson/Psi.lean
+++ b/Carleson/Psi.lean
@@ -632,7 +632,7 @@ lemma norm_Ks_sub_Ks_le {s : ℤ} {x y y' : X} (hK : Ks s x y ≠ 0) :
 
 /-- The function `y ↦ Ks s x y` is integrable. -/
 lemma integrable_Ks_x {s : ℤ} {x : X} (hD : 1 < (D : ℝ)) : Integrable (Ks s x) := by
-  /- Define a function `K₀` that is bounded and equal to `K s x` on the support of
+  /- Define a measurable, bounded function `K₀` that is equal to `K x` on the support of
   `y ↦ ψ (D ^ (-s) * dist x y)`, so that `Ks s x y = K₀ y * ψ (D ^ (-s) * dist x y)`. -/
   let K₀ (y : X) : ℂ := ite (dist x y ≤ D ^ s / (4 * D)) 0 (K x y)
   have : Ks s x = fun y ↦ K₀ y * (ψ (D ^ (-s) * dist x y) : ℂ) := by
@@ -645,7 +645,7 @@ lemma integrable_Ks_x {s : ℤ} {x : X} (hD : 1 < (D : ℝ)) : Integrable (Ks s 
   rw [this]
   refine Integrable.bdd_mul ?_ (Measurable.aestronglyMeasurable ?_) ?_
   · apply Continuous.integrable_of_hasCompactSupport
-    · exact Complex.continuous_ofReal.comp <| continuous_ψ.comp <| continuous_const.mul <|
+    · exact continuous_ofReal.comp <| continuous_ψ.comp <| continuous_const.mul <|
         continuous_const.dist continuous_id
     · apply HasCompactSupport.of_support_subset_isCompact (isCompact_closedBall x (D ^ s / 2))
       intro y hy
@@ -658,12 +658,12 @@ lemma integrable_Ks_x {s : ℤ} {x : X} (hD : 1 < (D : ℝ)) : Integrable (Ks s 
     simp_rw [dist_comm x _, closedBall]
   · refine ⟨C_K a / volume.real (ball x ( D ^ s / (4 * D))), fun y ↦ ?_⟩
     by_cases hy : dist x y ≤ D ^ s / (4 * D)
-    · simp only [hy, ↓reduceIte, norm_zero, C_K, K₀]
+    · simp only [hy, reduceIte, norm_zero, C_K, K₀]
       positivity
     · simp only [hy, reduceIte, K₀]
       apply (norm_K_le_vol_inv x y).trans
       gcongr
       · exact (C_K_pos a).le
-      · exact Metric.measure_ball_pos_real x _ (div_pos (Ds0 X s) (fourD0 hD))
+      · exact measure_ball_pos_real x _ (div_pos (Ds0 X s) (fourD0 hD))
       · exact ENNReal.toReal_mono (measure_ball_ne_top x (dist x y)) <|
           measure_mono <| ball_subset_ball (lt_of_not_ge hy).le

--- a/Carleson/Psi.lean
+++ b/Carleson/Psi.lean
@@ -82,6 +82,10 @@ lemma ψ_formula₄ {x : ℝ} (hx : x ≥ 1 / 2) : ψ D x = 0 :=
 lemma psi_zero : ψ D 0 = 0 :=
   ψ_formula₀ (div_nonneg one_pos.le <| mul_nonneg four_pos.le (Nat.cast_nonneg D))
 
+lemma continuous_ψ : Continuous (ψ D) :=
+  continuous_const.max <| continuous_const.min <| ((continuous_mul_left _).sub continuous_const).min
+    (continuous_const.sub (continuous_mul_left 4))
+
 lemma support_ψ : support (ψ D) = Ioo (4 * D : ℝ)⁻¹ 2⁻¹ := by
   ext x
   by_cases hx₀ : x ≤ 1 / (4 * D)
@@ -625,3 +629,41 @@ lemma norm_Ks_sub_Ks_le {s : ℤ} {x y y' : X} (hK : Ks s x y ≠ 0) :
   by_cases h : 2 * dist y y' ≤ dist x y
   · exact norm_Ks_sub_Ks_le₀ hK h
   · exact norm_Ks_sub_Ks_le₁ hK h
+
+/-- The function `y ↦ Ks s x y` is integrable. -/
+lemma integrable_Ks_x {s : ℤ} {x : X} (hD : 1 < (D : ℝ)) : Integrable (Ks s x) := by
+  /- Define a function `K₀` that is bounded and equal to `K s x` on the support of
+  `y ↦ ψ (D ^ (-s) * dist x y)`, so that `Ks s x y = K₀ y * ψ (D ^ (-s) * dist x y)`. -/
+  let K₀ (y : X) : ℂ := ite (dist x y ≤ D ^ s / (4 * D)) 0 (K x y)
+  have : Ks s x = fun y ↦ K₀ y * (ψ (D ^ (-s) * dist x y) : ℂ) := by
+    ext y
+    by_cases hy : dist x y ≤ D ^ s / (4 * D)
+    · suffices D ^ (-s) * dist x y ≤ 1 / (4 * D) by simp [-defaultD, -zpow_neg, Ks, ψ_formula₀ this]
+      apply le_of_le_of_eq <| (mul_le_mul_left (zpow_pos_of_pos (one_pos.trans (D1 X)) (-s))).2 hy
+      field_simp
+    · simp [-defaultD, Ks, K₀, hy]
+  rw [this]
+  refine Integrable.bdd_mul ?_ (Measurable.aestronglyMeasurable ?_) ?_
+  · apply Continuous.integrable_of_hasCompactSupport
+    · exact Complex.continuous_ofReal.comp <| continuous_ψ.comp <| continuous_const.mul <|
+        continuous_const.dist continuous_id
+    · apply HasCompactSupport.of_support_subset_isCompact (isCompact_closedBall x (D ^ s / 2))
+      intro y hy
+      rw [mem_support, ne_eq, ofReal_eq_zero, ← ne_eq, ← mem_support, support_ψ (D1 X)] at hy
+      replace hy := le_of_lt hy.2
+      rw [zpow_neg, mul_comm, ← div_eq_mul_inv, _root_.div_le_iff (Ds0 X s)] at hy
+      rwa [mem_closedBall, dist_comm, div_eq_mul_inv, mul_comm]
+  · refine Measurable.ite ?_ measurable_const measurable_K_right.of_uncurry_left
+    convert measurableSet_closedBall (x := x) (ε := D ^ s / (4 * D))
+    simp_rw [dist_comm x _, closedBall]
+  · refine ⟨C_K a / volume.real (ball x ( D ^ s / (4 * D))), fun y ↦ ?_⟩
+    by_cases hy : dist x y ≤ D ^ s / (4 * D)
+    · simp only [hy, ↓reduceIte, norm_zero, C_K, K₀]
+      positivity
+    · simp only [hy, reduceIte, K₀]
+      apply (norm_K_le_vol_inv x y).trans
+      gcongr
+      · exact (C_K_pos a).le
+      · exact Metric.measure_ball_pos_real x _ (div_pos (Ds0 X s) (fourD0 hD))
+      · exact ENNReal.toReal_mono (measure_ball_ne_top x (dist x y)) <|
+          measure_mono <| ball_subset_ball (lt_of_not_ge hy).le

--- a/Carleson/Psi.lean
+++ b/Carleson/Psi.lean
@@ -656,7 +656,7 @@ lemma integrable_Ks_x {s : ℤ} {x : X} (hD : 1 < (D : ℝ)) : Integrable (Ks s 
   · refine Measurable.ite ?_ measurable_const measurable_K_right.of_uncurry_left
     convert measurableSet_closedBall (x := x) (ε := D ^ s / (4 * D))
     simp_rw [dist_comm x _, closedBall]
-  · refine ⟨C_K a / volume.real (ball x ( D ^ s / (4 * D))), fun y ↦ ?_⟩
+  · refine ⟨C_K a / volume.real (ball x (D ^ s / (4 * D))), fun y ↦ ?_⟩
     by_cases hy : dist x y ≤ D ^ s / (4 * D)
     · simp only [hy, reduceIte, norm_zero, C_K, K₀]
       positivity


### PR DESCRIPTION
Prove `integrable_tile_sum_operator`.

As an intermediate step, prove that `y ↦ Ks s x y` is integrable.