### PR TITLE
Speed up CI 

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -57,6 +57,7 @@ jobs:
             .lake/build/doc/Std
             .lake/build/doc/Mathlib
             .lake/build/doc/declarations
+            .lake/build/doc/find
             .lake/build/doc/*.*
             !.lake/build/doc/declarations/declaration-data-Carleson*
           key: MathlibDoc-3

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -58,7 +58,7 @@ jobs:
             .lake/build/doc/Mathlib
             .lake/build/doc/declarations
             !.lake/build/doc/declarations/declaration-data-Carleson*
-          key: ${{ hashFiles('lake-manifest.json') }}
+          key: MathlibDoc-${{ hashFiles('lake-manifest.json') }}
           #restore-keys: MathlibDoc-
 
       - name: Build project documentation
@@ -92,10 +92,10 @@ jobs:
           sudo chown -R runner docs
           cp -r .lake/build/doc docs/docs
 
-      - name: Remove lake files from documentation in `docs/docs`
-        run: |
-          find docs/docs -name "*.trace" -delete
-          find docs/docs -name "*.hash" -delete
+      # - name: Remove lake files from documentation in `docs/docs`
+      #   run: |
+      #     find docs/docs -name "*.trace" -delete
+      #     find docs/docs -name "*.hash" -delete
 
       - name: Bundle dependencies
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -58,7 +58,7 @@ jobs:
             .lake/build/doc/Mathlib
             .lake/build/doc/declarations
             !.lake/build/doc/declarations/declaration-data-Carleson*
-          key: MathlibDoc-1
+          key: MathlibDoc-2
           #${{ hashFiles('lake-manifest.json') }}
           #restore-keys: MathlibDoc-
 
@@ -123,5 +123,5 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v1
 
-      # - name: Make sure the cache works
-      #   run: mv docs/docs .lake/build/doc
+      - name: Make sure the cache works
+        run: mv docs/docs .lake/build/doc

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -60,7 +60,7 @@ jobs:
             .lake/build/doc/find
             .lake/build/doc/*.*
             !.lake/build/doc/declarations/declaration-data-Carleson*
-          key: MathlibDoc-3
+          key: MathlibDoc-4
           #${{ hashFiles('lake-manifest.json') }}
           #restore-keys: MathlibDoc-
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -57,8 +57,9 @@ jobs:
             .lake/build/doc/Std
             .lake/build/doc/Mathlib
             .lake/build/doc/declarations
+            .lake/build/doc/*.*
             !.lake/build/doc/declarations/declaration-data-Carleson*
-          key: MathlibDoc-2
+          key: MathlibDoc-3
           #${{ hashFiles('lake-manifest.json') }}
           #restore-keys: MathlibDoc-
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - master
-      - workflow
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -60,9 +59,8 @@ jobs:
             .lake/build/doc/find
             .lake/build/doc/*.*
             !.lake/build/doc/declarations/declaration-data-Carleson*
-          key: MathlibDoc-5
-          #${{ hashFiles('lake-manifest.json') }}
-          #restore-keys: MathlibDoc-
+          key: MathlibDoc-${{ hashFiles('lake-manifest.json') }}
+          restore-keys: MathlibDoc-
 
       - name: Build project documentation
         run: ~/.elan/bin/lake -Kenv=dev build Carleson:docs
@@ -125,5 +123,5 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v1
 
-      - name: Make sure the cache works
-        run: mv docs/docs .lake/build/doc
+      # - name: Make sure the cache works
+      #   run: mv docs/docs .lake/build/doc

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -58,7 +58,8 @@ jobs:
             .lake/build/doc/Mathlib
             .lake/build/doc/declarations
             !.lake/build/doc/declarations/declaration-data-Carleson*
-          key: MathlibDoc-${{ hashFiles('lake-manifest.json') }}
+          key: MathlibDoc-1
+          #${{ hashFiles('lake-manifest.json') }}
           #restore-keys: MathlibDoc-
 
       - name: Build project documentation
@@ -122,5 +123,5 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v1
 
-      - name: Make sure the cache works
-        run: mv docs/docs .lake/build/doc
+      # - name: Make sure the cache works
+      #   run: mv docs/docs .lake/build/doc

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -60,7 +60,7 @@ jobs:
             .lake/build/doc/find
             .lake/build/doc/*.*
             !.lake/build/doc/declarations/declaration-data-Carleson*
-          key: MathlibDoc-4
+          key: MathlibDoc-5
           #${{ hashFiles('lake-manifest.json') }}
           #restore-keys: MathlibDoc-
 
@@ -95,10 +95,10 @@ jobs:
           sudo chown -R runner docs
           cp -r .lake/build/doc docs/docs
 
-      # - name: Remove lake files from documentation in `docs/docs`
-      #   run: |
-      #     find docs/docs -name "*.trace" -delete
-      #     find docs/docs -name "*.hash" -delete
+      - name: Remove lake files from documentation in `docs/docs`
+        run: |
+          find docs/docs -name "*.trace" -delete
+          find docs/docs -name "*.hash" -delete
 
       - name: Bundle dependencies
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+      - workflow
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -57,8 +58,8 @@ jobs:
             .lake/build/doc/Mathlib
             .lake/build/doc/declarations
             !.lake/build/doc/declarations/declaration-data-Carleson*
-          key: MathlibDoc-${{ hashFiles('lake-manifest.json') }}
-          restore-keys: MathlibDoc-
+          key: ${{ hashFiles('lake-manifest.json') }}
+          #restore-keys: MathlibDoc-
 
       - name: Build project documentation
         run: ~/.elan/bin/lake -Kenv=dev build Carleson:docs
@@ -86,15 +87,15 @@ jobs:
       - name: Check declarations
         run: ~/.elan/bin/lake exe checkdecls blueprint/lean_decls
 
-      - name: Remove lake files from documentation
-        run: |
-          find .lake/build/doc -name "*.trace" -delete
-          find .lake/build/doc -name "*.hash" -delete
-
       - name: Copy documentation to `docs/docs`
         run: |
           sudo chown -R runner docs
           cp -r .lake/build/doc docs/docs
+
+      - name: Remove lake files from documentation in `docs/docs`
+        run: |
+          find docs/docs -name "*.trace" -delete
+          find docs/docs -name "*.hash" -delete
 
       - name: Bundle dependencies
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This PR ensures correct docs caching and minimization of disk space usage
- [x] Fix "Cache mathlib documentation" step (from 12 to 2 minutes)
- [x] Fix "Remove lake files from documentation" (remove from GitHub page but not from cache: 378MB to 369MB)