### PR TITLE
Prove Lemma 5.2.8

### DIFF
--- a/Carleson/DiscreteCarleson.lean
+++ b/Carleson/DiscreteCarleson.lean
@@ -11,7 +11,7 @@ noncomputable section
 
 open scoped ShortVariables
 variable {X : Type*} {a : ℕ} {q : ℝ} {K : X → X → ℂ} {σ₁ σ₂ : X → ℤ} {F G : Set X}
-  [MetricSpace X] [ProofData a q K σ₁ σ₂ F G] [ts : TileStructure Q D κ S o]
+  [MetricSpace X] [ProofData a q K σ₁ σ₂ F G] [TileStructure Q D κ S o]
 
 def aux𝓒 (k : ℕ) : Set (Grid X) :=
   {i : Grid X | ∃ j : Grid X, i ≤ j ∧ 2 ^ (- (k : ℤ)) * volume (j : Set X) < volume (G ∩ j) }

--- a/Carleson/DiscreteCarleson.lean
+++ b/Carleson/DiscreteCarleson.lean
@@ -780,8 +780,7 @@ private lemma ball_eq_ball : ball_(u) = ball_(u') := by
 
 private lemma disjoint_balls (h : u' ≠ u'') :
     Disjoint (ball_(u) (𝒬 u') 0.2) (ball_(u) (𝒬 u'') 0.2) := by
-  nth_rewrite 1 [ball_eq_ball hu hu']
-  rw [ball_eq_ball hu hu'']
+  nth_rewrite 1 [ball_eq_ball hu hu', ball_eq_ball hu hu'']
   convert cball_disjoint h (𝓘_eq_𝓘 hu' hu'') using 2 <;> norm_num
 
 private lemma mem_big_ball : 𝒬 u' ∈ big_ball m u := by

--- a/Carleson/DiscreteCarleson.lean
+++ b/Carleson/DiscreteCarleson.lean
@@ -798,7 +798,7 @@ variable (m) (u : 𝔓 X) in
 private lemma balls_cover_big_ball : CoveredByBalls (big_ball m u) (defaultA a ^ 9) 0.2 :=
   BallsCoverBalls.pow_mul (fun _ ↦ CompatibleFunctions.ballsCoverBalls) (𝒬 m)
 
-private lemma 𝒬_injOn_𝔘m : InjOn (𝒬 (X := X)) (𝔘 k n j x m).toSet :=
+private lemma 𝒬_injOn_𝔘m : InjOn 𝒬 (𝔘 k n j x m).toSet :=
   fun _ hu _ hu' h ↦ 𝒬_inj h (𝓘_eq_𝓘 hu hu')
 
 private lemma card_𝔘m_le : (𝔘 k n j x m).card ≤ (defaultA a) ^ 9 := by

--- a/Carleson/DiscreteCarleson.lean
+++ b/Carleson/DiscreteCarleson.lean
@@ -854,7 +854,7 @@ private lemma indicator_le : ∀ u ∈ (𝔘₁ k n j).toFinset.filter (x ∈ �
   simp only [𝔘₁, Finset.mem_filter, toFinset_setOf] at hu
   apply le_of_le_of_eq hu.1.2.1.1.2
   simp only [Finset.coe_filter, mem_toFinset, 𝔐', Finset.card_eq_sum_ones]
-  refine Finset.sum_congr (by congr) (fun m hm ↦ ?_)
+  refine Finset.sum_congr rfl (fun m hm ↦ ?_)
   simp only [TileLike.le_def, smul_fst, Finset.mem_filter] at hm
   simp [hm.2.2.1.1 hx]
 

--- a/Carleson/Forest.lean
+++ b/Carleson/Forest.lean
@@ -33,6 +33,13 @@ lemma stackSize_mono (h : C ⊆ C') : stackSize C x ≤ stackSize C' x := by
   apply Finset.sum_le_sum_of_subset (fun x ↦ ?_)
   simp [iff_true_intro (@h x)]
 
+-- Simplify the cast of `stackSize C x` from `ℕ` to `ℝ`
+lemma stackSize_real (C : Set (𝔓 X)) (x : X) : (stackSize C x : ℝ) =
+    ∑ p ∈ Finset.univ.filter (· ∈ C), (𝓘 p : Set X).indicator (1 : X → ℝ) x := by
+  rw [stackSize, Nat.cast_sum]
+  refine Finset.sum_congr rfl (fun u _ ↦ ?_)
+  by_cases hx : x ∈ (𝓘 u : Set X) <;> simp [hx]
+
 /-! We might want to develop some API about partitioning a set.
 But maybe `Set.PairwiseDisjoint` and `Set.Union` are enough.
 Related, but not quite useful: `Setoid.IsPartition`. -/

--- a/Carleson/TileStructure.lean
+++ b/Carleson/TileStructure.lean
@@ -75,6 +75,10 @@ notation "ball_(" 𝔭 ")" => @ball (WithFunctionDistance (𝔠 𝔭) (D ^ 𝔰 
 @[simp] lemma cball_subset {p : 𝔓 X} : ball_(p) (𝒬 p) 5⁻¹ ⊆ Ω p := TileStructure.cball_subset
 @[simp] lemma subset_cball {p : 𝔓 X} : Ω p ⊆ ball_(p) (𝒬 p) 1 := TileStructure.subset_cball
 
+lemma cball_disjoint {p p' : 𝔓 X} (h : p ≠ p') (hp : 𝓘 p = 𝓘 p') :
+    Disjoint (ball_(p) (𝒬 p) 5⁻¹) (ball_(p') (𝒬 p') 5⁻¹) :=
+  disjoint_of_subset cball_subset cball_subset (disjoint_Ω h hp)
+
 /-- The set `E` defined in Proposition 2.0.2. -/
 def E (p : 𝔓 X) : Set X :=
   { x ∈ 𝓘 p | Q x ∈ Ω p ∧ 𝔰 p ∈ Icc (σ₁ x) (σ₂ x) }
@@ -132,6 +136,10 @@ lemma toTileLike_le_smul : toTileLike p ≤ smul 5⁻¹ p := by
   simp [TileLike.le_def, cball_subset (p := p)]
 
 lemma 𝒬_mem_Ω : 𝒬 p ∈ Ω p := cball_subset <| mem_ball_self <| by norm_num
+
+lemma 𝒬_inj {p' : 𝔓 X} (h : 𝒬 p = 𝒬 p') (h𝓘 : 𝓘 p = 𝓘 p') : p = p' := by
+  contrapose! h
+  exact fun h𝒬 ↦ (not_disjoint_iff.2 ⟨𝒬 p, 𝒬_mem_Ω, h𝒬 ▸ 𝒬_mem_Ω⟩) (disjoint_Ω h h𝓘)
 
 lemma toTileLike_injective : Injective (fun p : 𝔓 X ↦ toTileLike p) := by
   intros p p' h

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -2267,10 +2267,11 @@ As the center of $B'$ can be in at most one of the disjoint balls
 $B_{\fu}(\fcc(\fu),0.2)$ and
 $B_{\fu}(\fcc(\fu'),0.2)$,
 the ball $B'$ can contain at most
-one of the points $\fu$, $\fu'$.
+one of the points $\fcc(\fu)$, $\fcc(\fu')$.
 
-Hence the set $\fU(\mathfrak{m})$ has at most
-$2^{9a}$ many elements.
+Hence the image of $\fU(\mathfrak{m})$ under $\fcc$ has at most
+$2^{9a}$ elements; since $\fcc$ is injective on $\fU(\mathfrak{m})$,
+the same is true of $\fU(\mathfrak{m})$.
 Inserting this into \eqref{usumbymsum} proves the lemma.
 \end{proof}
 


### PR DESCRIPTION
Prove Lemma 5.2.8.

Notes:

* I changed the statement of Lemma 5.2.8 to use `ℝ` instead of `ℕ`, and changed the exponent `9 * a - j` to use subtraction in  `ℤ` instead of `ℕ`. I think the lemma is only used to prove an inequality in `ℝ≥0`, so this shouldn't cause any problems.
* I corrected a minor error in the blueprint's proof, where it referred to `u` and `u'` as possible elements of `B'`, rather than `𝒬 u` and `𝒬 u'` (and then needed an extra injectivity argument to finish the proof).