### PR TITLE
Remove unnecessary step in update_mathlib scripts

### DIFF
--- a/scripts/update_mathlib.bat
+++ b/scripts/update_mathlib.bat
@@ -1,4 +1,3 @@
 rem Update mathlib and the lean toolchain.
 curl -L https://raw.githubusercontent.com/leanprover-community/mathlib4/master/lean-toolchain -o lean-toolchain
 lake -Kenv=dev update rem The `-Kenv=dev` is making sure we also update doc-gen
-lake exe cache get

--- a/scripts/update_mathlib.sh
+++ b/scripts/update_mathlib.sh
@@ -3,4 +3,3 @@
 # Update mathlib and the lean toolchain.
 curl -L https://raw.githubusercontent.com/leanprover-community/mathlib4/master/lean-toolchain -o lean-toolchain
 lake -R -Kenv=dev update # The `-R -Kenv=dev` is making sure we also update doc-gen and other dependencies
-lake exe cache get


### PR DESCRIPTION
Mathlib currently fetches the cache as part of [its post-update hook](https://github.com/leanprover-community/mathlib4/blob/ede775853cc9f271a9fcf1475dec887f82544e30/lakefile.lean#L166-L176). Thus, calling `lake exe cache get` after a mathlib update is unnecessary.