### PR TITLE
chore: small clean-ups in the Hölder-van der Corput file

### DIFF
--- a/Carleson/HolderVanDerCorput.lean
+++ b/Carleson/HolderVanDerCorput.lean
@@ -11,16 +11,16 @@ noncomputable section
 open Set MeasureTheory Metric Function Complex Bornology TileStructure
 open scoped NNReal ENNReal ComplexConjugate
 
-/-- `L R t x y` is `L(x, y)` in the proof of Lemma 8.0.1. -/
-def cutoff (R t : ℝ) (x y : X) : ℝ :=
-  max 0 (1 - dist x y / (t * R))
+/-- `cutoff R t x y` is `L(x, y)` in the proof of Lemma 8.0.1. -/
+def cutoff (R t : ℝ) (x y : X) : ℝ≥0 :=
+  ⟨max 0 (1 - dist x y / (t * R)), by positivity⟩
 
 /-- The constant occurring in Lemma 8.0.1. -/
 def C8_0_1 (a : ℝ) (t : ℝ≥0) : ℝ≥0 := ⟨2 ^ (4 * a) * t ^ (- (a + 1)), by positivity⟩
 
 /-- `ϕ ↦ \tilde{ϕ}` in the proof of Lemma 8.0.1. -/
 def holderApprox (R t : ℝ) (ϕ : X → ℂ) (x : X) : ℂ :=
-  (∫ y, cutoff R t x y * ϕ y) / ∫ y, cutoff R t x y
+  (∫ y, cutoff R t x y * ϕ y) / (∫⁻ y, cutoff R t x y).toReal
 
 /-- Part of Lemma 8.0.1. -/
 lemma support_holderApprox_subset {z : X} {R t : ℝ} (hR : 0 < R) {C : ℝ≥0}

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -6231,15 +6231,16 @@ We have for $y\in B(x, 2^{-1}tR)$ that
     \end{equation}
 Hence
 \begin{equation}
-        \int L(x,y) \, \mathrm{d}\mu(y)\ge 2^{-1}\mu(B(x, 2^{-1}Rt))\, .
-    \end{equation}
+    \int L(x,y) \, \mathrm{d}\mu(y)\ge 2^{-1}\mu(B(x, 2^{-1}tR))\, .
+\end{equation}
  Let $n$ be the smallest integer so that
  \begin{equation}\label{2nt1}
      2^nt\ge 1\, .
- \end{equation} Iterating $n+2$ times the doubling condition \eqref{doublingx}, we obtain
-      \begin{equation}\label{eql32}
-        \int L(x,y) \, \mathrm{d}\mu(y)\ge 2^{-1-a(n+2)}\mu(B(x, 2R))\, .
-    \end{equation}
+ \end{equation}
+ Iterating $n+2$ times the doubling condition \eqref{doublingx}, we obtain
+ \begin{equation}\label{eql32}
+    \int L(x,y) \, \mathrm{d}\mu(y)\ge 2^{-1-a(n+2)}\mu(B(x, 2R))\, .
+ \end{equation}
 
 Now define
     $$


### PR DESCRIPTION
- adjust order (tR instead of Rt) in the blueprint, for consistency
- improve LaTeX indentation a bit
- make  NNReal-valued instead; fix a typo in its doc-string