### PR TITLE
chore: enable two uncontroversial mathlib linters

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -6,12 +6,6 @@ jobs:
     name: Lint style
     runs-on: ubuntu-latest
     steps:
-      # Check for long lines in .lean files and report if any lines exceed 100 characters
-      - name: Check for long lines
-        if: always()
-        run: |
-          ! (find Carleson -name "*.lean" -type f -exec grep -E -H -n '^.{101,}$' {} \; | grep -v -E 'https?://')
-
       - name: Don't 'import Mathlib', use precise imports
         if: always()
         run: |

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -5,6 +5,10 @@ defaultTargets = ["Carleson"]
 relaxedAutoImplicit = false
 pp.unicode.fun = true
 autoImplicit = false
+# This has lots of false positives currently.
+linter.style.longLine = false
+linter.oldObtain = true
+linter.refine = true
 
 [[require]]
 name = "mathlib"


### PR DESCRIPTION
And disable the 'long lines check' in CI, as it doesn't seem to work. The corresponding mathlib linter finds *many* violations. If desired, it seems easier to just enable that linter instead.