### PR TITLE
chore: label sorries from bumping to 4.13.0

### DIFF
--- a/Carleson/FinitaryCarleson.lean
+++ b/Carleson/FinitaryCarleson.lean
@@ -52,7 +52,7 @@ lemma exists_Grid {x : X} (hx : x ∈ G) {s : ℤ} (hs : s ∈ (Icc (σ₁ x) (�
     ∃ I : GridStructure.Grid X (defaultA a), GridStructure.s I = s ∧ x ∈ I := by
   have DS : (D : ℝ) ^ S = (D : ℝ) ^ (S : ℤ) := rfl
   have : x ∈ ball o (D ^ S / 4) := ProofData.G_subset hx
-  sorry /- TODO fix proof, was
+  sorry /- TODO(bump-4.13): fix proof, was
   rw [← c_topCube (X := X), DS, ← s_topCube (X := X)] at this
   have x_mem_topCube := ball_subset_Grid this
   by_cases hS : s = S -- Handle separately b/c `Grid_subset_biUnion`, as stated, doesn't cover `s=S`

--- a/Carleson/ForestOperator/RemainingTiles.lean
+++ b/Carleson/ForestOperator/RemainingTiles.lean
@@ -100,13 +100,14 @@ lemma square_function_count (hJ : J ∈ 𝓙₆ t u₁) (s' : ℤ) :
   have est₁ (s₀ x) : (𝒟 s₀ x).toFinset.card ≤ (defaultA a) ^ 7 := by
     apply Nat.cast_le (α := ℝ).mp
     have : 0 < volume.real (ball x (9 * ↑D ^ s₀)) :=
-      -- TODO fix: last sorry was finiteness; related to max application depth?
-      ENNReal.toReal_pos (measure_ball_pos _ _ (by simp; positivity)).ne' (measure_ball_ne_top _ _) --finiteness
+      -- TODO(bump-4.13): `measure_ball_ne_top` was `by finiteness`
+      ENNReal.toReal_pos (measure_ball_pos _ _ (by simp; positivity)).ne' (measure_ball_ne_top _ _)
     refine le_of_mul_le_mul_right (a := volume.real (ball x (9 * D ^ s₀))) ?_ this
     transitivity (defaultA a) ^ 7 * ∑ I ∈ 𝒟 s₀ x, volume.real (ball (c I) (D ^ s I / 4))
     · rw [Finset.mul_sum, ← nsmul_eq_mul, ← Finset.sum_const]
       refine Finset.sum_le_sum fun I hI ↦ ?_
       simp only [mem_toFinset] at hI
+      -- TODO(bump-4.13): `measure_ball_ne_top` was `by finiteness`
       refine (measureReal_mono ?_ (measure_ball_ne_top _ _)).trans measure_ball_le_pow_two
       apply ball_subset_ball'
       refine (add_le_add le_rfl hI.1.le).trans ?_
@@ -117,11 +118,13 @@ lemma square_function_count (hJ : J ∈ 𝓙₆ t u₁) (s' : ℤ) :
       intros I₁ hI₁ I₂ hI₂ e
       exact disjoint_of_subset ball_subset_Grid ball_subset_Grid
         ((eq_or_disjoint (hI₁.2.trans hI₂.2.symm)).resolve_left e)
+    -- TODO(bump-4.13): `measure_ball_ne_top` was `by finiteness`
     rw [← measureReal_biUnion_finset (by simpa only [coe_toFinset] using disj)
       (fun _ _ ↦ measurableSet_ball) (fun _ _ ↦ measure_ball_ne_top _ _)]
     simp only [Nat.cast_pow, Nat.cast_ofNat]
     gcongr
-    · exact measure_ball_ne_top _ _
+    · -- TODO(bump-4.13): `measure_ball_ne_top` was `by finiteness`
+      exact measure_ball_ne_top _ _
     · simp only [mem_toFinset, iUnion_subset_iff]
       intro I hI
       apply ball_subset_ball'

--- a/Carleson/GridStructure.lean
+++ b/Carleson/GridStructure.lean
@@ -218,7 +218,7 @@ lemma exists_supercube (l : ℤ) (h : l ∈ Icc (s i) S) : ∃ j, s j = l ∧ i 
   rcases ub.eq_or_lt with ub | ub; · exact ⟨topCube, by simpa [ub] using s_topCube, le_topCube⟩
   obtain ⟨x, hx⟩ := i.nonempty
   have bound_i : -S ≤ s i ∧ s i ≤ S := scale_mem_Icc
-  sorry /- TODO: fix proof again, was
+  sorry /- TODO(bump-4.13): fix proof again, was
   have ts := Grid_subset_biUnion (X := X) (i := topCube) l (by rw [s_topCube, mem_Ico]; omega)
   have := mem_of_mem_of_subset hx ((le_topCube (i := i)).1.trans ts)
   simp_rw [mem_preimage, mem_singleton_iff, mem_iUnion, exists_prop] at this

--- a/Carleson/RealInterpolation.lean
+++ b/Carleson/RealInterpolation.lean
@@ -3139,7 +3139,8 @@ lemma biSup {ι : Type*} (𝓑 : Set ι) (h𝓑 : 𝓑.Countable) {T : ι → (�
     exact fun h ↦ hx <| h.trans (le_biSup (fun i ↦ T i f x) hi)
   rcases lt_or_le A 0 with A0 | A0
   · refine AESubAdditiveOn.zero hP A (fun f hf ↦ ?_)
-    sorry  /- TODO fix! have h {i : ι} (hi : i ∈ 𝓑) := (h i hi).neg A0
+    sorry  /- TODO(bump-4.13): fix this proof, was
+    have h {i : ι} (hi : i ∈ 𝓑) := (h i hi).neg A0
     simp_rw [Set.forall_in_swap, imp.swap, ← imp_forall_iff] at h hT'
     filter_upwards [(ae_ball_iff h𝓑).mpr (h f hf), (ae_ball_iff h𝓑).mpr (hT' f hf)] with x hx hx'
     simp only [Pi.zero_apply, toReal_eq_zero_iff, ENNReal.iSup_eq_zero]

--- a/Carleson/TileExistence.lean
+++ b/Carleson/TileExistence.lean
@@ -2096,7 +2096,7 @@ lemma Ω_RFD {p q : 𝔓 X} (h𝓘 : 𝓘 p ≤ 𝓘 q) : Disjoint (Ω p) (Ω q)
     obtain ⟨I, y⟩ := p
     obtain ⟨J, z⟩ := q
     have hij : I = J := le_antisymm h𝓘 (Grid.le_dyadic h h𝓘 le_rfl)
-    sorry /- TODO: fix this proof, was
+    sorry /- TODO(bump-4.13): fix this proof, was
     have k := @Ω_disjoint (p := ⟨I, y⟩) ⟨J, z⟩
     replace k : (⟨I, y⟩ : 𝔓 X) = ⟨J, z⟩ := by tauto
     rw [k] -/


### PR DESCRIPTION
I intend to revisit these; now, one can at least find them somewhat easily.