### PR TITLE
chore: enable the flexible and multi-goal linters

### DIFF
--- a/Carleson/Antichain/AntichainOperator.lean
+++ b/Carleson/Antichain/AntichainOperator.lean
@@ -89,9 +89,9 @@ lemma _root_.ENNReal.div_mul (a : ℝ≥0∞) {b c : ℝ≥0∞} (hb0 : b ≠ 0)
     a / b * c = a / (b / c) := by
   rw [← ENNReal.mul_div_right_comm, ENNReal.div_eq_div_iff (ENNReal.div_ne_zero.mpr ⟨hb0, hc_top⟩)
     _ hb0 hb_top]
-  rw [ENNReal.div_eq_inv_mul, mul_comm a, mul_assoc]
-  simp only [mul_comm b, ← mul_assoc, ENNReal.inv_mul_cancel hc0 hc_top]
-  ring
+  · rw [ENNReal.div_eq_inv_mul, mul_comm a, mul_assoc]
+    simp only [mul_comm b, ← mul_assoc, ENNReal.inv_mul_cancel hc0 hc_top]
+    ring
   · simp only [ne_eq, div_eq_top]
     tauto
 
@@ -114,7 +114,7 @@ private lemma ineq_6_1_7 (x : X) {𝔄 : Set (𝔓 X)} (p : 𝔄) :
           mul_inv_cancel₀ hvol, mul_one]
     _ ≤ 2 ^ a ^ 3 * 2 ^ (5 * a + 100 * a ^ 3) / volume.real (ball x (8 * D ^ 𝔰 p.1)) := by
       gcongr
-      apply (measure_real_ball_pos x (mul_pos (by positivity) (zpow_pos (defaultD_pos _) _)))
+      · exact (measure_real_ball_pos x (mul_pos (by positivity) (zpow_pos (defaultD_pos _) _)))
       · have heq : 2 ^ (100 * a ^ 2) * 2 ^ 5 * (1 / (↑D * 32) * (8 * (D : ℝ) ^ 𝔰 p.1)) =
             (8 * ↑D ^ 𝔰 p.1) := by
           have hD : (D : ℝ) = 2 ^ (100 * a^2) := by simp
@@ -261,8 +261,8 @@ lemma MaximalBoundAntichain {𝔄 : Finset (𝔓 X)} (h𝔄 : IsAntichain (·≤
         (fun _ ↦ ⨍⁻ y, ‖f y‖₊ ∂volume.restrict (ball (𝔠 p.1) (8*D ^ 𝔰 p.1))) := by
       simp only [coe_ofNat, indicator, mem_ball, mul_ite, mul_zero]
       rw [if_pos]
-      gcongr
-      · rw [C_6_1_2, add_comm (5*a), add_assoc]; norm_cast
+      · gcongr
+        rw [C_6_1_2, add_comm (5*a), add_assoc]; norm_cast
         apply pow_le_pow_right₀ one_le_two
         calc
         _ ≤ 101 * a ^ 3  + 6 * a ^ 3:= by
@@ -352,15 +352,15 @@ lemma eLpNorm_maximal_function_le' {𝔄 : Finset (𝔓 X)} (h𝔄 : IsAntichain
       sorry
   · simp only [not_lt, top_le_iff] at hf_top
     rw [hf_top, mul_top]
-    exact le_top
-    · simp only [ne_eq, ENNReal.div_eq_zero_iff, mul_eq_zero, pow_eq_zero_iff',
-      OfNat.ofNat_ne_zero, false_or, false_and, sub_eq_top_iff, two_ne_top, not_false_eq_true,
-      and_true, not_or]
-      refine ⟨?_, mul_ne_top two_ne_top (mul_ne_top (mul_ne_top two_ne_top coe_ne_top)
-        (inv_ne_top.mpr (by simp)))⟩
-      · rw [tsub_eq_zero_iff_le]
-        exact not_le.mpr (lt_trans (by norm_cast)
-          (ENNReal.mul_lt_mul_left' three_ne_zero ofNat_ne_top one_lt_nnq'_coe))
+    · exact le_top
+    simp only [ne_eq, ENNReal.div_eq_zero_iff, mul_eq_zero, pow_eq_zero_iff',
+    OfNat.ofNat_ne_zero, false_or, false_and, sub_eq_top_iff, two_ne_top, not_false_eq_true,
+    and_true, not_or]
+    refine ⟨?_, mul_ne_top two_ne_top (mul_ne_top (mul_ne_top two_ne_top coe_ne_top)
+      (inv_ne_top.mpr (by simp)))⟩
+    rw [tsub_eq_zero_iff_le]
+    exact not_le.mpr (lt_trans (by norm_cast)
+      (ENNReal.mul_lt_mul_left' three_ne_zero ofNat_ne_top one_lt_nnq'_coe))
 
 
 -- lemma 6.1.3, inequality 6.1.10

--- a/Carleson/Classical/Approximation.lean
+++ b/Carleson/Classical/Approximation.lean
@@ -147,8 +147,8 @@ open Topology Filter
 lemma int_sum_nat {β : Type*} [AddCommGroup β] [TopologicalSpace β] [ContinuousAdd β] {f : ℤ → β} {a : β} (hfa : HasSum f a) :
     Filter.Tendsto (fun N ↦ ∑ n in Icc (-Int.ofNat ↑N) N, f n) Filter.atTop (𝓝 a) := by
   have := Filter.Tendsto.add_const (- (f 0)) hfa.nat_add_neg.tendsto_sum_nat
-  simp at this
-  /-Need to start at 1 instead of zero for the base case to be true· -/
+  simp only [add_neg_cancel_right] at this
+  /- Need to start at 1 instead of zero for the base case to be true. -/
   rw [←tendsto_add_atTop_iff_nat 1] at this
   convert this using 1
   ext N
@@ -165,10 +165,10 @@ lemma int_sum_nat {β : Type*} [AddCommGroup β] [TopologicalSpace β] [Continuo
       · norm_num
         linarith
     rw [this, sum_insert, sum_insert, ih, ← add_assoc]
-    symm
-    rw [sum_range_succ, add_comm, ←add_assoc, add_comm]
-    simp only [Nat.cast_add, Nat.cast_one, neg_add_rev, Int.reduceNeg, Nat.succ_eq_add_one,
-      Int.ofNat_eq_coe, add_right_inj, add_comm]
+    · symm
+      rw [sum_range_succ, add_comm, ←add_assoc, add_comm]
+      simp only [Nat.cast_add, Nat.cast_one, neg_add_rev, Int.reduceNeg, Nat.succ_eq_add_one,
+        Int.ofNat_eq_coe, add_right_inj, add_comm]
     · simp
     · norm_num
       linarith
@@ -182,7 +182,7 @@ lemma fourierConv_ofTwiceDifferentiable {f : ℝ → ℂ} (periodicf : f.Periodi
   set g : C(AddCircle (2 * π), ℂ) := ⟨AddCircle.liftIco (2*π) 0 f, AddCircle.liftIco_continuous ((periodicf 0).symm) fdiff.continuous.continuousOn⟩ with g_def
   have two_pi_pos' : 0 < 0 + 2 * π := by linarith [Real.two_pi_pos]
   have fourierCoeff_correspondence {i : ℤ} : fourierCoeff g i = fourierCoeffOn two_pi_pos' f i := fourierCoeff_liftIco_eq f i
-  simp at fourierCoeff_correspondence
+  simp only [zero_add] at fourierCoeff_correspondence
   have function_sum : HasSum (fun (i : ℤ) => fourierCoeff g i • fourier i) g := by
     apply hasSum_fourier_series_of_summable
     obtain ⟨C, hC⟩ := fourierCoeffOn_ContDiff_two_bound periodicf fdiff

--- a/Carleson/Classical/Basic.lean
+++ b/Carleson/Classical/Basic.lean
@@ -42,8 +42,8 @@ lemma fourierCoeffOn_add {a b : ℝ} {hab : a < b} {f g : ℝ → ℂ} {n : ℤ}
     fourier_coe_apply', Complex.ofReal_sub, Pi.add_apply, smul_eq_mul, mul_add, Complex.real_smul,
     Complex.ofReal_inv]
   rw [← mul_add, ← intervalIntegral.integral_add]
-  ring_nf
-  · apply hf.continuousOn_mul (Continuous.continuousOn _); continuity
+  · ring_nf
+    apply hf.continuousOn_mul (Continuous.continuousOn _); continuity
   · apply hg.continuousOn_mul (Continuous.continuousOn _); continuity
 
 @[simp]
@@ -92,11 +92,11 @@ lemma Function.Periodic.uniformContinuous_of_continuous {f : ℝ → ℂ} {T : �
   have hyb: f y = f (y - n • T) := (hp.sub_zsmul_eq n).symm
   rw [hxa, hyb]
   apply h (x - n • T) _ (y - n • T)
-  rw [Real.dist_eq, abs_lt] at hxy
+  on_goal 1 => rw [Real.dist_eq, abs_lt] at hxy
   constructor <;> linarith [ha.1, ha.2]
-  rw [Real.dist_eq,zsmul_eq_mul, sub_sub_sub_cancel_right, ← Real.dist_eq]
-  exact hxy.trans_le h1
-  constructor <;> linarith [ha.1, ha.2]
+  · rw [Real.dist_eq,zsmul_eq_mul, sub_sub_sub_cancel_right, ← Real.dist_eq]
+    exact hxy.trans_le h1
+  · constructor <;> linarith [ha.1, ha.2]
 
 
 lemma fourier_uniformContinuous {n : ℤ} :

--- a/Carleson/Classical/CarlesonOperatorReal.lean
+++ b/Carleson/Classical/CarlesonOperatorReal.lean
@@ -28,7 +28,7 @@ lemma annulus_real_eq {x r R: ℝ} (r_nonneg : 0 ≤ r) : {y | dist x y ∈ Set.
 lemma annulus_real_volume {x r R : ℝ} (hr : r ∈ Set.Icc 0 R) :
     volume {y | dist x y ∈ Set.Ioo r R} = ENNReal.ofReal (2 * (R - r)) := by
   rw [annulus_real_eq hr.1, measure_union _ measurableSet_Ioo, Real.volume_Ioo, Real.volume_Ioo, ← ENNReal.ofReal_add (by linarith [hr.2]) (by linarith [hr.2])]
-  ring_nf
+  · ring_nf
   rw [Set.disjoint_iff]
   intro y hy
   linarith [hy.1.2, hy.2.1, hr.1]
@@ -152,9 +152,9 @@ lemma carlesonOperatorReal_measurable {f : ℝ → ℂ} (f_measurable : Measurab
         simp only [Set.mem_Ioo]
         by_cases h : dist x y < 1
         · rw [Set.indicator_apply, ite_cond_eq_true, Set.indicator_apply, ite_cond_eq_true]
-          · simp
+          · simp only [Set.mem_setOf_eq, eq_iff_iff, iff_true]
             use ht
-          · simp
+          · simp only [Set.mem_setOf_eq, eq_iff_iff, iff_true]
             use hs
         · push_neg at h
           rw [Set.indicator_apply, ite_cond_eq_false, Set.indicator_apply, ite_cond_eq_false]
@@ -168,17 +168,17 @@ lemma carlesonOperatorReal_measurable {f : ℝ → ℂ} (f_measurable : Measurab
         simp only [Set.restrict_apply, Subtype.forall]
         intro s hs t ht
         rw [Fdef]
-        simp
+        simp only [Set.mem_Ioo]
         rw [Set.indicator_apply, ite_cond_eq_false, Set.indicator_apply, ite_cond_eq_false]
         · rw [Set.mem_Ioi, min_lt_iff] at ht
-          simp
+          simp only [Set.mem_setOf_eq, eq_iff_iff, iff_false, not_and, not_lt]
           intro h
           rcases ht with h' | h'
           · exfalso
             exact (lt_self_iff_false _).mp (h'.trans h)
           · exact (h'.trans h).le
         · rw [Set.mem_Ioi, min_lt_iff] at hs
-          simp
+          simp only [Set.mem_setOf_eq, eq_iff_iff, iff_false, not_and, not_lt]
           intro h
           rcases hs with h' | h'
           · exfalso
@@ -198,7 +198,8 @@ lemma carlesonOperatorReal_measurable {f : ℝ → ℂ} (f_measurable : Measurab
           rw [Set.mem_setOf_eq, not_not]
           exact contOn y r hy.symm
         rw [Real.dist_eq, abs_eq hr.1.le] at this
-        simp
+        simp only [Finset.coe_insert, Finset.coe_singleton, Set.mem_insert_iff,
+          Set.mem_singleton_iff]
         rcases this with h | h
         · left; linarith
         · right; linarith

--- a/Carleson/Classical/ClassicalCarleson.lean
+++ b/Carleson/Classical/ClassicalCarleson.lean
@@ -32,7 +32,7 @@ theorem exceptional_set_carleson {f : ℝ → ℂ}
   have h_periodic : h.Periodic (2 * π) := periodic_f₀.sub periodic_f
   have h_bound : ∀ x, ‖h x‖ ≤ ε' := by
     intro x
-    simp [hdef]
+    simp only [hdef, Pi.sub_apply, Complex.norm_eq_abs]
     rw [← Complex.dist_eq, dist_comm, Complex.dist_eq]
     exact hf₀ x
 

--- a/Carleson/Classical/ControlApproximationEffect.lean
+++ b/Carleson/Classical/ControlApproximationEffect.lean
@@ -23,7 +23,7 @@ lemma ENNReal.le_on_subset {X : Type} [MeasurableSpace X] (μ : Measure X) {f g 
   have : E ⊆ Ef ∪ Eg := by
     intro x hx
     rw [Ef_def, Eg_def]
-    simp
+    simp only [Set.mem_union, Set.mem_inter_iff, Set.mem_preimage, Set.mem_Ici]
     by_contra hx'
     push_neg at hx'
     absurd le_refl a
@@ -159,7 +159,7 @@ lemma intervalIntegrable_mul_dirichletKernel' {x : ℝ} (hx : x ∈ Set.Icc 0 (2
     intro y
     apply norm_dirichletKernel'_le
   · rw [Set.uIcc_of_le, Set.uIcc_of_le]
-    apply Set.Icc_subset_Icc
+    on_goal 1 => apply Set.Icc_subset_Icc
     all_goals linarith [hx.1, hx.2, pi_pos]
 
 lemma intervalIntegrable_mul_dirichletKernel'_max {x : ℝ} (hx : x ∈ Set.Icc 0 (2 * π)) {f : ℝ → ℂ} (hf : IntervalIntegrable f volume (-π) (3 * π)) {N : ℕ} :
@@ -250,10 +250,10 @@ lemma le_CarlesonOperatorReal {g : ℝ → ℂ} (hg : IntervalIntegrable g volum
       apply lt_trans hn
       linarith
     · intro hy
-      simp at hy
+      simp only [Set.mem_iUnion] at hy
       rcases hy with ⟨n, hn⟩
       rw [sdef] at hn
-      simp at hn
+      simp only [one_div, Set.mem_Ioo, Set.mem_setOf_eq] at hn
       refine ⟨lt_trans' hn.1 ?_, hn.2⟩
       norm_num
       linarith
@@ -334,7 +334,7 @@ lemma le_CarlesonOperatorReal {g : ℝ → ℂ} (hg : IntervalIntegrable g volum
           · conv => pattern ((g _) * _); rw [mul_comm]
             apply Integrable.bdd_mul' integrable₁ measurable₁.aestronglyMeasurable
             · rw [ae_restrict_iff' annulus_measurableSet]
-              apply Eventually.of_forall
+              on_goal 1 => apply Eventually.of_forall
               exact fun _ hy ↦ boundedness₁ hy.1.le
           · conv => pattern ((g _) * _); rw [mul_comm]
             apply Integrable.bdd_mul' integrable₁
@@ -342,9 +342,9 @@ lemma le_CarlesonOperatorReal {g : ℝ → ℂ} (hg : IntervalIntegrable g volum
               apply Measurable.aestronglyMeasurable
               exact continuous_star.measurable.comp measurable₁
             · rw [ae_restrict_iff' annulus_measurableSet]
-              apply Eventually.of_forall
-              intro y hy
-              rw [RCLike.norm_conj]
+              on_goal 1 => apply Eventually.of_forall
+              on_goal 1 => intro y hy
+              on_goal 1 => rw [RCLike.norm_conj]
               exact boundedness₁ hy.1.le
         _ ≤   ‖∫ y in {y | dist x y ∈ Set.Ioo r 1}, g y * (exp (I * (-n * x)) * K x y * exp (I * n * y))‖₊
             + ‖∫ y in {y | dist x y ∈ Set.Ioo r 1}, g y * conj (exp (I * (-n * x)) * K x y * exp (I * n * y))‖₊ := by
@@ -437,7 +437,7 @@ lemma partialFourierSum_bound {δ : ℝ} (hδ : 0 < δ) {g : ℝ → ℂ} (measu
               apply Dirichlet_Hilbert_diff
               constructor <;> linarith [hy.1, hy.2]
           _ = π * δ * (2 * π) := by
-            simp
+            simp only [add_sub_sub_cancel]
             rw [←two_mul, _root_.abs_of_nonneg Real.two_pi_pos.le]
             ring
     _ = (T g x + T (conj ∘ g) x) / ENNReal.ofReal (2 * π) + ENNReal.ofReal (π * δ) := by
@@ -459,14 +459,15 @@ lemma rcarleson_exceptional_set_estimate {δ : ℝ} (δpos : 0 < δ) {f : ℝ �
       apply setLIntegral_mono' measurableSetE hE
     _ = ENNReal.ofReal δ * ∫⁻ x in E, T (fun x ↦ (1 / δ) * f x) x := by
       rw [← lintegral_const_mul']
+      swap; · exact ENNReal.ofReal_ne_top
       congr with x
       rw [carlesonOperatorReal_mul δpos]
       congr
-      exact ENNReal.ofReal_ne_top
     _ ≤ ENNReal.ofReal δ * (ENNReal.ofReal (C10_0_1 4 2) * (volume E) ^ (2 : ℝ)⁻¹ * (volume F) ^ (2 : ℝ)⁻¹) := by
       gcongr
       apply rcarleson measurableSetF measurableSetE _ (by fun_prop)
       intro x
+      -- FIXME: simp? suggests output that doesn't work
       simp
       rw [_root_.abs_of_nonneg δpos.le, inv_mul_le_iff₀ δpos]
       exact hf x
@@ -513,15 +514,15 @@ lemma C_control_approximation_effect_eq {ε : ℝ} {δ : ℝ} (ε_nonneg : 0 ≤
     mul_comm δ, ← mul_assoc, ← mul_assoc, ← add_mul, mul_comm _ (C10_0_1 4 2), mul_assoc]
   congr
   rw [Real.div_rpow, Real.div_rpow _ (mul_nonneg _ _), Real.mul_rpow, Real.mul_rpow]
-  ring_nf
-  rw [mul_assoc, mul_comm (2 ^ _), mul_assoc, mul_assoc, mul_assoc, mul_comm (4 ^ _), ← mul_assoc π⁻¹,
+  all_goals
+    ring_nf
+    try rw [mul_assoc, mul_comm (2 ^ _), mul_assoc, mul_assoc, mul_assoc, mul_comm (4 ^ _), ← mul_assoc π⁻¹,
       ← Real.rpow_neg_one π, ← Real.rpow_add, mul_comm (π ^ _), ← mul_assoc (2 ^ _), ← Real.mul_rpow]
-  congr
-  norm_num
-  ring_nf
-  rw [neg_div, Real.rpow_neg]
+  on_goal 1 => congr
+  · norm_num
+  on_goal 1 => ring_nf
+  on_goal 1 => rw [neg_div, Real.rpow_neg]
   all_goals linarith [pi_pos]
-
 
 
 /- This is Lemma 11.6.4 (partial Fourier sums of small) in the blueprint.-/
@@ -540,11 +541,7 @@ lemma control_approximation_effect {ε : ℝ} (εpos : 0 < ε) {δ : ℝ} (hδ :
     apply measurableSet_Icc.inter (MeasurableSet.iUnion _)
     intro N
     apply measurableSet_lt measurable_const (Measurable.norm partialFourierSum_uniformContinuous.continuous.measurable)
-  have Esubset : E ⊆ Set.Icc 0 (2 * π) := by
-    intro x hx
-    rw [Edef] at hx
-    simp at hx
-    exact hx.1
+  have Esubset : E ⊆ Set.Icc 0 (2 * π) := fun x hx ↦ by simpa using hx.1
   use E, Esubset, measurableSetE
   --Change order of proofs to start with the simple part
   rw [and_comm]
@@ -626,12 +623,14 @@ lemma control_approximation_effect {ε : ℝ} (εpos : 0 < ε) {δ : ℝ} (hδ :
       rw [Real.rpow_mul measureReal_nonneg]
       gcongr
       rw [Real.rpow_add' measureReal_nonneg (by norm_num), Real.rpow_one, le_div_iff₀' ε'_δ_expression_pos, ← mul_assoc]
-      apply mul_le_of_le_div₀ δ_mul_const_pos.le
-      apply Real.rpow_nonneg measureReal_nonneg
-      rw[Real.rpow_neg measureReal_nonneg, div_inv_eq_mul]
-      rw [← ENNReal.ofReal_le_ofReal_iff, ENNReal.ofReal_mul ε'_δ_expression_pos.le, measureReal_def, ENNReal.ofReal_toReal E'volume.ne]
-      apply le_trans E'volume_bound
-      rw [ENNReal.ofReal_mul δ_mul_const_pos.le, ← ENNReal.ofReal_rpow_of_nonneg ENNReal.toReal_nonneg (by norm_num), ENNReal.ofReal_toReal E'volume.ne]
+      apply mul_le_of_le_div₀ δ_mul_const_pos.le (by positivity)
+      rw [Real.rpow_neg measureReal_nonneg, div_inv_eq_mul,
+        ← ENNReal.ofReal_le_ofReal_iff, ENNReal.ofReal_mul ε'_δ_expression_pos.le, measureReal_def,
+        ENNReal.ofReal_toReal E'volume.ne]
+      · apply le_trans E'volume_bound
+        rw [ENNReal.ofReal_mul δ_mul_const_pos.le,
+          ← ENNReal.ofReal_rpow_of_nonneg ENNReal.toReal_nonneg (by norm_num),
+          ENNReal.ofReal_toReal E'volume.ne]
       positivity
     _ = ε := by
       --We have chosen ε' such that this works.

--- a/Carleson/Classical/ControlApproximationEffect.lean
+++ b/Carleson/Classical/ControlApproximationEffect.lean
@@ -447,6 +447,7 @@ lemma partialFourierSum_bound {δ : ℝ} (hδ : 0 < δ) {g : ℝ → ℂ} (measu
 
 end section
 
+set_option linter.flexible false in
 lemma rcarleson_exceptional_set_estimate {δ : ℝ} (δpos : 0 < δ) {f : ℝ → ℂ} (hmf : Measurable f)
     {F : Set ℝ} (measurableSetF : MeasurableSet F) (hf : ∀ x, ‖f x‖ ≤ δ * F.indicator 1 x)
     {E : Set ℝ} (measurableSetE : MeasurableSet E) {ε : ENNReal} (hE : ∀ x ∈ E, ε ≤ T f x) :

--- a/Carleson/Classical/DirichletKernel.lean
+++ b/Carleson/Classical/DirichletKernel.lean
@@ -132,7 +132,7 @@ lemma dirichletKernel'_eq_zero {x : ℝ} (h : cexp (I * x) = 1) : dirichletKerne
 lemma dirichletKernel_eq_ae : ∀ᵐ (x : ℝ), dirichletKernel N x = dirichletKernel' N x := by
   have : {x | ¬dirichletKernel N x = dirichletKernel' N x} ⊆ {x | ∃ n : ℤ, n * (2 * π) = x} := by
     intro x hx
-    simp at *
+    simp only [Set.mem_setOf_eq]
     by_contra h
     apply hx (dirichletKernel_eq _)
     rw [ne_eq, Complex.exp_eq_one_iff]
@@ -219,7 +219,8 @@ lemma partialFourierSum_eq_conv_dirichletKernel' {f : ℝ → ℂ} {x : ℝ} (h 
       have : {a | ¬f (x - a) * dirichletKernel N a = f (x - a) * dirichletKernel' N a} ⊆ {a | ¬dirichletKernel N a = dirichletKernel' N a} := by
         intro a ha
         contrapose! ha
-        simp at *
+        simp only [ne_eq, Set.mem_setOf_eq, Decidable.not_not, mul_eq_mul_left_iff, not_or,
+          not_and] at *
         intro h
         exfalso
         exact h ha

--- a/Carleson/Classical/Helper.lean
+++ b/Carleson/Classical/Helper.lean
@@ -49,18 +49,17 @@ lemma ConditionallyCompleteLattice.le_biSup {α : Type} [ConditionallyCompleteLi
     rcases hfs with ⟨x, hx⟩
     use (max x (sSup ∅))
     intro y hy
-    simp at hy
+    simp only [Set.mem_range] at hy
     rcases hy with ⟨z, hz⟩
     rw [iSup] at hz
     by_cases h : z ∈ s
     · have : (@Set.range α (z ∈ s) fun _ ↦ f z) = {f z} := by
         rw [Set.eq_singleton_iff_unique_mem]
-        exact ⟨Set.mem_range_self h, fun x hx => hx.2.symm⟩
-      rw [this] at hz
-      have : sSup {f z} = f z := csSup_singleton _
-      rw [this] at hz
-      simp at hx
-      have : f z ≤ x := hx z h
+        exact ⟨Set.mem_range_self h, fun x hx ↦ hx.2.symm⟩
+      rw [this, csSup_singleton _] at hz
+      have : f z ≤ x := by
+        simp only [Set.mem_image, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂] at hx
+        exact hx z h
       rw [hz] at this
       exact le_max_of_le_left this
     have : (@Set.range α (z ∈ s) fun _ ↦ f z) = ∅ := by simpa

--- a/Carleson/Classical/HilbertKernel.lean
+++ b/Carleson/Classical/HilbertKernel.lean
@@ -57,7 +57,7 @@ lemma Hilbert_kernel_bound {x y : ℝ} : ‖K x y‖ ≤ 2 ^ (2 : ℝ) / (2 * |x
         · apply lower_secant_bound _ (by rfl)
           rw [Set.mem_Icc]
           constructor
-          · simp
+          · simp only [neg_mul, neg_add_le_iff_le_add]
             calc |x - y|
               _ ≤ 1 := h.2.le
               _ ≤ 2 * π - 1 := by rw [le_sub_iff_add_le]; linarith [Real.two_le_pi]
@@ -101,7 +101,7 @@ lemma Hilbert_kernel_regularity_main_part {y y' : ℝ} (yy'nonneg : 0 ≤ y ∧ 
       have ht' : 0 < t ∧ t ≤ 1 := by
         rcases ht with ht | ht <;> (constructor <;> linarith)
       rw [ddef]
-      simp
+      simp only [ne_eq]
       rw [←norm_eq_zero]
       apply ne_of_gt
       calc ‖1 - exp (-(I * ↑t))‖
@@ -124,7 +124,7 @@ lemma Hilbert_kernel_regularity_main_part {y y' : ℝ} (yy'nonneg : 0 ≤ y ∧ 
       apply HasDerivAt.div _ _ _
       · exact cdef ▸ c'def ▸ HasDerivAt.const_sub _ (HasDerivAt.ofReal_comp (hasDerivAt_id' _))
       · rw [ddef, d'def]
-        simp
+        simp only
         rw [←neg_neg (I * exp (-(I * ↑t)))]
         rw [←neg_mul, mul_comm]
         apply HasDerivAt.const_sub _ (HasDerivAt.cexp (HasDerivAt.neg _))
@@ -137,7 +137,7 @@ lemma Hilbert_kernel_regularity_main_part {y y' : ℝ} (yy'nonneg : 0 ≤ y ∧ 
         apply hasDerivAt_mul_const
       · exact d_nonzero ht
     have f'_cont : ContinuousOn (fun t ↦ f' t) (Set.uIcc y' y) :=
-      ContinuousOn.div (by fun_prop) (by fun_prop) (by simp; exact fun _ ht ↦ d_nonzero ht)
+      ContinuousOn.div (by fun_prop) (by fun_prop) (by simpa using fun _ ht ↦ d_nonzero ht)
     calc ‖(1 - ↑y) / (1 - exp (-(I * ↑y))) - (1 - ↑y') / (1 - exp (-(I * ↑y')))‖
       _ = ‖f y - f y'‖ := by simp
       _ = ‖∫ (t : ℝ) in y'..y, f' t‖ := by
@@ -179,9 +179,9 @@ lemma Hilbert_kernel_regularity_main_part {y y' : ℝ} (yy'nonneg : 0 ≤ y ∧ 
                   exact le_of_eq (abs_exp_ofReal_mul_I _)
                 · simp only [map_mul, abs_I, one_mul]
                   apply mul_le_one₀
-                  norm_cast
+                  on_goal 1 => norm_cast
                   rw [abs_of_nonpos] <;> linarith
-                  simp only [apply_nonneg]
+                  · simp only [apply_nonneg]
                   rw [mul_comm, ←neg_mul]
                   norm_cast
                   exact le_of_eq (abs_exp_ofReal_mul_I _)
@@ -218,7 +218,7 @@ lemma Hilbert_kernel_regularity {x y y' : ℝ} :
     simpa
   rw [x_eq_zero]
   intro h
-  simp at h
+  simp only [zero_sub, abs_neg] at h
   simp only [zero_sub, abs_neg]
   wlog yy'nonneg : 0 ≤ y ∧ 0 ≤ y' generalizing y y'
   · by_cases yge0 : 0 ≤ y
@@ -308,9 +308,8 @@ lemma Hilbert_kernel_regularity {x y y' : ℝ} :
         _ ≤ (2 ^ 6 * 2 * 2) * (1 / |y|) * (|y - y'| / |y|) := by
           gcongr
           apply div_nonneg <;> linarith
-          rw [_root_.abs_of_nonneg yy'nonneg.1]
-          rw [_root_.abs_of_nonneg] <;> linarith
-          rw [_root_.abs_of_nonneg yy'nonneg.1]
+          on_goal 2 => rw [_root_.abs_of_nonneg] <;> linarith
+          all_goals rw [_root_.abs_of_nonneg yy'nonneg.1]
         _ ≤ 2 ^ 8 * (1 / |y|) * (|y - y'| / |y|) := by norm_num
     · rw [abs_neg, _root_.abs_of_nonneg] <;> linarith
   · calc ‖k (-y) - k (-y')‖

--- a/Carleson/Classical/VanDerCorput.lean
+++ b/Carleson/Classical/VanDerCorput.lean
@@ -76,14 +76,14 @@ lemma van_der_Corput {a b : ℝ} (hab : a ≤ b) {n : ℤ} {ϕ : ℝ → ℂ} {B
       _ = B * (b - a) := by rw [Real.volume_Ioo, ENNReal.toReal_ofReal (by linarith)]
       _ = (1 + |n| * (b - a)) * (1 + |n| * (b - a))⁻¹ * (b - a) * B := by
         rw [mul_inv_cancel₀]
-        ring
+        · ring
         exact ne_of_gt this
       _ ≤ (π + π) * (1 + |n| * (b - a))⁻¹ * (b - a) * (B + K * (b - a) / 2) := by
         gcongr
         · apply mul_nonneg
-          apply mul_nonneg
-          linarith [Real.two_pi_pos]
-          · exact inv_nonneg_of_nonneg this.le
+          · apply mul_nonneg
+            · linarith [Real.two_pi_pos]
+            · exact inv_nonneg_of_nonneg this.le
           · linarith
         · linarith
         · linarith [Real.two_le_pi]
@@ -115,7 +115,7 @@ lemma van_der_Corput {a b : ℝ} (hab : a ≤ b) {n : ℤ} {ϕ : ℝ → ℂ} {B
     _ = 1 / 2 * ‖(∫ (x : ℝ) in a..b, (I * n * x).exp * ϕ x) - (∫ (x : ℝ) in a..b, (I * n * (x + π / n)).exp * ϕ x)‖ := by
       rw [norm_mul]
       congr
-      simp
+      · simp
       rw [← intervalIntegral.integral_sub]
       · exact integrand_continuous.intervalIntegrable _ _
       · exact integrand_continuous2.intervalIntegrable _ _
@@ -124,7 +124,7 @@ lemma van_der_Corput {a b : ℝ} (hab : a ≤ b) {n : ℤ} {ϕ : ℝ → ℂ} {B
                  -((∫ (x : ℝ) in a..(b - π / n), (I * n * (x + π / n)).exp * ϕ x)
                  + (∫ (x : ℝ) in (b - π / n)..b, (I * n * (x + π / n)).exp * ϕ x))‖ := by
       congr 3
-      rw [intervalIntegral.integral_add_adjacent_intervals]
+      on_goal 1 => rw [intervalIntegral.integral_add_adjacent_intervals]
       · exact integrand_continuous.intervalIntegrable _ _
       · exact integrand_continuous.intervalIntegrable _ _
       rw [intervalIntegral.integral_add_adjacent_intervals]
@@ -149,9 +149,9 @@ lemma van_der_Corput {a b : ℝ} (hab : a ≤ b) {n : ℤ} {ϕ : ℝ → ℂ} {B
                  - (∫ (x : ℝ) in (b - π / n)..b, (I * n * (x + π / n)).exp * ϕ x)‖ := by
       congr 4
       rw [← intervalIntegral.integral_sub]
-      congr
-      ext x
-      ring
+      · congr
+        ext x
+        ring
       · exact integrand_continuous.intervalIntegrable _ _
       · exact integrand_continuous3.intervalIntegrable _ _
     _ ≤ 1 / 2 * (  ‖(∫ (x : ℝ) in a..(a + π / n), (I * n * x).exp * ϕ x)
@@ -187,7 +187,7 @@ lemma van_der_Corput {a b : ℝ} (hab : a ≤ b) {n : ℤ} {ϕ : ℝ → ℂ} {B
           rw [norm_mul, mul_assoc, mul_comm I]
           rw_mod_cast [Complex.norm_exp_ofReal_mul_I, one_mul, ← dist_eq_norm]
           apply le_trans (h1.dist_le_mul _ _)
-          simp
+          simp only [dist_self_sub_right, norm_div, Real.norm_eq_abs]
           rw [_root_.abs_of_nonneg Real.pi_pos.le, _root_.abs_of_nonneg (by simp; linarith [n_pos])]
           apply le_of_eq
           ring
@@ -201,7 +201,7 @@ lemma van_der_Corput {a b : ℝ} (hab : a ≤ b) {n : ℤ} {ϕ : ℝ → ℂ} {B
         · exact Real.volume_Ioo ▸ ENNReal.ofReal_lt_top
     _ = π / n * (B + K * (b - (a + π / n)) / 2) := by
       rw [Real.volume_Ioo, Real.volume_Ioo, Real.volume_Ioo, ENNReal.toReal_ofReal, ENNReal.toReal_ofReal, ENNReal.toReal_ofReal]
-      ring
+      · ring
       all_goals linarith
     _ ≤ π / n * (B + K * (b - a) / 2) := by
       gcongr
@@ -209,15 +209,15 @@ lemma van_der_Corput {a b : ℝ} (hab : a ≤ b) {n : ℤ} {ϕ : ℝ → ℂ} {B
     _ ≤ (2 * π / (1 + n * (b - a)) * (b - a)) * (B + K * (b - a) / 2) := by
       gcongr
       rw [mul_comm, ← mul_div_assoc, div_le_div_iff (by simpa)]
-      calc π * (1 + n * (b - a))
-        _ ≤ π * (π + n * (b - a)) := by
-          gcongr
-          linarith [Real.two_le_pi]
-        _ ≤ π * (n * (b - a) + n * (b - a)) := by
-          gcongr
-          rwa [← div_le_iff₀' (Int.cast_pos.mpr n_pos)]
-        _ = (b - a) * (2 * π) * n := by ring
-      exact add_pos zero_lt_one (mul_pos (Int.cast_pos.mpr n_pos) (gt_of_ge_of_gt h pi_div_n_pos))
+      · calc π * (1 + n * (b - a))
+          _ ≤ π * (π + n * (b - a)) := by
+            gcongr
+            linarith [Real.two_le_pi]
+          _ ≤ π * (n * (b - a) + n * (b - a)) := by
+            gcongr
+            rwa [← div_le_iff₀' (Int.cast_pos.mpr n_pos)]
+          _ = (b - a) * (2 * π) * n := by ring
+      · exact add_pos zero_lt_one (mul_pos (Int.cast_pos.mpr n_pos) (gt_of_ge_of_gt h pi_div_n_pos))
     _ = 2 * π * (b - a) * (B + K * (b - a) / 2) * (1 + |n| * (b - a))⁻¹ := by
       rw [_root_.abs_of_nonneg n_pos.le]
       ring

--- a/Carleson/CoverByBalls.lean
+++ b/Carleson/CoverByBalls.lean
@@ -37,7 +37,7 @@ protected lemma CoveredByBalls.empty : CoveredByBalls (∅ : Set X) n r :=
 @[simp]
 lemma CoveredByBalls.zero_left : CoveredByBalls s 0 r ↔ s = ∅ := by
   refine ⟨fun ⟨b, hn, hs⟩ ↦ ?_, by rintro rfl; exact CoveredByBalls.empty⟩
-  simp at hn; subst hn; simpa using hs
+  simp only [nonpos_iff_eq_zero, card_eq_zero] at hn; subst hn; simpa using hs
 
 @[simp]
 lemma CoveredByBalls.zero_right : CoveredByBalls s n 0 ↔ s = ∅ := by

--- a/Carleson/DoublingMeasure.lean
+++ b/Carleson/DoublingMeasure.lean
@@ -170,11 +170,11 @@ lemma measure_ball_le_same (x : X) {r s r': ℝ} (hsp : 0 < s) (hs : r' ≤ s * 
   have hAs : (As A s: ℝ≥0∞) ≠ ⊤ := coe_ne_top
   rw [← ENNReal.ofReal_toReal hbr,← ENNReal.ofReal_toReal hbr',
     ← ENNReal.ofReal_toReal hAs, ← ENNReal.ofReal_mul] at hz
-  simp only [coe_toReal] at hz
-  rw [← ENNReal.ofReal_le_ofReal_iff]
-  · exact hz
-  positivity
-  simp only [coe_toReal, zero_le_coe]
+  · simp only [coe_toReal] at hz
+    rw [← ENNReal.ofReal_le_ofReal_iff]
+    · exact hz
+    positivity
+  · simp only [coe_toReal, zero_le_coe]
 
 lemma measure_ball_le_of_dist_le' {x x' : X} {r r' s : ℝ} (hs : 0 < s)
     (h : dist x x' + r' ≤ s * r) :

--- a/Carleson/ForestOperator/LargeSeparation.lean
+++ b/Carleson/ForestOperator/LargeSeparation.lean
@@ -128,8 +128,8 @@ lemma scales_impacting_interval (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : 
   apply Set.mem_or_mem_of_mem_union at hp
   have belongs : p ∈ t.𝔖₀ u₁ u₂ := by
     cases' hp with h1 h2
-    exact 𝔗_subset_𝔖₀ hu₁ hu₂ hu h2u h1
-    exact Set.mem_of_mem_inter_right h2
+    · exact 𝔗_subset_𝔖₀ hu₁ hu₂ hu h2u h1
+    · exact Set.mem_of_mem_inter_right h2
   cases' hJLeft with scaleVerySmall noGridInBall
   · exact trans scaleVerySmall (scale_mem_Icc.left)
   have pGridIsNotInBall := noGridInBall p belongs
@@ -172,20 +172,16 @@ lemma scales_impacting_interval (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : 
       apply lt_tsub_iff_left.mp
       have DIsPos := one_lt_D (X := X)
       calc (D : ℝ) ^ 𝔰 p
-        _ < D ^ (s J) := by
-          gcongr
-          exact DIsPos
+        _ < D ^ (s J) := by gcongr; exact DIsPos
         _ < D ^ (s J) * (25 * D - 4) := by
           rewrite (config := {occs := .pos [1]}) [mul_comm]
           apply lt_mul_left
-          positivity
-          linarith
-        _ = (D ^ (s J) * D) * 25 - D ^ (s J) * 4 := by
-          ring
+          · positivity
+          · linarith
+        _ = (D ^ (s J) * D) * 25 - D ^ (s J) * 4 := by ring
         _ = D ^ ((s J) + 1) * 25 - D ^ (s J) * 4 := by
           rw [zpow_add_one₀ (by positivity)]
-        _ = D ^ (1 + (s J)) * 25 - D ^ (s J) * 4 := by
-          ring_nf
+        _ = D ^ (1 + (s J)) * 25 - D ^ (s J) * 4 := by ring_nf
 
 /-- The constant used in `global_tree_control1_1`.
 Has value `2 ^ (154 * a ^ 3)` in the blueprint. -/

--- a/Carleson/ForestOperator/RemainingTiles.lean
+++ b/Carleson/ForestOperator/RemainingTiles.lean
@@ -51,6 +51,7 @@ lemma thin_scale_impact (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠
 /-- The constant used in `square_function_count`. -/
 irreducible_def C7_6_4 (a : ℕ) (s : ℤ) : ℝ≥0 := 2 ^ (14 * (a : ℝ) + 1) * (8 * D ^ (- s)) ^ κ
 
+set_option linter.flexible false in -- Addressing the linter makes the code less readable.
 /-- Lemma 7.6.4. -/
 lemma square_function_count (hJ : J ∈ 𝓙₆ t u₁) (s' : ℤ) :
     ⨍⁻ x in J, (∑ I ∈ {I : Grid X | s I = s J - s' ∧ Disjoint (I : Set X) (𝓘 u₁) ∧

--- a/Carleson/Psi.lean
+++ b/Carleson/Psi.lean
@@ -360,7 +360,7 @@ variable (s)
 /-- Apply `volume_ball_two_le_same` `n` times. -/
 lemma DoublingMeasure.volume_ball_two_le_same_repeat (x : X) (r : ℝ) (n : ℕ) :
     volume.real (ball x (2 ^ n * r)) ≤ (defaultA a) ^ n * volume.real (ball x r) := by
-  induction' n with d ih; simp
+  induction' n with d ih; · simp
   rw [add_comm, pow_add, pow_one, mul_assoc]
   apply (measure_real_ball_two_le_same x _).trans
   have A_cast: (defaultA a : ℝ≥0).toReal = (defaultA a : ℝ) := rfl

--- a/Carleson/Psi.lean
+++ b/Carleson/Psi.lean
@@ -213,9 +213,12 @@ private lemma sum_ψ₁ (hx : 0 < x) (h : D ^ (-⌈logb D (4 * x)⌉) ≥ 1 / (2
   calc
     D ^ (-⌈logb D (4 * x)⌉) * x
       = D ^ (-⌈logb D (4 * x)⌉ : ℝ) * x := by norm_cast
-    _ ≤ D ^ (-logb D (4 * x)) * x      := by gcongr; exact hD.le; exact Int.le_ceil (logb D (4 * x))
-    _ = 1 / (4 * x) * x                := by rw [rpow_neg (D0 hD).le, inv_eq_one_div,
-                                              rpow_logb (D0 hD) hD.ne.symm (by linarith)]
+    _ ≤ D ^ (-logb D (4 * x)) * x      := by
+      gcongr
+      · exact hD.le
+      · exact Int.le_ceil (logb D (4 * x))
+    _ = 1 / (4 * x) * x                := by
+      rw [rpow_neg (D0 hD).le, inv_eq_one_div, rpow_logb (D0 hD) hD.ne.symm (by linarith)]
     _ = 1 / 4                          := by field_simp; exact mul_comm x 4
 
 -- Special case of `sum_ψ`, for the case where `nonzeroS D x` has two elements.

--- a/Carleson/RealInterpolation.lean
+++ b/Carleson/RealInterpolation.lean
@@ -2921,7 +2921,7 @@ lemma weaktype_estimate_trunc_top_top {a : ℝ} {C₁ : ℝ≥0}
       have coe_C : C.toNNReal = C₁ := Real.toNNReal_coe
       rw [← coe_C, coe_coe_eq_ofReal, ← ENNReal.ofReal_mul, max_eq_right, congrArg toReal coe_C,
         mul_div_cancel₀]
-      · exact Ne.symm hC₁.ne
+      · exact Ne.symm (ne_of_lt hC₁)
       · positivity
       · positivity
   calc
@@ -2947,7 +2947,8 @@ lemma weaktype_estimate_trunc_compl_top {C₀ : ℝ≥0} (hC₀ : C₀ > 0) {p p
       exact weaktype_aux₀ hp₀ q₀pos zero_lt_top zero_lt_top h₀T
           (aestronglyMeasurable_trunc_compl hf.1) this
     apply nonpos_iff_eq_zero.mp
-    exact Trans.trans (distribution_mono_right (Trans.trans obs (zero_le (ENNReal.ofReal t))))
+    exact
+      Trans.trans (distribution_mono_right (Trans.trans obs (zero_le (ENNReal.ofReal t))))
         meas_eLpNormEssSup_lt
   · have p_pos : p > 0 := lt_trans hp₀ hp₀p
     have snorm_p_pos : eLpNorm f p μ ≠ 0 :=
@@ -3081,10 +3082,7 @@ variable {α α' E E₁ E₂ E₃ : Type*} {m : MeasurableSpace α} {m' : Measur
   {p p' q p₀ q₀ p₁ q₁: ℝ≥0∞}
   {C₀ C₁ : ℝ≥0} {μ : Measure α} {ν : Measure α'}
   {a : ℝ}-- truncation parameter
-  [NormedAddCommGroup E]
-  [NormedAddCommGroup E₁]
-  [NormedAddCommGroup E₂]
-  [NormedAddCommGroup E₃]
+  [NormedAddCommGroup E] [NormedAddCommGroup E₁] [NormedAddCommGroup E₂] [NormedAddCommGroup E₃]
   [MeasurableSpace E] [BorelSpace E]
   [MeasurableSpace E₃] [BorelSpace E₃]
   {f : α → E₁} {t : ℝ}
@@ -3286,8 +3284,8 @@ lemma rewrite_norm_func {q : ℝ} {g : α' → E}
     distribution g ((ENNReal.ofReal (2 * A * s)))  ν * (ENNReal.ofReal (s^(q - 1))) := by
   rw [lintegral_norm_pow_eq_distribution hg (by linarith)]
   nth_rewrite 1 [← lintegral_scale_constant_halfspace' (a := (2*A)) (by linarith)]
-  rw [← lintegral_const_mul']; swap; exact coe_ne_top
-  rw [← lintegral_const_mul']; swap; exact coe_ne_top
+  rw [← lintegral_const_mul']; swap; · exact coe_ne_top
+  rw [← lintegral_const_mul']; swap; · exact coe_ne_top
   apply lintegral_congr_ae
   filter_upwards [self_mem_ae_restrict measurableSet_Ioi] with t (zero_lt_t : 0 < t)
   nth_rw 12 [mul_comm]
@@ -3354,8 +3352,8 @@ lemma estimate_norm_rpow_range_operator'
   have p_pos : p > 0 := lt_trans hp₀ hp₀p
   -- TODO: is there a way to use lintegral_rw₂ conveniently?
   rw [lintegral_rw_aux power_aux_2, lintegral_rw_aux power_aux_2]
-  nth_rw 2 [← lintegral_const_mul']; swap; refine rpow_ne_top_of_nonneg toReal_nonneg coe_ne_top
-  nth_rw 1 [← lintegral_const_mul']; swap; refine rpow_ne_top_of_nonneg toReal_nonneg coe_ne_top
+  nth_rw 2 [← lintegral_const_mul']; swap; · exact rpow_ne_top_of_nonneg toReal_nonneg coe_ne_top
+  nth_rw 1 [← lintegral_const_mul']; swap; · exact rpow_ne_top_of_nonneg toReal_nonneg coe_ne_top
   simp_rw [← mul_assoc]
   split_ifs with is_q₁top is_q₀top
   · rw [one_mul, one_mul, ← lintegral_add_left']
@@ -3755,14 +3753,14 @@ lemma combine_estimates₀ {A : ℝ} (hA : A > 0)
         ENNReal.ofReal |q.toReal - q₀.toReal|⁻¹) := by
     congr 1
     · split_ifs with is_q₁top
-      congr 3
-      · apply simplify_factor₁ _ hp₀ <;> try assumption
+      · congr 3
+        apply simplify_factor₁ _ hp₀ <;> try assumption
         · rw [hspf]; rfl
         · exact is_q₁top.ne_top
       · simp
     · split_ifs with is_q₀top
-      congr 3
-      · apply simplify_factor₀ _ hp₀ hp₁ <;> try assumption
+      · congr 3
+        apply simplify_factor₀ _ hp₀ hp₁ <;> try assumption
         · rw [hspf]; rfl
         · exact is_q₀top.ne_top
       · simp

--- a/Carleson/RealInterpolation.lean
+++ b/Carleson/RealInterpolation.lean
@@ -425,10 +425,12 @@ lemma ζ_equality₂ (ht : t ∈ Ioo 0 1) :
 lemma ζ_symm :
     @ζ p₀ q₀ p₁ q₁ t = @ζ p₁ q₁ p₀ q₀ (1 - t) := by
   unfold ζ
-  rw [← mul_div_mul_right (c := - 1), mul_assoc _ _ (-1), mul_assoc _ _ (-1)]; swap; positivity
+  rw [← mul_div_mul_right (c := - 1), mul_assoc _ _ (-1), mul_assoc _ _ (-1)]; on_goal 2 => positivity
   simp only [mul_neg, mul_one, neg_sub, _root_.sub_sub_cancel]
   nth_rewrite 1 [add_comm]; nth_rw 2 [add_comm]
 
+set_option linter.style.multiGoal false in
+set_option linter.flexible false in
 lemma ζ_equality₃ (ht : t ∈ Ioo 0 1) (hp₀ : p₀ > 0) (hq₀ : q₀ > 0) (hp₁ : p₁ > 0) (hq₁ : q₁ > 0)
     (hp₀p₁ : p₀ ≠ p₁) (hq₀q₁ : q₀ ≠ q₁)
     (hp : p⁻¹ = (1 - ENNReal.ofReal t) * p₀⁻¹ + ENNReal.ofReal t * p₁⁻¹)
@@ -464,8 +466,7 @@ lemma ζ_equality₃ (ht : t ∈ Ioo 0 1) (hp₀ : p₀ > 0) (hq₀ : q₀ > 0) 
 lemma one_sub_coe_one_sub (ht : t ∈ Ioo 0 1) :
     (1 - ENNReal.ofReal (1 - t)) = ENNReal.ofReal t := by
   have := ht.2
-  rw [← ofReal_one, ← ENNReal.ofReal_sub]
-  congr
+  rw [← ofReal_one, ← ENNReal.ofReal_sub] <;> congr
   · linarith
   · linarith
 
@@ -641,7 +642,7 @@ lemma ζ_pos_iff_aux₀ (ht : t ∈ Ioo 0 1) (hp₀ : p₀ > 0) (hq₀ : q₀ > 
   rw [_root_.div_pos_iff, ← Left.neg_pos_iff, ← Left.neg_pos_iff, neg_mul_eq_mul_neg,
       neg_mul_eq_mul_neg, mul_pos_iff_of_pos_left, mul_pos_iff_of_pos_left,
       mul_pos_iff_of_pos_left, mul_pos_iff_of_pos_left, neg_sub, neg_sub]
-  simp only [sub_pos, sub_neg]
+  · simp only [sub_pos, sub_neg]
   · exact preservation_positivity_inv_toReal ht hq₀ hq₁ hq₀q₁
   · exact preservation_positivity_inv_toReal ht hp₀ hp₁ hp₀p₁
   · exact preservation_positivity_inv_toReal ht hq₀ hq₁ hq₀q₁
@@ -840,7 +841,7 @@ lemma eq_exponents₀ (ht : t ∈ Ioo 0 1) (hq₀ : q₀ > 0) (hq₁ : q₁ > 0)
         congr
         ring
     rw [this, mul_div_assoc, mul_div_cancel_right₀]
-    ring
+    · ring
     exact ne_sub_toReal_exp hq₀ hq₁ hq₀q₁
   · exact ne_sub_toReal_exp hq₀ hq₁ hq₀q₁
 

--- a/Carleson/RealInterpolation.lean
+++ b/Carleson/RealInterpolation.lean
@@ -2559,8 +2559,7 @@ lemma estimate_trnc {p₀ q₀ q : ℝ} {spf : ScaledPowerFunction} {j : Bool}
       apply setLIntegral_congr_fun measurableSet_Ioi
       apply ae_of_all
       intro s _
-      rw [lintegral_const_mul']
-      rw [ENNReal.mul_rpow_of_nonneg]
+      rw [lintegral_const_mul', ENNReal.mul_rpow_of_nonneg]
       · positivity
       · exact (ENNReal.rpow_lt_top_of_nonneg (by positivity) coe_ne_top).ne
     _ ≤ (∫⁻ a : α in Function.support f,
@@ -2836,7 +2835,7 @@ lemma weaktype_estimate {C₀ : ℝ≥0} {p : ℝ≥0∞} {q : ℝ≥0∞} {f : 
   have tq_pos : ENNReal.ofReal t ^ q.toReal > 0 := coe_pow_pos ht
   have tq_ne_top : (ENNReal.ofReal t) ^ q.toReal ≠ ⊤ := coe_rpow_ne_top' q_pos
   -- have hq₁ : q.toReal = q := by exact toReal_ofReal q_nonneg
-  unfold wnorm wnorm' at wt_est; simp [hq'.ne_top] at wt_est
+  simp only [wnorm, wnorm', hq'.ne_top, ↓reduceIte, iSup_le_iff] at wt_est
   have wt_est_t := wt_est t.toNNReal -- this is the weaktype estimate applied to t
   rw [← ENNReal.mul_le_mul_right (c := (ENNReal.ofReal t) ^ q.toReal) _ tq_ne_top,
       ofReal_rpow_of_pos, mul_assoc _ _ (ENNReal.ofReal (t ^ q.toReal)), ← ofReal_mul',
@@ -2910,8 +2909,7 @@ lemma weaktype_estimate_trunc_top_top {a : ℝ} {C₁ : ℝ≥0}
   rw [ha]
   have obs : Memℒp (trunc f (t / C₁)) p₁ μ := trunc_Lp_Lq_higher ⟨hp, hp₁p⟩ hf
   have wt_est := (h₁T (trunc f (t / C₁)) obs).2
-  unfold wnorm eLpNorm at wt_est
-  simp [hq₁, hp₁] at wt_est
+  simp only [wnorm, eLpNorm, hq₁, ↓reduceIte, hp₁, top_ne_zero] at wt_est
   apply nonpos_iff_eq_zero.mp
   have ineq : eLpNormEssSup (T (trunc f (t / C₁))) ν ≤ ENNReal.ofReal t := calc
     _ ≤ C₁ * eLpNormEssSup (trunc f (t / C₁)) μ := wt_est
@@ -2923,7 +2921,7 @@ lemma weaktype_estimate_trunc_top_top {a : ℝ} {C₁ : ℝ≥0}
       have coe_C : C.toNNReal = C₁ := Real.toNNReal_coe
       rw [← coe_C, coe_coe_eq_ofReal, ← ENNReal.ofReal_mul, max_eq_right, congrArg toReal coe_C,
         mul_div_cancel₀]
-      · exact Ne.symm (ne_of_lt hC₁)
+      · exact Ne.symm hC₁.ne
       · positivity
       · positivity
   calc
@@ -2949,8 +2947,7 @@ lemma weaktype_estimate_trunc_compl_top {C₀ : ℝ≥0} (hC₀ : C₀ > 0) {p p
       exact weaktype_aux₀ hp₀ q₀pos zero_lt_top zero_lt_top h₀T
           (aestronglyMeasurable_trunc_compl hf.1) this
     apply nonpos_iff_eq_zero.mp
-    exact
-      Trans.trans (distribution_mono_right (Trans.trans obs (zero_le (ENNReal.ofReal t))))
+    exact Trans.trans (distribution_mono_right (Trans.trans obs (zero_le (ENNReal.ofReal t))))
         meas_eLpNormEssSup_lt
   · have p_pos : p > 0 := lt_trans hp₀ hp₀p
     have snorm_p_pos : eLpNorm f p μ ≠ 0 :=

--- a/Carleson/RealInterpolation.lean
+++ b/Carleson/RealInterpolation.lean
@@ -868,8 +868,8 @@ lemma eq_exponents₂ (ht : t ∈ Ioo 0 1) (hq₀ : q₀ > 0) (hq₁ : q₁ > 0)
         congr
         ring
     rw [this, mul_div_assoc, mul_div_cancel_right₀]
-    ring
-    exact ne_sub_toReal_exp hq₀ hq₁ hq₀q₁
+    · ring
+    · exact ne_sub_toReal_exp hq₀ hq₁ hq₀q₁
   · exact ne_sub_toReal_exp hq₀ hq₁ hq₀q₁
 
 lemma eq_exponents₁ (ht : t ∈ Ioo 0 1) (hq₀ : q₀ > 0) (hq₁ : q₁ > 0) (hq₀q₁ : q₀ ≠ q₁)
@@ -1168,7 +1168,7 @@ lemma d_eq_top_of_eq (hC₁ : C₁ > 0) (hp₀ : p₀ > 0) (hq₀ : q₀ > 0) (h
 (hp₀': p₀ ≠ ⊤) (hp₁ : p₁ > 0) (hp₀p₁ : p₀ = p₁) (hpp₀: p = p₀) (hq₁' : q₁ = ⊤) :
     @d α E₁ m p p₀ q₀ p₁ q₁ C₀ C₁ μ _ f = (C₁ * eLpNorm f p μ).toReal := by
   rw [d_eq_top₁, ← hp₀p₁, hpp₀] <;> try assumption
-  rw [toReal_rpow, ENNReal.mul_rpow_of_nonneg, ENNReal.rpow_rpow_inv, ENNReal.rpow_rpow_inv]
+  on_goal 1 => rw [toReal_rpow, ENNReal.mul_rpow_of_nonneg, ENNReal.rpow_rpow_inv, ENNReal.rpow_rpow_inv]
   · exact exp_toReal_ne_zero' hp₀ hp₀'
   · exact exp_toReal_ne_zero' hp₀ hp₀'
   · positivity
@@ -1612,7 +1612,7 @@ lemma rpow_le_rpow_of_exponent_le_base_le {a b t γ : ℝ} (ht : t > 0) (htγ : 
     rw [← neg_one_mul, Real.rpow_mul, Real.rpow_neg_one, ← Real.mul_rpow] <;> try positivity
     rw [one_div]
     nth_rw 2 [← Real.rpow_neg_one]
-    rw [← Real.rpow_mul]; swap; positivity
+    rw [← Real.rpow_mul (by positivity)]
     nth_rw 3 [mul_comm]
     rw [Real.rpow_mul, Real.rpow_neg_one, ← Real.mul_rpow, ← div_eq_mul_inv] <;> try positivity
     exact ofReal_le_ofReal (power_estimate' ht htγ hab)
@@ -1631,7 +1631,7 @@ lemma rpow_le_rpow_of_exponent_le_base_ge {a b t γ : ℝ} (hγ : γ > 0) (htγ 
     rw [← neg_one_mul, Real.rpow_mul, Real.rpow_neg_one, ← Real.mul_rpow] <;> try positivity
     rw [one_div]
     nth_rw 2 [← Real.rpow_neg_one]
-    rw [← Real.rpow_mul]; swap; positivity
+    rw [← Real.rpow_mul (by positivity)]
     nth_rw 3 [mul_comm]
     rw [Real.rpow_mul, Real.rpow_neg_one, ← Real.mul_rpow, ← div_eq_mul_inv] <;> try positivity
     exact ofReal_le_ofReal (Real.rpow_le_rpow_of_exponent_le ((one_le_div hγ).mpr htγ) hab)
@@ -1686,7 +1686,7 @@ lemma estimate_eLpNorm_trunc_compl {p q : ℝ≥0∞} [MeasurableSpace E₁] [No
       apply trnc_le_func (j := ⊥)
     _ ≤ ENNReal.ofReal (a ^ (q.toReal - p.toReal)) * ∫⁻ x : α in {x | a < ‖f x‖},
         ↑‖f x‖₊ ^ p.toReal ∂μ := by
-      rw [← lintegral_const_mul']; swap; exact coe_ne_top
+      rw [← lintegral_const_mul']; swap; · exact coe_ne_top
       apply setLIntegral_mono_ae (AEMeasurable.restrict (by fun_prop))
       · apply ae_of_all
         intro x (hx : a < ‖f x‖)
@@ -1823,7 +1823,7 @@ lemma res_subset_Ioi {j : Bool} {β : ℝ} (hβ : β > 0) : res j β ⊆ Ioi 0 :
   split
   · exact Ioo_subset_Ioi_self
   · unfold Ioi
-    simp
+    simp only [setOf_subset_setOf]
     intro s hs
     linarith
 
@@ -1871,41 +1871,41 @@ lemma lintegral_trunc_mul₀ {g : ℝ → ℝ≥0∞} {j : Bool} {x : α} {tc : 
     rw [this]
   · apply ae_of_all
     rw [res'comp]
-    intro s
-    unfold res trnc trunc
-    have mon_pf := tc.inv_pf
-    split_ifs at mon_pf with mon
-    · rw [mon]
-      rcases j
-      · simp only [Bool.bne_true, Bool.not_false, not_true_eq_false, decide_False,
-        Bool.false_eq_true, ↓reduceIte, Pi.sub_apply]
-        intro (hs : s > tc.inv ‖f x‖)
-        split_ifs with h
-        · simp [hp]
-        · have := (mon_pf s (lt_trans (tc.ran_inv ‖f x‖ hfx) hs) (‖f x‖) hfx).2.mpr hs
-          contrapose! h; linarith
-      · simp only [bne_self_eq_false, Bool.false_eq_true, not_false_eq_true, decide_True]
-        intro hs
-        split_ifs with h
-        · have := (mon_pf s hs.1 (‖f x‖) hfx).1.mpr hs.2
-          linarith
-        · simp [hp]
-    · rw [Bool.not_eq_true] at mon
-      rw [mon]
-      rcases j
-      · simp only [bne_self_eq_false, Bool.false_eq_true, not_false_eq_true, decide_True,
-        ↓reduceIte, Pi.sub_apply]
-        intro hs
-        split_ifs with h
-        · simp [hp]
-        · have := (mon_pf s hs.1 (‖f x‖) hfx).2.mpr hs.2
-          linarith
-      · simp only [Bool.bne_false, not_true_eq_false, decide_False, Bool.false_eq_true, ↓reduceIte]
-        intro (hs : tc.inv ‖f x‖ < s)
-        have := (mon_pf s (lt_trans (tc.ran_inv ‖f x‖ hfx) hs) (‖f x‖) hfx).1.mpr hs
-        split_ifs with h
-        · linarith
-        · simp [hp]
+    · intro s
+      unfold res trnc trunc
+      have mon_pf := tc.inv_pf
+      split_ifs at mon_pf with mon
+      · rw [mon]
+        rcases j
+        · simp only [Bool.bne_true, Bool.not_false, not_true_eq_false, decide_False,
+          Bool.false_eq_true, ↓reduceIte, Pi.sub_apply]
+          intro (hs : s > tc.inv ‖f x‖)
+          split_ifs with h
+          · simp [hp]
+          · have := (mon_pf s (lt_trans (tc.ran_inv ‖f x‖ hfx) hs) (‖f x‖) hfx).2.mpr hs
+            contrapose! h; linarith
+        · simp only [bne_self_eq_false, Bool.false_eq_true, not_false_eq_true, decide_True]
+          intro hs
+          split_ifs with h
+          · have := (mon_pf s hs.1 (‖f x‖) hfx).1.mpr hs.2
+            linarith
+          · simp [hp]
+      · rw [Bool.not_eq_true] at mon
+        rw [mon]
+        rcases j
+        · simp only [bne_self_eq_false, Bool.false_eq_true, not_false_eq_true, decide_True,
+          ↓reduceIte, Pi.sub_apply]
+          intro hs
+          split_ifs with h
+          · simp [hp]
+          · have := (mon_pf s hs.1 (‖f x‖) hfx).2.mpr hs.2
+            linarith
+        · simp only [Bool.bne_false, not_true_eq_false, decide_False, Bool.false_eq_true, ↓reduceIte]
+          intro (hs : tc.inv ‖f x‖ < s)
+          have := (mon_pf s (lt_trans (tc.ran_inv ‖f x‖ hfx) hs) (‖f x‖) hfx).1.mpr hs
+          split_ifs with h
+          · linarith
+          · simp [hp]
     · exact tc.ran_inv ‖f x‖ hfx
 
 lemma lintegral_trunc_mul₁ {g : ℝ → ℝ≥0∞} {j : Bool} {x : α} {p : ℝ} {tc : ToneCouple} :
@@ -1995,10 +1995,10 @@ lemma lintegral_rpow_abs {j : Bool} {tc : ToneCouple} {γ : ℝ} {t : ℝ}
   unfold res
   split at hγ <;> rename_i xor_split
   · rw [xor_split]
-    simp
+    simp only [↓reduceIte]
     rw [lintegral_rpow_of_gt_abs (tc.ran_inv t ht) hγ]
   · rw [eq_false_of_ne_true xor_split]
-    simp
+    simp only [Bool.false_eq_true, ↓reduceIte]
     rw [lintegral_Ioi_rpow_of_lt_abs (tc.ran_inv t ht) hγ]
 
 lemma value_lintegral_res₀ {j : Bool} {β γ : ℝ} {tc : ToneCouple} (hβ : β > 0)
@@ -2106,6 +2106,7 @@ lemma trunc_cut_sup {μ : Measure α} [SigmaFinite μ] {f : α → ℝ≥0∞} :
     · contrapose! is_x_in_Ampn
       exact monotone_spanningSets _ (Nat.le_add_right m n) wm
 
+set_option linter.flexible false in
 /-- Characterization of `∫⁻ x : α, f x ^ p ∂μ` by a duality argument. -/
 lemma representationLp {μ : Measure α} [SigmaFinite μ] {f : α → ℝ≥0∞}
     (hf : AEMeasurable f μ) {p q : ℝ} (hp : p > 1) (hq : q ≥ 1)
@@ -2154,7 +2155,7 @@ lemma representationLp {μ : Measure α} [SigmaFinite μ] {f : α → ℝ≥0∞
       dsimp only
       split_ifs
       · rfl
-      · simp; positivity
+      · simp only [ENNReal.rpow_eq_zero_iff, true_and, zero_ne_top, false_and, or_false]; positivity
     _ ≤ ∫⁻ (_x : α) in A n, n ^ p ∂μ := by
       apply setLIntegral_mono measurable_const
       · intro x hx

--- a/Carleson/RealInterpolation.lean
+++ b/Carleson/RealInterpolation.lean
@@ -3922,7 +3922,7 @@ lemma exists_hasStrongType_real_interpolation_aux {p₀ p₁ q₀ q₁ p q : ℝ
     apply exists_hasStrongType_real_interpolation_aux₀ (hp := hp) (hq := hq) <;> try assumption
   · let spf := spf_ch ht hq₀q₁ hp₀.1 hq₀ hp₁.1 hq₁ hp₀p₁.ne hC₀ hC₁ ⟨hF, hf.2⟩
     apply combine_estimates₁ <;> try assumption
-    unfold_let spf
+    on_goal 1 => unfold_let spf
     rfl
 
 -- TODO: the below lemmas were split because otherwise the lean server would crash

--- a/Carleson/TileExistence.lean
+++ b/Carleson/TileExistence.lean
@@ -289,8 +289,8 @@ instance {k : ℤ}: LinearOrder (Yk X k) := (Yk_encodable X k).linearOrder
 instance {k : ℤ}: WellFoundedLT (Yk X k) where
   wf := by
     apply (@OrderEmbedding.wellFounded (Yk X k) ℕ)
-    use ⟨(Yk_encodable X k).encode,(Yk_encodable X k).encode_injective⟩
-    · simp only [Embedding.coeFn_mk, Subtype.forall]
+    · use ⟨(Yk_encodable X k).encode,(Yk_encodable X k).encode_injective⟩
+      simp only [Embedding.coeFn_mk, Subtype.forall]
       exact fun i hi j hj ↦ by rfl
     exact wellFounded_lt
 
@@ -922,14 +922,14 @@ lemma transitive_boundary' {k1 k2 k3 : ℤ} (hk1 : -S ≤ k1) (hk2 : -S ≤ k2) 
         exact hx_4k2
       _ < 6 * D^k1 + 4 * D^k1 + 4 * D^k2 := by
         rw [ENNReal.add_lt_add_iff_right]
-        apply ENNReal.add_lt_add hx' hx_4k2'
-        exact ENNReal.mul_ne_top (by finiteness) (hdp_finit k2)
+        · apply ENNReal.add_lt_add hx' hx_4k2'
+        · exact ENNReal.mul_ne_top (by finiteness) (hdp_finit k2)
       _ ≤ 2 * D^k2 + 4 * D^k2 := by
         rw [← right_distrib 6 4 (D^k1:ℝ≥0∞)]
         have hz : (6 + 4 : ℝ≥0∞) = 2 * 5 := by norm_num
         rw [hz, ENNReal.add_le_add_iff_right, mul_assoc]
-        apply mul_le_mul_of_nonneg_left _ (by norm_num)
-        · calc
+        · apply mul_le_mul_of_nonneg_left _ (by norm_num)
+          calc
             (5 * D ^ k1:ℝ≥0∞)
               ≤ D * D^k1 := by
                 gcongr
@@ -1079,9 +1079,9 @@ lemma small_boundary' (k:ℤ) (hk:-S ≤ k) (hk_mK : -S ≤ k - K') (y:Yk X k):
       constructor
       · apply And.right
         apply transitive_boundary hk_mK (le_s hk_mK k') hk k'.property.left.le k'.property.right z y' y
-        simp only [mem_inter_iff]
-        exact And.intro (And.intro hx hy') this
-        exact hz
+        · simp only [mem_inter_iff]
+          exact And.intro (And.intro hx hy') this
+        · exact hz
       exact hy'
     _ = ∑ (k':Ioc (k-K') k), ∑'(z:Yk X k'),
         volume (⋃ (_ : clProp((le_s hk_mK k'),z|hk,y)), I3 (le_s hk_mK k') z) := by
@@ -1557,11 +1557,11 @@ lemma boundary_measure {k:ℤ} (hk:-S ≤ k) (y:Yk X k) {t:ℝ≥0} (ht:t∈ Set
           -- add_lt_add_of_le_of_lt hxb' hxy'
         _ ≤ D^(k-const_n a ht * K') + 4 * D^(k-const_n a ht * K') := by
           rw [ENNReal.add_le_add_iff_right]
-          have := const_n_prop_2 X ht k
-          simp only at this
-          nth_rw 1 [NNReal.val_eq_coe] at this
-          simp_rw [← Real.rpow_intCast] at this
-          · rw [← ENNReal.ofReal_le_ofReal_iff (Real.rpow_nonneg (realD_nonneg) _),
+          · have := const_n_prop_2 X ht k
+            simp only at this
+            nth_rw 1 [NNReal.val_eq_coe] at this
+            simp_rw [← Real.rpow_intCast] at this
+            rw [← ENNReal.ofReal_le_ofReal_iff (Real.rpow_nonneg (realD_nonneg) _),
               ENNReal.ofReal_mul (by exact ht.left.le), ENNReal.ofReal_coe_nnreal,
               ← ENNReal.ofReal_rpow_of_pos (defaultD_pos a),← ENNReal.ofReal_rpow_of_pos (defaultD_pos a),
               ENNReal.ofReal_natCast, ENNReal.rpow_intCast, ENNReal.rpow_intCast] at this

--- a/Carleson/ToMathlib/Height.lean
+++ b/Carleson/ToMathlib/Height.lean
@@ -31,6 +31,11 @@ Some results found here:
   This lemma proves the recursive equation in the blueprint.
 -/
 
+-- This file is polished while upstreaming to mathlib and has an open PR already:
+-- no reason to also do the same polish here.
+set_option linter.flexible false
+set_option linter.style.multiGoal false
+
 lemma ENat.iSup_eq_coe_iff' {α : Type*} [Nonempty α] (f : α → ℕ∞) (n : ℕ) :
     (⨆ x, f x = n) ↔ (∃ x, f x = n) ∧ (∀ y, f y ≤ n) := by
   constructor

--- a/Carleson/WeakType.lean
+++ b/Carleson/WeakType.lean
@@ -140,7 +140,7 @@ lemma approx_above_superset (t₀ : ℝ≥0∞) :
       _  < ↑‖f y‖₊     := wn
   · have h₁ : Iio (↑‖f y‖₊ - t₀) ∈ 𝓝 0 := Iio_mem_nhds (tsub_pos_of_lt h)
     have h₂ := ENNReal.tendsto_inv_nat_nhds_zero h₁
-    simp at h₂
+    simp only [mem_map, mem_atTop_sets, mem_preimage, mem_Iio] at h₂
     rcases h₂ with ⟨n, wn⟩
     simp only [mem_iUnion, mem_setOf_eq]
     use n
@@ -160,7 +160,7 @@ lemma select_neighborhood_distribution (t₀ : ℝ≥0∞) (l : ℝ≥0∞) (hu 
     ∃ n : ℕ, l < distribution f (t₀ + (↑n)⁻¹) μ := by
   have h₁ : Ioi l ∈ (𝓝 (distribution f t₀ μ)) := Ioi_mem_nhds hu
   have h₂ := (tendsto_measure_iUnion_distribution t₀) h₁
-  simp at h₂
+  simp only [mem_map, mem_atTop_sets, mem_preimage, comp_apply, mem_Ioi] at h₂
   rcases h₂ with ⟨n, wn⟩
   use n; exact wn n (Nat.le_refl n)
 
@@ -173,7 +173,7 @@ lemma continuousWithinAt_distribution (t₀ : ℝ≥0∞) :
   · unfold ContinuousWithinAt
     rcases (eq_top_or_lt_top (distribution f t₀ μ)) with db_top | db_not_top
     -- Case: distribution f t₀ μ = ⊤
-    · simp
+    · simp only
       rw [db_top, ENNReal.tendsto_nhds_top_iff_nnreal]
       intro b
       have h₀ : ∃ n : ℕ, ↑b < distribution f (t₀ + (↑n)⁻¹) μ :=
@@ -264,9 +264,9 @@ lemma lintegral_norm_pow_eq_distribution {p : ℝ} (hp : 0 < p) :
   have h2p : 0 ≤ p := hp.le
   have := lintegral_rpow_eq_lintegral_meas_lt_mul μ (f := fun x ↦ ‖f x‖)
     (Eventually.of_forall fun x ↦ norm_nonneg _) hf.norm hp
-  simp [*, ENNReal.coe_rpow_of_nonneg, ← ENNReal.ofReal_rpow_of_nonneg, ← ofReal_norm_eq_coe_nnnorm,
-    ofReal_mul, ← lintegral_const_mul', ← mul_assoc, mul_comm (μ _), distribution]
-    at this ⊢
+  simp only [norm_nonneg, ← ofReal_rpow_of_nonneg, mul_comm (μ _), ne_eq, ofReal_ne_top,
+    not_false_eq_true, ← lintegral_const_mul', ← mul_assoc, ← ofReal_norm_eq_coe_nnnorm, ofReal_mul,
+    distribution, h2p] at this ⊢
   convert this using 1
   refine setLIntegral_congr_fun measurableSet_Ioi (Eventually.of_forall fun x hx ↦ ?_)
   simp_rw [ENNReal.ofReal_lt_ofReal_iff_of_nonneg (le_of_lt hx)]
@@ -293,7 +293,8 @@ lemma eLpNorm_eq_distribution {p : ℝ} (hp : 0 < p) :
   · unfold eLpNorm'
     rw [toReal_ofReal (le_of_lt hp), one_div]
     congr 1
-    rw [← lintegral_const_mul']; swap; exact coe_ne_top
+    rw [← lintegral_const_mul']
+    on_goal 2 => exact coe_ne_top
     rw [lintegral_norm_pow_eq_distribution hf hp]
     congr 1; ext x; rw [ofReal_mul] <;> [ring; positivity]
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -9,6 +9,8 @@ autoImplicit = false
 linter.style.longLine = false
 linter.oldObtain = true
 linter.refine = true
+linter.style.multiGoal = true
+linter.flexible = true
 
 [[require]]
 name = "mathlib"


### PR DESCRIPTION
Both of them could help making proofs more robust. For code to be upstreamed, fixing these is required anyway.