### PR TITLE
Lemma 7.4.2, `adjointCarleson_adjoint`, `BoundedCompactSupport`

### DIFF
--- a/Carleson/Antichain/AntichainTileCount.lean
+++ b/Carleson/Antichain/AntichainTileCount.lean
@@ -2,11 +2,13 @@ import Carleson.TileStructure
 import Carleson.HardyLittlewood
 import Carleson.Psi
 
+macro_rules | `(tactic |gcongr_discharger) => `(tactic | with_reducible assumption)
+
 noncomputable section
 
 open scoped ENNReal NNReal ShortVariables
 
-open MeasureTheory Set
+open MeasureTheory Metric Set
 
 namespace Antichain
 
@@ -14,9 +16,106 @@ variable {X : Type*} {a : ℕ} {q : ℝ} {K : X → X → ℂ} {σ₁ σ₂ : X 
   [MetricSpace X] [ProofData a q K σ₁ σ₂ F G] [TileStructure Q D κ S o]
 
 -- Lemma 6.3.1
-lemma tile_reach {ϑ : Θ X} {N : ℕ} {p p' : 𝔓 X} (hp : dist_(p) (𝒬 p) ϑ ≤ 2^N)
-    (hp' : dist_(p') (𝒬 p') ϑ ≤ 2^N) (hI : 𝓘 p ≤ 𝓘 p') (hs : 𝔰 p < 𝔰 p'):
-  smul (2^(N + 2)) p ≤ smul (2^(N + 2)) p' := sorry
+-- hp is eq. 6.3.1, hp' is eq. 6.3.2.
+lemma tile_reach (ha : 4 ≤ a) {ϑ : Θ X} {N : ℕ} {p p' : 𝔓 X} (hp : dist_(p) (𝒬 p) ϑ ≤ 2^N)
+    (hp' : dist_(p') (𝒬 p') ϑ ≤ 2^N) (hI : 𝓘 p ≤ 𝓘 p') (hs : 𝔰 p < 𝔰 p') :
+    smul (2^(N + 2)) p ≤ smul (2^(N + 2)) p' := by
+  -- 6.3.4
+  have hp2 : dist_(p) ϑ (𝒬 p') ≤ 2^N := by
+    rw [dist_comm]
+    exact le_trans (Grid.dist_mono hI) hp'
+  -- 6.3.5
+  have hp'2 : dist_(p) (𝒬 p) (𝒬 p') ≤ 2^(N + 1) :=
+    calc dist_(p) (𝒬 p) (𝒬 p')
+      _ ≤ dist_(p) (𝒬 p) ϑ + dist_(p) ϑ (𝒬 p') := dist_triangle _ _ _
+      _ ≤ 2^N + 2^N := add_le_add hp hp2
+      _ = 2^(N + 1) := by ring
+  -- Start proof of 6.3.3.
+  simp only [TileLike.le_def, smul_fst, smul_snd]
+  refine ⟨hI, fun o' ho' ↦ ?_⟩ -- o' is ϑ' in blueprint, ho' is 6.3.6.
+  -- 6.3.7
+  have hlt : dist_{𝔠 p', 8 * D^𝔰 p'} (𝒬 p') o' < 2^(5*a + N + 2) := by
+    have hle : dist_{𝔠 p', 8 * D^𝔰 p'} (𝒬 p') o' ≤ (defaultA a) ^ 5 * dist_(p') (𝒬 p') o' := by
+      have hpos : (0 : ℝ) < D^𝔰 p'/4 := by
+        rw [div_eq_mul_one_div, mul_comm]
+        apply mul_defaultD_pow_pos _ (by linarith)
+      have h8 : (8 : ℝ) * D^𝔰 p' = 2^5 * (D^𝔰 p'/4) := by ring
+      rw [h8]
+      exact cdist_le_iterate hpos (𝒬 p') o' 5
+    apply lt_of_le_of_lt hle
+    simp only [defaultA, add_assoc]
+    rw [pow_add, Nat.cast_pow, Nat.cast_ofNat, ← pow_mul, mul_comm a, dist_comm]
+    gcongr
+    exact ho'
+  -- 6.3.8
+  have hin : 𝔠 p ∈ ball (𝔠 p') (4 * D^𝔰 p') := Grid_subset_ball (hI.1 Grid.c_mem_Grid)
+  -- 6.3.9
+  have hball_le : ball (𝔠 p) (4 * D^𝔰 p') ⊆ ball (𝔠 p') (8 * D^𝔰 p') := by
+    intro x hx
+    rw [mem_ball] at hx hin ⊢
+    calc dist x (𝔠 p')
+      _ ≤ dist x (𝔠 p)  + dist (𝔠 p) (𝔠 p') := dist_triangle _ _ _
+      _ < 4 * ↑D ^ 𝔰 p' + 4 * ↑D ^ 𝔰 p' := add_lt_add hx hin
+      _ = 8 * ↑D ^ 𝔰 p' := by ring
+  -- 6.3.10
+  have hlt2 : dist_{𝔠 p, 4 * D^𝔰 p'} (𝒬 p') o' < 2^(5*a + N + 2) :=
+    lt_of_le_of_lt (cdist_mono hball_le) hlt
+  -- 6.3.11
+  have hlt3 : dist_{𝔠 p, 2^((2 : ℤ) - 5*a^2 - 2*a) * D^𝔰 p'} (𝒬 p') o' < 2^N := by
+    have hle : 2 ^ ((5 : ℤ)*a + 2) * dist_{𝔠 p, 2^((2 : ℤ) - 5*a^2 - 2*a) * D^𝔰 p'} (𝒬 p') o' ≤
+        dist_{𝔠 p, 4 * D^𝔰 p'} (𝒬 p') o' := by
+      have heq : (defaultA a : ℝ) ^ ((5 : ℤ)*a + 2) * 2^((2 : ℤ) - 5*a^2 - 2*a) = 4 := by
+        simp only [defaultA, Nat.cast_pow, Nat.cast_ofNat, ← zpow_natCast, ← zpow_mul]
+        rw [← zpow_add₀ two_ne_zero]
+        ring_nf
+      rw [← heq, mul_assoc]
+      exact le_cdist_iterate (by positivity) (𝒬 p') o' (5*a + 2)
+    rw [← le_div_iff₀' (by positivity), div_eq_mul_inv, ← zpow_neg, neg_add, ← neg_mul,
+      ← sub_eq_add_neg, mul_comm _ ((2 : ℝ) ^ _)] at hle
+    calc dist_{𝔠 p, 2^((2 : ℤ) - 5*a^2 - 2*a) * D^𝔰 p'} (𝒬 p') o'
+      _ ≤ 2^(-(5 : ℤ)*a - 2) * dist_{𝔠 p, 4 * D^𝔰 p'} (𝒬 p') o' := hle
+      _ < 2^(-(5 : ℤ)*a - 2) * 2^(5*a + N + 2) := (mul_lt_mul_left (by positivity)).mpr hlt2
+      _ = 2^N := by
+        rw [← zpow_natCast, ← zpow_add₀ two_ne_zero]
+        simp only [Int.reduceNeg, neg_mul, Nat.cast_add, Nat.cast_mul, Nat.cast_ofNat,
+          sub_add_add_cancel, neg_add_cancel_left, zpow_natCast]
+  -- 6.3.12
+  have hp'3 : dist_(p) (𝒬 p') o' < 2^N := by
+    apply lt_of_le_of_lt (cdist_mono _) hlt3
+    gcongr
+    rw [div_le_iff₀ (by positivity)]
+    rw [mul_comm, ← mul_assoc]
+    calc (D : ℝ) ^ 𝔰 p
+      _ = 1 * (D : ℝ) ^ 𝔰 p := by rw [one_mul]
+      _ ≤ 4 * 2 ^ (2 - 5 * (a : ℤ) ^ 2 - 2 * ↑a) * D * D ^ 𝔰 p := by
+        have h4 : (4 : ℝ) = 2^(2 : ℤ) := by ring
+        apply mul_le_mul _ (le_refl _) (by positivity) (by positivity)
+        · have h12 : (1 : ℝ) ≤ 2 := one_le_two
+          simp only [defaultD, Nat.cast_pow, Nat.cast_ofNat]
+          rw [h4, ← zpow_natCast, ← zpow_add₀ two_ne_zero, ← zpow_add₀ two_ne_zero,
+            ← zpow_zero (2 : ℝ)]
+          rw [Nat.cast_mul, Nat.cast_ofNat, Nat.cast_pow]
+          gcongr --uses h12
+          have : (2 : ℝ)^a = 2^(a : ℤ) := by rw [@zpow_natCast]
+          ring_nf
+          nlinarith
+      _ = (4 * 2 ^ (2 - 5 * (a : ℤ)  ^ 2 - 2 * ↑a)) * (D * D ^ 𝔰 p) := by ring
+      _ ≤ 4 * 2 ^ (2 - 5 * (a : ℤ)  ^ 2 - 2 * ↑a) * D ^ 𝔰 p' := by
+        have h1D : 1 ≤ (D : ℝ) := one_le_D
+        nth_rewrite 1 [mul_le_mul_left (by positivity), ← zpow_one (D : ℝ),
+          ← zpow_add₀ (ne_of_gt (defaultD_pos _))]
+        gcongr
+        rw [add_comm]
+        exact hs
+  -- 6.3.13 (and 6.3.3.)
+  have h34 : (3 : ℝ) < 4 := by linarith
+  calc dist_(p) o' (𝒬 p)
+    _ = dist_(p) (𝒬 p) o' := by rw [dist_comm]
+    _ ≤ dist_(p) (𝒬 p) (𝒬 p') + dist_(p) (𝒬 p') o' := dist_triangle _ _ _
+    _ < 2^(N + 1) + 2^N := add_lt_add_of_le_of_lt hp'2 hp'3
+    _ < 2^(N + 2) := by ring_nf; gcongr -- uses h34
+  -- 6.3.14 -- Not needed
+
 
 -- Def 6.3.15
 def 𝔄_aux (𝔄 : Finset (𝔓 X)) (ϑ : Θ X) (N : ℕ) : Finset (𝔓 X) :=

--- a/Carleson/ForestOperator/AlmostOrthogonality.lean
+++ b/Carleson/ForestOperator/AlmostOrthogonality.lean
@@ -115,28 +115,28 @@ theorem _root_.MeasureTheory.integral_mul_const {X : Type*} [MeasurableSpace X] 
 --#check integrable_Ks_x
 theorem _root_.MeasureTheory.BoundedCompactSupport.carlesonOn
     (hf : BoundedCompactSupport f) : BoundedCompactSupport (carlesonOn p f) :=
-  sorry
+  sorry -- still painful, set up so that things below are reused as much as possible
 
 -- remove comments when actually used
 -- theorem _root_.MeasureTheory.BoundedCompactSupport.carlesonSum {ℭ : Set (𝔓 X)}
 --     (hf : BoundedCompactSupport f) : BoundedCompactSupport (carlesonSum ℭ f) :=
 --   Finset.boundedCompactSupport_sum fun _ _ ↦ hf.carlesonOn
 
-theorem adjointCarleson_isBounded (hf : BoundedCompactSupport f) :
-    IsBounded (range (adjointCarleson p f)) := by sorry
-  --apply isBounded_range_iff_forall_norm_le.mpr
+-- theorem adjointCarleson_isBounded (hf : BoundedCompactSupport f) :
+--     IsBounded (range (adjointCarleson p f)) := by sorry
+--   --apply isBounded_range_iff_forall_norm_le.mpr
 
-theorem _root_.HasCompactSupport.adjointCarleson (hf : BoundedCompactSupport f) :
-    HasCompactSupport (adjointCarleson p f) := sorry
+-- theorem _root_.HasCompactSupport.adjointCarleson (hf : BoundedCompactSupport f) :
+--     HasCompactSupport (adjointCarleson p f) := sorry
 
 theorem _root_.MeasureTheory.BoundedCompactSupport.adjointCarleson
     (hf : BoundedCompactSupport f) : BoundedCompactSupport (adjointCarleson p f) :=
-  ⟨adjointCarleson_isBounded hf, HasCompactSupport.adjointCarleson hf, hf.3.adjointCarleson⟩
+  sorry -- similar proof as for `carlesonOn` -- try to set it up with not too much redundancy
+--  ⟨adjointCarleson_isBounded hf, HasCompactSupport.adjointCarleson hf, hf.3.adjointCarleson⟩
 
 theorem _root_.MeasureTheory.BoundedCompactSupport.adjointCarlesonSum {ℭ : Set (𝔓 X)}
     (hf : BoundedCompactSupport f) : BoundedCompactSupport (adjointCarlesonSum ℭ f) :=
   Finset.boundedCompactSupport_sum fun _ _ ↦ hf.adjointCarleson
-
 
 /-- `Ks` is bounded uniformly in `x`, `y` assuming `x` is in a fixed closed ball. -/
 lemma norm_Ks_le_of_dist_le {x y x₀ : X} {r₀ : ℝ} (hr₀ : 0 < r₀) (hx : dist x x₀ ≤ r₀) (s : ℤ) :
@@ -227,7 +227,7 @@ lemma adjointCarleson_adjoint
     have hHleH₀ x y : ‖H x y‖ ≤ M₀ * H₀ x y := by
       by_cases h : x ∈ tsupport g
       · specialize hM₀ x y h
-        calc -- can certainly be shortened..
+        calc -- can certainly be shortened!
           _ ≤ ‖conj (g x) * (E p).indicator 1 x * MKD (𝔰 p) x y‖ * ‖f y‖ := norm_mul_le ..
           _ ≤ ‖conj (g x) * (E p).indicator 1 x‖ * ‖MKD (𝔰 p) x y‖ * ‖f y‖ := by
             gcongr; exact norm_mul_le ..

--- a/Carleson/ForestOperator/AlmostOrthogonality.lean
+++ b/Carleson/ForestOperator/AlmostOrthogonality.lean
@@ -108,7 +108,7 @@ lemma _root_.MeasureTheory.ae_bounded_of_isBounded_range
   intro x
   calc
     _ = ‖f x - f x₀ + f x₀‖ := by group
-    _ ≤ ‖f x - f x₀‖ + ‖f x₀‖ := norm_add_le _ _
+    _ ≤ ‖f x - f x₀‖ + ‖f x₀‖ := norm_add_le ..
     _ ≤ _ := by gcongr; exact hM x x₀
 
 -- -- mathlib?
@@ -166,9 +166,15 @@ lemma adjointCarleson_adjoint
     (hf : BoundedCompactSupport f) (hg : BoundedCompactSupport g) (p : 𝔓 X) :
     ∫ x, conj (g x) * carlesonOn p f x = ∫ y, conj (adjointCarleson p g y) * f y := by
   let H := fun x ↦ fun y ↦ conj (g x) * (E p).indicator 1 x * MKD (𝔰 p) x y * f y
-  have H_int : Integrable (uncurry H) := by
-    -- todo: should be a tactic `integrable` or so that kills this
-    sorry
+  have hH : BoundedCompactSupport (uncurry H) := by
+    let M₀ : ℝ := sorry -- insert bound for `K`
+    let H₀ := fun x y ↦ M₀ * ‖g x‖ * ‖f y‖
+    have hHleH₀ x y : ‖H x y‖ ≤ H₀ x y := by
+      sorry -- use bound for `K`
+    refine BoundedCompactSupport.of_norm_le (g := uncurry H₀) ?_ ?_
+    · refine BoundedCompactSupport.prod_mul ?_ hf.norm
+      sorry -- hg.norm.const_mul _
+    · intro ⟨x,y⟩; simp only [uncurry_apply_pair]; exact hHleH₀ ..
   calc
     _ = ∫ x, conj (g x) * ∫ y, (E p).indicator 1 x * MKD (𝔰 p) x y * f y := by
       conv =>
@@ -176,7 +182,7 @@ lemma adjointCarleson_adjoint
         rw [indicator_eq_mul_indicator_one, mul_comm, ← integral_const_mul]
         enter [2, y]; rw [← mul_assoc]
     _ = ∫ x, ∫ y, H x y := by unfold H; simp_rw [← integral_const_mul, mul_assoc]
-    _ = ∫ y, ∫ x, H x y := integral_integral_swap H_int
+    _ = ∫ y, ∫ x, H x y := integral_integral_swap hH.integrable
     _ = ∫ y, (∫ x, conj (g x) * (E p).indicator 1 x * MKD (𝔰 p) x y) * f y := by
       simp_rw [integral_mul_const]
     _ = ∫ y, conj (∫ x, g x * (E p).indicator 1 x * conj (MKD (𝔰 p) x y)) * f y := by
@@ -184,7 +190,7 @@ lemma adjointCarleson_adjoint
     _ = _ := by
       congr! with y
       calc
-        _ = ∫ x, (E p).indicator 1 x * g x * conj (MKD (𝔰 p) x y) := by congr! 3; exact mul_comm _ _
+        _ = ∫ x, (E p).indicator 1 x * g x * conj (MKD (𝔰 p) x y) := by congr! 3; exact mul_comm ..
         _ = ∫ x, (E p).indicator (fun x ↦ g x * conj (MKD (𝔰 p) x y)) x := by
           congr!; simp only [indicator]; split_ifs <;> simp
         _ = ∫ x in E p, g x * conj (MKD (𝔰 p) x y) := integral_indicator measurableSet_E

--- a/Carleson/ForestOperator/AlmostOrthogonality.lean
+++ b/Carleson/ForestOperator/AlmostOrthogonality.lean
@@ -173,12 +173,6 @@ lemma adjointCarleson_adjoint
           _ = M₀ *  ‖g x‖ * ‖f y‖ := by rw [mul_assoc]
       · suffices hz : H x y = 0 by rw [hz]; simp only [norm_zero, ge_iff_le]; positivity
         unfold H; simp [image_eq_zero_of_nmem_tsupport h]
-    ---- If we were proving `BoundedCompactSupport (uncurry H)` instead, then the following
-    ---- three lines would finish it up
-    -- refine BoundedCompactSupport.of_norm_le_const_mul (g := uncurry H₀) (M := M₀) ?_ ?_
-    -- · exact hg.norm.prod_mul hf.norm
-    -- · intro ⟨x,y⟩; simp only [uncurry_apply_pair]; exact hHleH₀ ..
-    ---- But instead we have to do the following:
     have : Integrable (fun z : X × X ↦ M₀ *  ‖g z.1‖ * ‖f z.2‖) :=
       Integrable.prod_mul (hg.norm.const_mul _).integrable hf.norm.integrable
     refine this.mono ?_ ?_

--- a/Carleson/ForestOperator/AlmostOrthogonality.lean
+++ b/Carleson/ForestOperator/AlmostOrthogonality.lean
@@ -101,31 +101,6 @@ lemma _root_.Set.conj_indicator {α 𝕜 : Type*} [RCLike 𝕜] {f : α → 𝕜
     conj (s.indicator f x) = s.indicator (conj f) x := by
   simp only [indicator]; split_ifs <;> simp
 
---#check integrable_Ks_x
-theorem _root_.MeasureTheory.BoundedCompactSupport.carlesonOn
-    (hf : BoundedCompactSupport f) : BoundedCompactSupport (carlesonOn p f) :=
-  sorry -- still painful, set up so that things below are reused as much as possible
-
--- remove comments when actually used
--- theorem _root_.MeasureTheory.BoundedCompactSupport.carlesonSum {ℭ : Set (𝔓 X)}
---     (hf : BoundedCompactSupport f) : BoundedCompactSupport (carlesonSum ℭ f) :=
---   Finset.boundedCompactSupport_sum fun _ _ ↦ hf.carlesonOn
-
--- theorem adjointCarleson_isBounded (hf : BoundedCompactSupport f) :
---     IsBounded (range (adjointCarleson p f)) := by sorry
---   --apply isBounded_range_iff_forall_norm_le.mpr
-
--- theorem _root_.HasCompactSupport.adjointCarleson (hf : BoundedCompactSupport f) :
---     HasCompactSupport (adjointCarleson p f) := sorry
-
-theorem _root_.MeasureTheory.BoundedCompactSupport.adjointCarleson
-    (hf : BoundedCompactSupport f) : BoundedCompactSupport (adjointCarleson p f) :=
-  sorry -- similar proof as for `carlesonOn` -- try to set it up with not too much redundancy
---  ⟨adjointCarleson_isBounded hf, HasCompactSupport.adjointCarleson hf, hf.3.adjointCarleson⟩
-
-theorem _root_.MeasureTheory.BoundedCompactSupport.adjointCarlesonSum {ℭ : Set (𝔓 X)}
-    (hf : BoundedCompactSupport f) : BoundedCompactSupport (adjointCarlesonSum ℭ f) :=
-  Finset.boundedCompactSupport_sum fun _ _ ↦ hf.adjointCarleson
 
 /-- `Ks` is bounded uniformly in `x`, `y` assuming `x` is in a fixed closed ball. -/
 lemma norm_Ks_le_of_dist_le {x y x₀ : X} {r₀ : ℝ} (hr₀ : 0 < r₀) (hx : dist x x₀ ≤ r₀) (s : ℤ) :
@@ -150,29 +125,27 @@ lemma norm_Ks_le_of_dist_le {x y x₀ : X} {r₀ : ℝ} (hr₀ : 0 < r₀) (hx :
     _ ≤ C⁻¹ * (C * volume.real (ball x (D^s))) := by gcongr
     _ = _ := by field_simp
 
-/-- Version of `norm_Ks_le_of_dist_le` without assumption `0 < r₀` but
-with lengthy (irrelevant) constant -/
-lemma norm_Ks_le_of_dist_le' {x y x₀ : X} {r₀ : ℝ} (hx : dist x x₀ ≤ r₀) (s : ℤ) :
-    ‖Ks s x y‖ ≤ (C2_1_3 a * (As (defaultA a) (2*r₀/D^s)) / volume.real (ball x₀ r₀)) ⊔
-        (C2_1_3 a / volume.real (ball x₀ (D^s))) := by
-  by_cases hr₀ : 0 < r₀
-  · exact norm_Ks_le_of_dist_le hr₀ hx _ |>.trans <| le_max_left ..
-  · have : x = x₀ := dist_le_zero.mp <| hx.trans <| not_lt.mp hr₀
-    rw [this]
-    exact norm_Ks_le.trans <| le_max_right ..
+-- /-- Version of `norm_Ks_le_of_dist_le` without assumption `0 < r₀` but
+-- with lengthy (irrelevant) constant -/
+---- not needed, remove later
+-- lemma norm_Ks_le_of_dist_le' {x y x₀ : X} {r₀ : ℝ} (hx : dist x x₀ ≤ r₀) (s : ℤ) :
+--     ‖Ks s x y‖ ≤ (C2_1_3 a * (As (defaultA a) (2*r₀/D^s)) / volume.real (ball x₀ r₀)) ⊔
+--         (C2_1_3 a / volume.real (ball x₀ (D^s))) := by
+--   by_cases hr₀ : 0 < r₀
+--   · exact norm_Ks_le_of_dist_le hr₀ hx _ |>.trans <| le_max_left ..
+--   · have : x = x₀ := dist_le_zero.mp <| hx.trans <| not_lt.mp hr₀
+--     rw [this]
+--     exact norm_Ks_le.trans <| le_max_right ..
 
 /-- `‖Ks x y‖` is bounded if `x` is in a bounded set -/
 lemma _root_.Bornology.IsBounded.exists_bound_of_norm_Ks
     {A : Set X} (hA : IsBounded A) (s : ℤ) :
     ∃ C, 0 ≤ C ∧ ∀ x y, x ∈ A → ‖Ks s x y‖ ≤ C := by
   obtain x₀ : X := Classical.choice (by infer_instance)
-  obtain ⟨r₀, h⟩ := Metric.isBounded_iff_subset_closedBall x₀ |>.mp hA
-  -- use (C2_1_3 a * (As (defaultA a) (2*r₀/D^s)) / volume.real (ball x₀ r₀)) ⊔
-  --       (C2_1_3 a / volume.real (ball x₀ (D^s)))
-  -- exact ⟨by positivity, fun _ _ hx ↦ norm_Ks_le_of_dist_le' (h hx) s⟩
+  obtain ⟨r₀, hr₀, h⟩ := hA.subset_closedBall_lt 0 x₀
   use ?_; constructor; swap -- let Lean fill in the value of the ugly constant
   · intro x y hx
-    convert norm_Ks_le_of_dist_le' (h hx) s
+    convert norm_Ks_le_of_dist_le hr₀ (h hx) s
   · positivity
 
 -- lemma _root_.Bornology.IsBounded.norm_Ks_mul_of_isBounded_range
@@ -193,7 +166,85 @@ lemma norm_indicator_one_le {α E}
     ‖s.indicator (1 : α → E) x‖ ≤ 1 :=
   Trans.trans (norm_indicator_le_norm_self 1 x) norm_one
 
+lemma norm_exp_I_mul_ofReal (x : ℝ) : ‖exp (.I * x)‖ = 1 := by
+  rw [mul_comm, Complex.norm_exp_ofReal_mul_I]
+
+lemma norm_exp_I_mul_sub_ofReal (x y: ℝ) : ‖exp (.I * (x - y))‖ = 1 := by
+  rw [mul_comm, ← ofReal_sub, Complex.norm_exp_ofReal_mul_I]
+
 end ToBeMovedToAppropriateLocations
+
+-- #check norm_integral_le_of_norm_le_const
+-- #check norm_setIntegral_le_of_norm_le_const_ae
+--#check integrable_Ks_x
+
+-- move
+lemma volume_E_lt_top : volume (E p) < ⊤ := trans (measure_mono E_subset_𝓘) volume_coeGrid_lt_top
+
+theorem _root_.MeasureTheory.BoundedCompactSupport.adjointCarleson
+    (hf : BoundedCompactSupport f) : BoundedCompactSupport (adjointCarleson p f) where
+  memℒp_top := by
+    obtain ⟨CKf, hCKf, hCKf⟩ := hf.2.isBounded.exists_bound_of_norm_Ks (𝔰 p)
+    let C : ℝ := CKf * (eLpNorm f ⊤).toReal * volume.real (E p)
+    suffices ∀ᵐ x, ‖TileStructure.Forest.adjointCarleson p f x‖ ≤ C from
+      memℒp_top_of_bound hf.aestronglyMeasurable.adjointCarleson _ this
+    apply ae_of_all
+    intro x
+    refine norm_setIntegral_le_of_norm_le_const_ae ?_ ?_
+    · exact volume_E_lt_top
+    · apply ae_restrict_of_ae
+      filter_upwards [hf.ae_le] with y hy
+      suffices ‖Ks (𝔰 p) y x‖ * ‖f y‖ ≤ ?C by
+        calc
+          _ ≤ ‖conj (Ks (𝔰 p) y x) * cexp (I * (↑((Q y) y) - ↑((Q y) x)))‖ * ‖f y‖ :=
+            norm_mul_le ..
+          _ ≤ ‖conj (Ks (𝔰 p) y x)‖ * 1 * ‖f y‖ := by
+            gcongr; convert norm_mul_le _ _; exact (norm_exp_I_mul_sub_ofReal ..).symm
+          _ = ‖Ks (𝔰 p) y x‖ * ‖f y‖ := by rw [mul_one, RCLike.norm_conj]
+          _ ≤ _ := by convert this
+      by_cases hy : y ∈ tsupport f
+      · specialize hCKf y x hy; gcongr
+      · simp only [norm_eq_abs, image_eq_zero_of_nmem_tsupport hy,
+          norm_zero, mul_zero, eLpNorm_exponent_top]; positivity
+  hasCompactSupport := by
+    obtain x₀ : X := Classical.choice (by infer_instance)
+    obtain ⟨r₀, h⟩ := hf.isBoundedSupport.subset_ball x₀
+    let C : ℝ := (↑D ^ 𝔰 p / 2) + r₀
+    suffices support (TileStructure.Forest.adjointCarleson p f) ⊆ closedBall x₀ C by
+      refine HasCompactSupport.of_support_subset_isCompact ?_ this
+      exact isCompact_closedBall ..
+    intro x hx
+    apply mem_support.mp at hx
+    have : ∃ y, conj (Ks (𝔰 p) y x) * exp (.I * (Q y y - Q y x)) * f y ≠ 0 := by
+      by_contra hc
+      simp only [not_exists, ne_eq, not_not] at hc
+      exact hx <| setIntegral_eq_zero_of_forall_eq_zero fun x _ ↦ hc x
+    simp only [ne_eq, mul_eq_zero, map_eq_zero, exp_ne_zero, or_false, not_or] at this
+    obtain ⟨y, hKy, hfy⟩ := this
+    change _ ≤ C
+    apply (dist_triangle _ y _).trans
+    unfold C
+    gcongr
+    · rw [dist_comm]; exact (dist_mem_Icc_of_Ks_ne_zero hKy).2
+    · exact le_of_lt <| h hfy
+
+-- -- mathlib?
+-- theorem _root_.MeasureTheory.HasCompactSupport.of_support_subset_isBounded {s : Set X}
+--   (hs : IsBounded s) (hf : support f ⊆ s) : HasCompactSupport
+
+-- indicator (E p)
+--   fun x ↦ ∫ y, exp (I * (Q x y - Q x x)) * K x y * ψ (D ^ (- 𝔰 p) * dist x y) * f y
+theorem _root_.MeasureTheory.BoundedCompactSupport.carlesonOn
+    (hf : BoundedCompactSupport f) : BoundedCompactSupport (carlesonOn p f) where
+  memℒp_top := sorry
+  hasCompactSupport := by
+    -- suffices support (_root_.carlesonOn p f) ⊆ (E p) by
+      -- refine HasCompactSupport.of_support_subset_isCompact ?_ this
+    sorry
+
+theorem _root_.MeasureTheory.BoundedCompactSupport.adjointCarlesonSum {ℭ : Set (𝔓 X)}
+    (hf : BoundedCompactSupport f) : BoundedCompactSupport (adjointCarlesonSum ℭ f) :=
+  Finset.boundedCompactSupport_sum fun _ _ ↦ hf.adjointCarleson
 
 -- short for `modulated kernel times dilated bump`
 private abbrev MKD (s:ℤ) x y := exp (.I * (Q x y - Q x x)) * K x y * ψ (D ^ (-s) * dist x y)
@@ -203,7 +254,7 @@ private lemma norm_MKD_le_norm_Ks {s:ℤ} {x y : X} : ‖MKD s x y‖ ≤ ‖Ks 
   unfold MKD; rw [mul_assoc, ← Ks_def]
   apply (norm_mul_le ..).trans
   apply le_of_eq
-  rw [mul_comm I _, ← ofReal_sub, Complex.norm_exp_ofReal_mul_I, one_mul]
+  rw [norm_exp_I_mul_sub_ofReal, one_mul]
 
 /-- `adjointCarleson` is the adjoint of `carlesonOn`. -/
 lemma adjointCarleson_adjoint
@@ -216,7 +267,7 @@ lemma adjointCarleson_adjoint
     have hHleH₀ x y : ‖H x y‖ ≤ M₀ * H₀ x y := by
       by_cases h : x ∈ tsupport g
       · specialize hM₀ x y h
-        calc -- can certainly be shortened!
+        calc
           _ ≤ ‖conj (g x) * (E p).indicator 1 x * MKD (𝔰 p) x y‖ * ‖f y‖ := norm_mul_le ..
           _ ≤ ‖conj (g x) * (E p).indicator 1 x‖ * ‖MKD (𝔰 p) x y‖ * ‖f y‖ := by
             gcongr; exact norm_mul_le ..

--- a/Carleson/ForestOperator/AlmostOrthogonality.lean
+++ b/Carleson/ForestOperator/AlmostOrthogonality.lean
@@ -86,122 +86,6 @@ lemma adjoint_tile_support2 (hu : u ∈ t) (hp : p ∈ t u) : adjointCarleson p 
     adjoint_tile_support1, indicator_indicator, ← right_eq_inter.mpr]
   exact (ball_subset_ball (by gcongr; norm_num)).trans (t.ball_subset hu hp)
 
-section ToBeMovedToAppropriateLocations
-
--- mathlib should have this, but I can't find it
--- lemma _root_.Set.indicator_eq_mul_indicator_one {ι M:Type*} [MulZeroOneClass M]
---     (s : Set ι) (f : ι → M) (x : ι) : s.indicator f x = f x * s.indicator 1 x := by
---   simp only [indicator]; split_ifs <;> simp
-
-lemma _root_.Set.indicator_eq_indicator_one_mul {ι M:Type*} [MulZeroOneClass M]
-    (s : Set ι) (f : ι → M) (x : ι) : s.indicator f x = s.indicator 1 x * f x := by
-  simp only [indicator]; split_ifs <;> simp
-
-lemma _root_.Set.conj_indicator {α 𝕜 : Type*} [RCLike 𝕜] {f : α → 𝕜} (s : Set α) (x : α):
-    conj (s.indicator f x) = s.indicator (conj f) x := by
-  simp only [indicator]; split_ifs <;> simp
-
-
-/-- `Ks` is bounded uniformly in `x`, `y` assuming `x` is in a fixed closed ball. -/
-lemma norm_Ks_le_of_dist_le {x y x₀ : X} {r₀ : ℝ} (hr₀ : 0 < r₀) (hx : dist x x₀ ≤ r₀) (s : ℤ) :
-    ‖Ks s x y‖ ≤ C2_1_3 a * (As (defaultA a) (2*r₀/D^s)) / volume.real (ball x₀ r₀) := by
-  let C := As (defaultA a) (2*r₀/D^s)
-  have : 0 < C := As_pos (volume : Measure X) (2*r₀/D^s)
-  have : 0 < volume.real (ball x₀ r₀) := measure_ball_pos_real _ _ hr₀
-  suffices h : C⁻¹*volume.real (ball x₀ r₀) ≤ volume.real (ball x (D^s)) by
-    apply norm_Ks_le.trans
-    calc
-      _ ≤ C2_1_3 a / (C⁻¹*volume.real (ball x₀ r₀)) := by gcongr
-      _ = _ := by unfold defaultA defaultD C; field_simp
-  have : volume.real (ball x (2*r₀)) ≤ C * volume.real (ball x (D^s)) := by
-    have : (0:ℝ) < D := defaultD_pos _
-    refine measure_ball_le_same x (by positivity) ?_
-    apply le_of_eq; field_simp
-  calc
-    _ ≤ C⁻¹ * volume.real (ball x (2*r₀)) := by
-      gcongr
-      · exact measure_ball_ne_top x (2 * r₀)
-      · exact ball_subset_ball_of_le (by linarith)
-    _ ≤ C⁻¹ * (C * volume.real (ball x (D^s))) := by gcongr
-    _ = _ := by field_simp
-
--- /-- Version of `norm_Ks_le_of_dist_le` without assumption `0 < r₀` but
--- with lengthy (irrelevant) constant -/
----- not needed, remove later
--- lemma norm_Ks_le_of_dist_le' {x y x₀ : X} {r₀ : ℝ} (hx : dist x x₀ ≤ r₀) (s : ℤ) :
---     ‖Ks s x y‖ ≤ (C2_1_3 a * (As (defaultA a) (2*r₀/D^s)) / volume.real (ball x₀ r₀)) ⊔
---         (C2_1_3 a / volume.real (ball x₀ (D^s))) := by
---   by_cases hr₀ : 0 < r₀
---   · exact norm_Ks_le_of_dist_le hr₀ hx _ |>.trans <| le_max_left ..
---   · have : x = x₀ := dist_le_zero.mp <| hx.trans <| not_lt.mp hr₀
---     rw [this]
---     exact norm_Ks_le.trans <| le_max_right ..
-
-/-- `‖Ks x y‖` is bounded if `x` is in a bounded set -/
-lemma _root_.Bornology.IsBounded.exists_bound_of_norm_Ks
-    {A : Set X} (hA : IsBounded A) (s : ℤ) :
-    ∃ C, 0 ≤ C ∧ ∀ x y, x ∈ A → ‖Ks s x y‖ ≤ C := by
-  obtain x₀ : X := Classical.choice (by infer_instance)
-  obtain ⟨r₀, hr₀, h⟩ := hA.subset_closedBall_lt 0 x₀
-  use ?_; constructor; swap -- let Lean fill in the value of the ugly constant
-  · intro x y hx
-    convert norm_Ks_le_of_dist_le hr₀ (h hx) s
-  · positivity
-
--- lemma _root_.Bornology.IsBounded.norm_Ks_mul_of_isBounded_range
---     (hf : IsBounded (range f)) (s : ℤ) :
-
----- not really needed
--- lemma measure_ball_le_same'' {x : X} {r r' : ℝ} (hr : r > 0) :
---     volume.real (ball x r') ≤ As (defaultA a) (r'/r) * volume.real (ball x r) := by
---   let s := r'/r
---   have : r' ≤ s * r := by apply le_of_eq; unfold s; field_simp
---   by_cases hr' : r' > 0
---   · apply measure_ball_le_same x (show 0 < s by positivity) this
---   · sorry
-
--- for mathlib?
-lemma norm_indicator_one_le {α E}
-    [SeminormedAddCommGroup E] [One E] [NormOneClass E] {s : Set α} (x : α) :
-    ‖s.indicator (1 : α → E) x‖ ≤ 1 :=
-  Trans.trans (norm_indicator_le_norm_self 1 x) norm_one
-
-lemma norm_exp_I_mul_ofReal (x : ℝ) : ‖exp (.I * x)‖ = 1 := by
-  rw [mul_comm, Complex.norm_exp_ofReal_mul_I]
-
-lemma norm_exp_I_mul_sub_ofReal (x y: ℝ) : ‖exp (.I * (x - y))‖ = 1 := by
-  rw [mul_comm, ← ofReal_sub, Complex.norm_exp_ofReal_mul_I]
-
-
--- mathlib? also `ball` variant, remove `Nonempty`
-theorem _root_.MeasureTheory.HasCompactSupport.of_support_subset_closedBall {x : X}
- {r : ℝ} [ProperSpace X] [Nonempty X] (hf : support f ⊆ closedBall x r) :
-    HasCompactSupport f := by
-  apply HasCompactSupport.of_support_subset_isCompact ?_ hf
-  exact isCompact_closedBall ..
-
-theorem _root_.MeasureTheory.HasCompactSupport.of_support_subset_isBounded {s : Set X}
-    [ProperSpace X] [Nonempty X] (hs : IsBounded s) (hf : support f ⊆ s) :
-    HasCompactSupport f := by
-  let x₀ : X := Classical.choice (by infer_instance)
-  obtain ⟨r₀, hr₀⟩ := hs.subset_closedBall x₀
-  exact HasCompactSupport.of_support_subset_closedBall <| Trans.trans hf hr₀
-
--- move
-lemma volume_E_lt_top : volume (E p) < ⊤ := trans (measure_mono E_subset_𝓘) volume_coeGrid_lt_top
-
--- must be in mathlib but can't find it
-theorem _root_.MeasureTheory.Integrable.indicator_const {c : ℝ} {s: Set X}
-    (hs: MeasurableSet s) (h2s : volume s < ⊤) : Integrable (s.indicator (fun x ↦ c)) :=
-  (integrable_indicator_iff hs).mpr <| integrableOn_const.mpr <| Or.inr h2s
-
-
-end ToBeMovedToAppropriateLocations
-
--- #check norm_integral_le_of_norm_le_const
--- #check norm_setIntegral_le_of_norm_le_const_ae
---#check integrable_Ks_x
-
 theorem _root_.MeasureTheory.BoundedCompactSupport.adjointCarleson
     (hf : BoundedCompactSupport f) : BoundedCompactSupport (adjointCarleson p f) where
   memℒp_top := by
@@ -236,6 +120,7 @@ theorem _root_.MeasureTheory.BoundedCompactSupport.adjointCarleson
     intro x hx
     apply mem_support.mp at hx
     have : ∃ y, conj (Ks (𝔰 p) y x) * exp (.I * (Q y y - Q y x)) * f y ≠ 0 := by
+      -- mathlib lemma: if integral ne zero, then integrand ne zero at a point
       by_contra hc
       simp only [not_exists, ne_eq, not_not] at hc
       exact hx <| setIntegral_eq_zero_of_forall_eq_zero fun x _ ↦ hc x
@@ -248,86 +133,11 @@ theorem _root_.MeasureTheory.BoundedCompactSupport.adjointCarleson
     · rw [dist_comm]; exact (dist_mem_Icc_of_Ks_ne_zero hKy).2
     · exact le_of_lt <| h hfy
 
-lemma support_carlesonOn_subset_E : support (carlesonOn p f) ⊆ E p :=
-  fun _ hx ↦ mem_of_indicator_ne_zero hx
-
--- indicator (E p)
---   fun x ↦ ∫ y, exp (I * (Q x y - Q x x)) * K x y * ψ (D ^ (- 𝔰 p) * dist x y) * f y
-theorem _root_.MeasureTheory.BoundedCompactSupport.carlesonOn
-    (hf : BoundedCompactSupport f) : BoundedCompactSupport (carlesonOn p f) where
-  memℒp_top := by
-    let x₀ : X := Classical.choice inferInstance
-    obtain ⟨r₀, hr₀, hfr₀⟩ := hf.isBoundedSupport.subset_closedBall_lt 0 x₀
-    let r₁ := (↑D ^ 𝔰 p / 2) + r₀
-    have hcf : support (_root_.carlesonOn p f) ⊆ closedBall x₀ r₁ := by
-      simp_rw [carlesonOn_def']
-      intro x hx
-      simp only [mem_support] at hx
-      apply indicator_apply_ne_zero.mp at hx
-      replace hx := hx.2
-      simp only [mem_support] at hx
-      have : ∃ y, Ks (𝔰 p) x y * f y * cexp (I * (↑((Q x) y) - ↑((Q x) x))) ≠ 0 := by
-        by_contra hc
-        simp only [not_exists, ne_eq, not_not] at hc
-        refine hx ?_--<| integral_eq_zero_of_forall_eq_zero fun x _ ↦ hc x
-        refine integral_eq_zero_of_ae ?_
-        simp_all only [support_subset_iff, ne_eq,
-          mem_closedBall, integral_zero, not_true_eq_false, x₀]
-      obtain ⟨y, hy⟩ := this
-      simp only [ne_eq, mul_eq_zero, exp_ne_zero, or_false, not_or] at hy
-      have := dist_mem_Icc_of_Ks_ne_zero hy.1
-      apply (dist_triangle _ y _).trans
-      unfold r₁
-      gcongr
-      · exact (dist_mem_Icc_of_Ks_ne_zero hy.1).2
-      · exact hfr₀ hy.2
-    obtain ⟨CK, hCK, hCK⟩ :=
-      IsBounded.exists_bound_of_norm_Ks (Metric.isBounded_closedBall (x := x₀) (r := r₁)) (𝔰 p)
-    let C := volume.real (closedBall x₀ r₀) * (CK * (eLpNorm f ⊤).toReal)
-    suffices ∀ᵐ x, ‖_root_.carlesonOn p f x‖ ≤ C from
-      memℒp_top_of_bound hf.aestronglyMeasurable.carlesonOn _ this
-    apply ae_of_all
-    intro x
-    wlog hx : x ∈ support (_root_.carlesonOn p f)
-    · simp only [mem_support, ne_eq, not_not] at hx
-      rw [hx, norm_zero]
-      positivity
-    · --simp only [mem_support] at hx
-      simp_rw [carlesonOn_def']
-      refine trans (norm_indicator_le_norm_self _ _) ?_
-      let g := (closedBall x₀ r₀).indicator (fun _ ↦ CK * (eLpNorm f ⊤).toReal)
-      have hK : ∀ᵐ y, ‖Ks (𝔰 p) x y * f y * cexp (I * (↑((Q x) y) - ↑((Q x) x)))‖ ≤ g y := by
-        filter_upwards [hf.ae_le] with y hy
-        by_cases hy' : y ∈ support f
-        · have := hfr₀ hy'
-          calc
-            _ ≤ ‖Ks (𝔰 p) x y * f y‖ * ‖cexp (I * (↑((Q x) y) - ↑((Q x) x)))‖ := norm_mul_le ..
-            _ = ‖Ks (𝔰 p) x y * f y‖ := by rw [norm_exp_I_mul_sub_ofReal, mul_one]
-            _ ≤ ‖Ks (𝔰 p) x y‖ * ‖f y‖ := norm_mul_le ..
-            _ ≤ CK * (eLpNorm f ⊤).toReal := by gcongr; exact hCK x y (hcf hx)
-            _ = g y := by simp_all only [indicator_of_mem, g]
-        · simp only [mem_support, ne_eq, not_not] at hy'
-          rw [hy']
-          simp only [mul_zero, zero_mul, norm_zero, g]
-          unfold indicator
-          split_ifs <;> positivity
-      calc
-        _ ≤ ∫ y, g y := by
-          refine norm_integral_le_of_norm_le ?_ hK
-          exact Integrable.indicator_const measurableSet_closedBall measure_closedBall_lt_top
-        _ = volume.real (closedBall x₀ r₀) * (CK * (eLpNorm f ⊤ volume).toReal) :=
-          integral_indicator_const _ measurableSet_closedBall
-  hasCompactSupport := by
-    suffices support (_root_.carlesonOn p f) ⊆ 𝓘 p by
-      refine HasCompactSupport.of_support_subset_isBounded ?_ this
-      exact Metric.isBounded_ball.subset Grid_subset_ball
-    exact Trans.trans support_carlesonOn_subset_E E_subset_𝓘
-
 theorem _root_.MeasureTheory.BoundedCompactSupport.adjointCarlesonSum {ℭ : Set (𝔓 X)}
     (hf : BoundedCompactSupport f) : BoundedCompactSupport (adjointCarlesonSum ℭ f) :=
-  Finset.boundedCompactSupport_sum fun _ _ ↦ hf.adjointCarleson
+  BoundedCompactSupport.finset_sum fun _ _ ↦ hf.adjointCarleson
 
--- short for `modulated kernel times dilated bump`
+/-- `MKD` is short for "modulated kernel times dilated bump". -/
 private abbrev MKD (s:ℤ) x y := exp (.I * (Q x y - Q x x)) * K x y * ψ (D ^ (-s) * dist x y)
 
 omit [TileStructure Q D κ S o] in
@@ -342,10 +152,10 @@ lemma adjointCarleson_adjoint
     (hf : BoundedCompactSupport f) (hg : BoundedCompactSupport g) (p : 𝔓 X) :
     ∫ x, conj (g x) * carlesonOn p f x = ∫ y, conj (adjointCarleson p g y) * f y := by
   let H := fun x ↦ fun y ↦ conj (g x) * (E p).indicator 1 x * MKD (𝔰 p) x y * f y
-  have hH : BoundedCompactSupport (uncurry H) := by
+  have hH : Integrable (uncurry H) := by
     let H₀ := fun x y ↦ ‖g x‖ * ‖f y‖
     obtain ⟨M₀, hM₀nn, hM₀⟩ := hg.2.isBounded.exists_bound_of_norm_Ks (𝔰 p)
-    have hHleH₀ x y : ‖H x y‖ ≤ M₀ * H₀ x y := by
+    have hHleH₀ x y : ‖H x y‖ ≤ M₀ * ‖g x‖ * ‖f y‖ := by
       by_cases h : x ∈ tsupport g
       · specialize hM₀ x y h
         calc
@@ -359,12 +169,39 @@ lemma adjointCarleson_adjoint
             · exact le_of_eq <| RCLike.norm_conj _
             · exact norm_indicator_one_le ..
           _ = ‖MKD (𝔰 p) x y‖ * (‖g x‖ * ‖f y‖) := by rw [mul_one, mul_comm ‖g _‖, mul_assoc]
-          _ ≤ M₀ * H₀ x y := by gcongr; exact norm_MKD_le_norm_Ks.trans hM₀
+          _ ≤ M₀ *  (‖g x‖ * ‖f y‖) := by gcongr; exact norm_MKD_le_norm_Ks.trans hM₀
+          _ = M₀ *  ‖g x‖ * ‖f y‖ := by rw [mul_assoc]
       · suffices hz : H x y = 0 by rw [hz]; simp only [norm_zero, ge_iff_le]; positivity
         unfold H; simp [image_eq_zero_of_nmem_tsupport h]
-    refine BoundedCompactSupport.of_norm_le_const_mul (g := uncurry H₀) (M := M₀) ?_ ?_
-    · exact hg.norm.prod_mul hf.norm
-    · intro ⟨x,y⟩; simp only [uncurry_apply_pair]; exact hHleH₀ ..
+    ---- If we were proving `BoundedCompactSupport (uncurry H)` instead, then the following
+    ---- three lines would finish it up
+    -- refine BoundedCompactSupport.of_norm_le_const_mul (g := uncurry H₀) (M := M₀) ?_ ?_
+    -- · exact hg.norm.prod_mul hf.norm
+    -- · intro ⟨x,y⟩; simp only [uncurry_apply_pair]; exact hHleH₀ ..
+    ---- But instead we have to do the following:
+    have : Integrable (fun z : X × X ↦ M₀ *  ‖g z.1‖ * ‖f z.2‖) :=
+      Integrable.prod_mul (hg.norm.const_mul _).integrable hf.norm.integrable
+    refine this.mono ?_ ?_
+    · refine .mul ?_ <| .snd hf.aestronglyMeasurable
+      refine .mul ?_ ?_
+      · refine .mul ?_ ?_
+        · exact RCLike.continuous_conj.comp_aestronglyMeasurable hg.aestronglyMeasurable.fst
+        · have : AEStronglyMeasurable (fun x:X ↦ (E p).indicator (1:X→ℂ) x) :=
+            .indicator aestronglyMeasurable_const measurableSet_E
+          exact this.fst
+      · unfold MKD
+        simp_rw [mul_assoc, ← Ks_def]
+        refine .mul ?_ aestronglyMeasurable_Ks
+        apply Measurable.aestronglyMeasurable
+        have : Measurable fun (p : X × X) ↦ (p.1, p.1) :=
+          .prod_mk (.fst measurable_id') (.fst measurable_id')
+        refine ((Measurable.sub ?_ ?_).const_mul I).cexp <;> apply measurable_ofReal.comp
+        · exact measurable_Q₂
+        · exact measurable_Q₂.comp this
+    · apply ae_of_all
+      intro z
+      refine trans (hHleH₀ z.1 z.2) ?_
+      exact Real.le_norm_self _
   calc
     _ = ∫ x, conj (g x) * ∫ y, (E p).indicator 1 x * MKD (𝔰 p) x y * f y := by
       conv =>
@@ -372,7 +209,7 @@ lemma adjointCarleson_adjoint
         rw [indicator_eq_indicator_one_mul, ← integral_mul_left]
         enter [2, y]; rw [← mul_assoc]
     _ = ∫ x, ∫ y, H x y := by unfold H; simp_rw [← integral_mul_left, mul_assoc]
-    _ = ∫ y, ∫ x, H x y := integral_integral_swap hH.integrable
+    _ = ∫ y, ∫ x, H x y := integral_integral_swap hH
     _ = ∫ y, (∫ x, conj (g x) * (E p).indicator 1 x * MKD (𝔰 p) x y) * f y := by
       simp_rw [integral_mul_right]
     _ = ∫ y, conj (∫ x, g x * (E p).indicator 1 x * conj (MKD (𝔰 p) x y)) * f y := by
@@ -393,7 +230,6 @@ lemma adjointCarleson_adjoint
           congr; simp; ring
 
 /-- `adjointCarlesonSum` is the adjoint of `carlesonSum`. -/
--- of course the assumptions are too strong
 lemma adjointCarlesonSum_adjoint
     (hf : BoundedCompactSupport f) (hg : BoundedCompactSupport g) (ℭ : Set (𝔓 X)) :
     ∫ x, conj (g x) * carlesonSum ℭ f x = ∫ x, conj (adjointCarlesonSum ℭ g x) * f x := by

--- a/Carleson/ForestOperator/AlmostOrthogonality.lean
+++ b/Carleson/ForestOperator/AlmostOrthogonality.lean
@@ -97,19 +97,6 @@ lemma _root_.Set.conj_indicator {α 𝕜 : Type*} [RCLike 𝕜] {f : α → 𝕜
   simp only [indicator]; split_ifs <;> simp
 
 
-/-- If `f` has bounded range, then it is bounded ae. -/
--- not currently used, remove?
-lemma _root_.MeasureTheory.ae_bounded_of_isBounded_range
-    (μ : Measure X) (hf : IsBounded (range f)) : ∃ M, ∀ᵐ x ∂μ, ‖f x‖ ≤ M := by
-  obtain ⟨M, hM⟩ := Metric.isBounded_range_iff.mp hf
-  let x₀ : X := Classical.choice (by infer_instance)
-  use M+‖f x₀‖
-  apply ae_of_all
-  intro x
-  calc
-    _ = ‖f x - f x₀ + f x₀‖ := by group
-    _ ≤ ‖f x - f x₀‖ + ‖f x₀‖ := norm_add_le ..
-    _ ≤ _ := by gcongr; exact hM x x₀
 
 -- -- mathlib?
 -- lemma _root_.HasCompactSupport.integrable_of_isBounded
@@ -135,31 +122,29 @@ theorem _root_.MeasureTheory.integral_mul_const {X : Type*} [MeasurableSpace X] 
 -- #check ae
 -- #check Integrable.prod_mul
 
--- short for `modulated kernel times dilated bump`
-abbrev MKD (s:ℤ) x y := exp (.I * (Q x y - Q x x)) * K x y * ψ (D ^ (-s) * dist x y)
-
 #check integrable_Ks_x
 
 theorem _root_.MeasureTheory.BoundedCompactSupport.carlesonOn
-    (hf : BoundedCompactSupport f) : BoundedCompactSupport (carlesonOn p f) where
-  bounded := sorry
-  compact_support := sorry
-  measurable := sorry -- hf.3.carlesonOn
+    (hf : BoundedCompactSupport f) : BoundedCompactSupport (carlesonOn p f) :=
+  sorry
+
+-- comment out when actually used
+-- theorem _root_.MeasureTheory.BoundedCompactSupport.carlesonSum {ℭ : Set (𝔓 X)}
+--     (hf : BoundedCompactSupport f) : BoundedCompactSupport (carlesonSum ℭ f) :=
+--   Finset.boundedCompactSupport_sum <| fun _ _ ↦ hf.carlesonOn
 
 theorem _root_.MeasureTheory.BoundedCompactSupport.adjointCarleson
-    (hf : BoundedCompactSupport f) : BoundedCompactSupport (adjointCarleson p f) where
-  bounded := sorry
-  compact_support := sorry
-  measurable := hf.3.adjointCarleson
+    (hf : BoundedCompactSupport f) : BoundedCompactSupport (adjointCarleson p f) :=
+  ⟨sorry, sorry, hf.3.adjointCarleson⟩
 
 theorem _root_.MeasureTheory.BoundedCompactSupport.adjointCarlesonSum {ℭ : Set (𝔓 X)}
-    (hf : BoundedCompactSupport f) : BoundedCompactSupport (adjointCarlesonSum ℭ f) where
-  bounded := sorry
-  compact_support := sorry
-  measurable := hf.3.adjointCarlesonSum
+    (hf : BoundedCompactSupport f) : BoundedCompactSupport (adjointCarlesonSum ℭ f) :=
+  Finset.boundedCompactSupport_sum <| fun _ _ ↦ hf.adjointCarleson
 
 end ToBeMovedToAppropriateLocations
 
+-- short for `modulated kernel times dilated bump`
+private abbrev MKD (s:ℤ) x y := exp (.I * (Q x y - Q x x)) * K x y * ψ (D ^ (-s) * dist x y)
 
 /-- `adjointCarleson` is the adjoint of `carlesonOn`. -/
 lemma adjointCarleson_adjoint
@@ -167,13 +152,12 @@ lemma adjointCarleson_adjoint
     ∫ x, conj (g x) * carlesonOn p f x = ∫ y, conj (adjointCarleson p g y) * f y := by
   let H := fun x ↦ fun y ↦ conj (g x) * (E p).indicator 1 x * MKD (𝔰 p) x y * f y
   have hH : BoundedCompactSupport (uncurry H) := by
+    let H₀ := fun x y ↦ ‖g x‖ * ‖f y‖
     let M₀ : ℝ := sorry -- insert bound for `K`
-    let H₀ := fun x y ↦ M₀ * ‖g x‖ * ‖f y‖
-    have hHleH₀ x y : ‖H x y‖ ≤ H₀ x y := by
+    have hHleH₀ x y : ‖H x y‖ ≤ M₀ * H₀ x y := by
       sorry -- use bound for `K`
-    refine BoundedCompactSupport.of_norm_le (g := uncurry H₀) ?_ ?_
-    · refine BoundedCompactSupport.prod_mul ?_ hf.norm
-      sorry -- hg.norm.const_mul _
+    refine BoundedCompactSupport.of_norm_le_const_mul (g := uncurry H₀) (M := M₀) ?_ ?_
+    · refine BoundedCompactSupport.prod_mul hg.norm hf.norm
     · intro ⟨x,y⟩; simp only [uncurry_apply_pair]; exact hHleH₀ ..
   calc
     _ = ∫ x, conj (g x) * ∫ y, (E p).indicator 1 x * MKD (𝔰 p) x y * f y := by

--- a/Carleson/ForestOperator/AlmostOrthogonality.lean
+++ b/Carleson/ForestOperator/AlmostOrthogonality.lean
@@ -101,17 +101,6 @@ lemma _root_.Set.conj_indicator {α 𝕜 : Type*} [RCLike 𝕜] {f : α → 𝕜
     conj (s.indicator f x) = s.indicator (conj f) x := by
   simp only [indicator]; split_ifs <;> simp
 
--- in mathlib?
-theorem _root_.MeasureTheory.integral_const_mul {X : Type*} [MeasurableSpace X] {μ : Measure X}
-  {𝕜 : Type*} [RCLike 𝕜] (f : X → 𝕜) (c : 𝕜) :
-    ∫ x, c * f x ∂μ = c * ∫ x, f x ∂μ := by
-  rw [mul_comm, ← smul_eq_mul, ← integral_smul_const]; simp_rw [mul_comm c, ← smul_eq_mul]
-
-theorem _root_.MeasureTheory.integral_mul_const {X : Type*} [MeasurableSpace X] {μ : Measure X}
-  {𝕜 : Type*} [RCLike 𝕜] (f : X → 𝕜) (c : 𝕜) :
-    ∫ x, f x * c ∂μ = (∫ x, f x ∂μ) * c := by
-  rw [← smul_eq_mul, ← integral_smul_const]; simp_rw [← smul_eq_mul]
-
 --#check integrable_Ks_x
 theorem _root_.MeasureTheory.BoundedCompactSupport.carlesonOn
     (hf : BoundedCompactSupport f) : BoundedCompactSupport (carlesonOn p f) :=
@@ -248,12 +237,12 @@ lemma adjointCarleson_adjoint
     _ = ∫ x, conj (g x) * ∫ y, (E p).indicator 1 x * MKD (𝔰 p) x y * f y := by
       conv =>
         enter [1, 2, x, 2]; unfold carlesonOn
-        rw [indicator_eq_indicator_one_mul, ← integral_const_mul]
+        rw [indicator_eq_indicator_one_mul, ← integral_mul_left]
         enter [2, y]; rw [← mul_assoc]
-    _ = ∫ x, ∫ y, H x y := by unfold H; simp_rw [← integral_const_mul, mul_assoc]
+    _ = ∫ x, ∫ y, H x y := by unfold H; simp_rw [← integral_mul_left, mul_assoc]
     _ = ∫ y, ∫ x, H x y := integral_integral_swap hH.integrable
     _ = ∫ y, (∫ x, conj (g x) * (E p).indicator 1 x * MKD (𝔰 p) x y) * f y := by
-      simp_rw [integral_mul_const]
+      simp_rw [integral_mul_right]
     _ = ∫ y, conj (∫ x, g x * (E p).indicator 1 x * conj (MKD (𝔰 p) x y)) * f y := by
       simp_rw [← integral_conj]; congrm (∫ _, (∫ _, ?_) * (f _))
       rw [map_mul, conj_conj, map_mul, conj_indicator, map_one]

--- a/Carleson/ForestOperator/AlmostOrthogonality.lean
+++ b/Carleson/ForestOperator/AlmostOrthogonality.lean
@@ -288,7 +288,7 @@ lemma _root_._aux_L2NormSq {X : Type*} [MeasureSpace X] {f : X → ℂ}
     (hf : Memℒp f 2): ↑‖∫ x, ofReal (normSq (f x))‖₊ = (eLpNorm f 2)^2 := by
   rw [show ∫ x, ofReal (normSq (f x)) = ofReal (∫ x, normSq (f x)) by exact integral_ofReal]
   rw [nnnorm_real]
-  have hnn: 0 ≤ ∫ x, normSq (f x) := by -- todo: adjust `positivity` to handle this
+  have hnn: 0 ≤ ∫ x, normSq (f x) := by-- todo: adjust `positivity` to handle this
     refine integral_nonneg ?_
     refine Pi.le_def.mpr ?_
     exact fun _ ↦ normSq_nonneg _
@@ -310,7 +310,7 @@ lemma adjoint_tree_estimate (hu : u ∈ t) (hf : BoundedCompactSupport f) :
   rw [C7_4_2_def]
   let g := adjointCarlesonSum (t u) f
   have hg : BoundedCompactSupport g := hf.adjointCarlesonSum
-  have h := density_tree_bound1 hg.1 hg.2 hg.3 hf.1 hf.2 hf.3 hu
+  have h := density_tree_bound1 hg hf hu
   simp_rw [adjointCarlesonSum_adjoint hg hf] at h
   have : ‖∫ x, conj (adjointCarlesonSum (t u) f x) * g x‖₊ =
       (eLpNorm g 2 volume)^2 := by
@@ -327,8 +327,7 @@ irreducible_def C7_4_3 (a : ℕ) : ℝ≥0 :=
   C7_4_2 a + CMB (defaultA a) 2 + 1
 
 /-- Lemma 7.4.3. -/
-lemma adjoint_tree_control (hu : u ∈ t) (hf : IsBounded (range f)) (h2f : HasCompactSupport f)
-    (h3f : AEStronglyMeasurable f) :
+lemma adjoint_tree_control (hu : u ∈ t) (hf : BoundedCompactSupport f) :
     eLpNorm (adjointBoundaryOperator t u f · |>.toReal) 2 volume ≤
     C7_4_3 a * eLpNorm f 2 volume := by
   calc _ ≤ eLpNorm (adjointBoundaryOperator t u f · |>.toReal) 2 volume := by rfl
@@ -345,11 +344,12 @@ lemma adjoint_tree_control (hu : u ∈ t) (hf : IsBounded (range f)) (h2f : HasC
     eLpNorm (MB volume 𝓑 c𝓑 r𝓑 f · |>.toReal) 2 volume +
     eLpNorm (‖f ·‖) 2 volume := by
       refine eLpNorm_add_le ?_ ?_ one_le_two |>.trans ?_
-      · exact h3f.adjointCarlesonSum.norm.add <| .maximalFunction_toReal 𝓑_finite.countable
-      · exact h3f.norm
+      · exact hf.aestronglyMeasurable.adjointCarlesonSum.norm.add
+          <| .maximalFunction_toReal 𝓑_finite.countable
+      · exact hf.aestronglyMeasurable.norm
       gcongr
       refine eLpNorm_add_le ?_ ?_ one_le_two |>.trans ?_
-      · exact h3f.adjointCarlesonSum.norm
+      · exact hf.aestronglyMeasurable.adjointCarlesonSum.norm
       · exact .maximalFunction_toReal 𝓑_finite.countable
       rfl
   _ ≤ eLpNorm (adjointCarlesonSum (t u) f) 2 volume +
@@ -359,8 +359,8 @@ lemma adjoint_tree_control (hu : u ∈ t) (hf : IsBounded (range f)) (h2f : HasC
     CMB (defaultA a) 2 * eLpNorm f 2 volume +
     eLpNorm f 2 volume := by
       gcongr
-      · exact adjoint_tree_estimate hu ⟨hf, h2f, h3f⟩
-      · exact hasStrongType_MB 𝓑_finite one_lt_two _ (h2f.memℒp_of_isBounded hf h3f) |>.2
+      · exact adjoint_tree_estimate hu hf
+      · exact hasStrongType_MB 𝓑_finite one_lt_two _ (hf.memℒp _) |>.2
   _ ≤ (C7_4_2 a * (1 : ℝ≥0∞) ^ (2 : ℝ)⁻¹ + CMB (defaultA a) 2 + 1) * eLpNorm f 2 volume := by
     simp_rw [add_mul]
     gcongr

--- a/Carleson/ForestOperator/Forests.lean
+++ b/Carleson/ForestOperator/Forests.lean
@@ -77,15 +77,13 @@ Has value `2 ^ (257 * a ^ 3 - n / 2)` in the blueprint. -/
 irreducible_def C7_7_2_2 (a n : ℕ) : ℝ≥0 := 2 ^ (257 * (a : ℝ) ^ 3 - n / 2)
 
 /-- Part of Lemma 7.7.2. -/
-lemma row_bound (hj : j < 2 ^ n) (hf : IsBounded (range f)) (h2f : HasCompactSupport f)
-    (h3f : AEStronglyMeasurable f) :
+lemma row_bound (hj : j < 2 ^ n) (hf : BoundedCompactSupport f) :
     eLpNorm (∑ u ∈ {p | p ∈ rowDecomp t j}, adjointCarlesonSum (t u) f) 2 volume ≤
     C7_7_2_1 a n * eLpNorm f 2 volume := by
   sorry
 
 /-- Part of Lemma 7.7.2. -/
-lemma indicator_row_bound (hj : j < 2 ^ n) (hf : IsBounded (range f)) (h2f : HasCompactSupport f)
-    (h3f : AEStronglyMeasurable f) :
+lemma indicator_row_bound (hj : j < 2 ^ n) (hf : BoundedCompactSupport f) :
     eLpNorm (∑ u ∈ {p | p ∈ rowDecomp t j}, F.indicator <| adjointCarlesonSum (t u) f) 2 volume ≤
     C7_7_2_2 a n * dens₂ (⋃ u ∈ t, t u) ^ (2 : ℝ)⁻¹ * eLpNorm f 2 volume := by
   sorry

--- a/Carleson/ForestOperator/L2Estimate.lean
+++ b/Carleson/ForestOperator/L2Estimate.lean
@@ -23,7 +23,7 @@ irreducible_def C7_2_2 (a : ℕ) : ℝ≥0 := 2 ^ (103 * (a : ℝ) ^ 3)
 
 /-- Lemma 7.2.2. -/
 lemma nontangential_operator_bound
-    (hf : IsBounded (range f)) (h2f : HasCompactSupport f) (h3f : AEStronglyMeasurable f)
+    (hf : BoundedCompactSupport f)
     (θ : Θ X) :
     eLpNorm (nontangentialMaximalFunction θ f · |>.toReal) 2 volume ≤ eLpNorm f 2 volume := by
   sorry
@@ -96,8 +96,7 @@ lemma boundary_overlap (I : Grid X) : (kissing I).card ≤ 2 ^ (9 * a) := by
 
 /-- Lemma 7.2.3. -/
 lemma boundary_operator_bound
-    (hf : IsBounded (range f)) (h2f : HasCompactSupport f) (h3f : AEStronglyMeasurable f)
-    (hu : u ∈ t) :
+    (hf : BoundedCompactSupport f) (hu : u ∈ t) :
     eLpNorm (boundaryOperator t u f · |>.toReal) 2 volume ≤ eLpNorm f 2 volume := by
   sorry
 
@@ -108,9 +107,7 @@ irreducible_def C7_2_1 (a : ℕ) : ℝ≥0 := 2 ^ (104 * (a : ℝ) ^ 3)
 
 /-- Lemma 7.2.1. -/
 lemma tree_projection_estimate
-    (hf : IsBounded (range f)) (h2f : HasCompactSupport f) (h3f : AEStronglyMeasurable f)
-    (hg : IsBounded (range g)) (h2g : HasCompactSupport g) (h3g : AEStronglyMeasurable g)
-    (hu : u ∈ t) :
+    (hf : BoundedCompactSupport f) (hg : BoundedCompactSupport g) (hu : u ∈ t) :
     ‖∫ x, conj (g x) * carlesonSum (t u) f x‖₊ ≤
     C7_2_1 a * eLpNorm (approxOnCube (𝓙 (t u)) (‖f ·‖)) 2 volume *
     eLpNorm (approxOnCube (𝓛 (t u)) (‖g ·‖)) 2 volume := by

--- a/Carleson/ForestOperator/LargeSeparation.lean
+++ b/Carleson/ForestOperator/LargeSeparation.lean
@@ -1,4 +1,5 @@
 import Carleson.ForestOperator.AlmostOrthogonality
+import Carleson.ToMathlib.BoundedCompactSupport
 
 open ShortVariables TileStructure
 variable {X : Type*} {a : ℕ} {q : ℝ} {K : X → X → ℂ} {σ₁ σ₂ : X → ℤ} {F G : Set X}
@@ -92,7 +93,7 @@ irreducible_def C7_5_5 (a : ℕ) : ℝ≥0 := 2 ^ (151 * (a : ℝ) ^ 3)
 
 /-- Lemma 7.5.5. -/
 lemma holder_correlation_tile (hu : u ∈ t) (hp : p ∈ t u)
-    (hf : IsBounded (range f)) (h2f : HasCompactSupport f) (h3f : AEStronglyMeasurable f) :
+    (hf : BoundedCompactSupport f) :
     nndist (exp (.I * 𝒬 u x) * adjointCarleson p f x)
       (exp (.I * 𝒬 u x') * adjointCarleson p f x') ≤
     C7_5_5 a / volume (ball (𝔠 p) (4 * D ^ 𝔰 p)) *
@@ -114,7 +115,7 @@ irreducible_def C7_5_7 (a : ℕ) : ℝ≥0 := 2 ^ (104 * (a : ℝ) ^ 3)
 /-- Lemma 7.5.7. -/
 lemma local_tree_control (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂)
     (h2u : 𝓘 u₁ ≤ 𝓘 u₂) (hJ : J ∈ 𝓙₅ t u₁ u₂)
-    (hf : IsBounded (range f)) (h2f : HasCompactSupport f) (h3f : AEStronglyMeasurable f) :
+    (hf : BoundedCompactSupport f) :
     ⨆ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f x‖₊ ≤
     C7_5_7 a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 (‖f ·‖) x := by
   sorry
@@ -196,8 +197,7 @@ irreducible_def C7_5_9_2 (a : ℕ) : ℝ≥0 := 2 ^ (153 * (a : ℝ) ^ 3)
 /-- Part 1 of Lemma 7.5.9 -/
 lemma global_tree_control1_1 (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂)
     (h2u : 𝓘 u₁ ≤ 𝓘 u₂) (ℭ : Set (𝔓 X)) (hℭ : ℭ = t u₁ ∨ ℭ = t u₂ ∩ 𝔖₀ t u₁ u₂)
-    (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf : IsBounded (range f)) (h2f : HasCompactSupport f)
-    (h3f : AEStronglyMeasurable f) :
+    (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf : BoundedCompactSupport f) :
     ⨆ x ∈ ball (c J) (8 * D ^ s J), ‖adjointCarlesonSum ℭ f x‖₊ ≤
     (⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum ℭ f x‖₊) +
     C7_5_9_1 a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 (‖f ·‖) x := by
@@ -206,8 +206,7 @@ lemma global_tree_control1_1 (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u�
 /-- Part 2 of Lemma 7.5.9 -/
 lemma global_tree_control1_2 (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂)
     (h2u : 𝓘 u₁ ≤ 𝓘 u₂) (ℭ : Set (𝔓 X)) (hℭ : ℭ = t u₁ ∨ ℭ = t u₂ ∩ 𝔖₀ t u₁ u₂)
-    (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf : IsBounded (range f)) (h2f : HasCompactSupport f)
-    (h3f : AEStronglyMeasurable f)
+    (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf : BoundedCompactSupport f)
     (hx : x ∈ ball (c J) (8 * D ^ s J)) (hx' : x' ∈ ball (c J) (8 * D ^ s J)) :
     nndist (exp (.I * 𝒬 u x) * adjointCarlesonSum ℭ f x)
       (exp (.I * 𝒬 u x') * adjointCarlesonSum ℭ f x') ≤
@@ -223,7 +222,7 @@ irreducible_def C7_5_10 (a : ℕ) : ℝ≥0 := 2 ^ (155 * (a : ℝ) ^ 3)
 /-- Lemma 7.5.10 -/
 lemma global_tree_control2 (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂)
     (h2u : 𝓘 u₁ ≤ 𝓘 u₂) (hJ : J ∈ 𝓙₅ t u₁ u₂)
-    (hf : IsBounded (range f)) (h2f : HasCompactSupport f) (h3f : AEStronglyMeasurable f) :
+    (hf : BoundedCompactSupport f) :
     ⨆ x ∈ ball (c J) (8 * D ^ s J), ‖adjointCarlesonSum (t u₂ ∩ 𝔖₀ t u₁ u₂) f x‖₊ ≤
     ⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₂) f x‖₊ +
     C7_5_10 a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 (‖f ·‖) x := by

--- a/Carleson/ForestOperator/PointwiseEstimate.lean
+++ b/Carleson/ForestOperator/PointwiseEstimate.lean
@@ -1,5 +1,6 @@
 import Carleson.Forest
 import Carleson.HardyLittlewood
+import Carleson.ToMathlib.BoundedCompactSupport
 
 open ShortVariables TileStructure
 variable {X : Type*} {a : ℕ} {q : ℝ} {K : X → X → ℂ} {σ₁ σ₂ : X → ℤ} {F G : Set X}
@@ -146,7 +147,7 @@ irreducible_def C7_1_4 (a : ℕ) : ℝ≥0 := 10 * 2 ^ (105 * (a : ℝ) ^ 3)
 
 /-- Lemma 7.1.4 -/
 lemma first_tree_pointwise (hu : u ∈ t) (hL : L ∈ 𝓛 (t u)) (hx : x ∈ L) (hx' : x' ∈ L)
-    (hf : IsBounded (range f)) (h2f : HasCompactSupport f) (h3f : AEStronglyMeasurable f) :
+    (hf : BoundedCompactSupport f) :
     ‖∑ i in t.σ u x, ∫ y, (exp (.I * (- 𝒬 u y + Q x y + 𝒬 u x - Q x x)) - 1) * Ks i x y * f y ‖₊ ≤
     C7_1_4 a * MB volume 𝓑 c𝓑 r𝓑 (approxOnCube (𝓙 (t u)) (‖f ·‖)) x' := by
   sorry
@@ -241,7 +242,7 @@ irreducible_def C7_1_6 (a : ℕ) : ℝ≥0 := 2 ^ (151 * (a : ℝ) ^ 3)
 
 /-- Lemma 7.1.6 -/
 lemma third_tree_pointwise (hu : u ∈ t) (hL : L ∈ 𝓛 (t u)) (hx : x ∈ L) (hx' : x' ∈ L)
-    (hf : IsBounded (range f)) (h2f : HasCompactSupport f) (h3f : AEStronglyMeasurable f) :
+    (hf : BoundedCompactSupport f) :
     ‖∑ i in t.σ u x, ∫ y, Ks i x y * (f y - approxOnCube (𝓙 (t u)) f y)‖₊ ≤
     C7_1_6 a * t.boundaryOperator u (approxOnCube (𝓙 (t u)) (‖f ·‖)) x' := by
   sorry
@@ -253,7 +254,7 @@ irreducible_def C7_1_3 (a : ℕ) : ℝ≥0 := 2 ^ (151 * (a : ℝ) ^ 3)
 
 /-- Lemma 7.1.3. -/
 lemma pointwise_tree_estimate (hu : u ∈ t) (hL : L ∈ 𝓛 (t u)) (hx : x ∈ L) (hx' : x' ∈ L)
-    (hf : IsBounded (range f)) (h2f : HasCompactSupport f) (h3f : AEStronglyMeasurable f) :
+    (hf : BoundedCompactSupport f) :
     ‖carlesonSum (t u) (fun y ↦ exp (.I * - 𝒬 u y) * f y) x‖₊ ≤
     C7_1_3 a * (MB volume 𝓑 c𝓑 r𝓑 (approxOnCube (𝓙 (t u)) (‖f ·‖)) x' +
     t.boundaryOperator u (approxOnCube (𝓙 (t u)) (‖f ·‖)) x' +

--- a/Carleson/ForestOperator/QuantativeEstimate.lean
+++ b/Carleson/ForestOperator/QuantativeEstimate.lean
@@ -1,4 +1,5 @@
 import Carleson.ForestOperator.L2Estimate
+import Carleson.ToMathlib.BoundedCompactSupport
 
 open ShortVariables TileStructure
 variable {X : Type*} {a : ℕ} {q : ℝ} {K : X → X → ℂ} {σ₁ σ₂ : X → ℤ} {F G : Set X}
@@ -45,8 +46,7 @@ irreducible_def C7_3_1_1 (a : ℕ) : ℝ≥0 := 2 ^ (155 * (a : ℝ) ^ 3)
 
 /-- First part of Lemma 7.3.1. -/
 lemma density_tree_bound1
-    (hf : IsBounded (range f)) (h2f : HasCompactSupport f) (h3f : AEStronglyMeasurable f)
-    (hg : IsBounded (range g)) (h2g : HasCompactSupport g) (h3g : AEStronglyMeasurable g)
+    (hf : BoundedCompactSupport f) (hg : BoundedCompactSupport g)
     (hu : u ∈ t) :
     ‖∫ x, conj (g x) * carlesonSum (t u) f x‖₊ ≤
     C7_3_1_1 a *  dens₁ (t u) ^ (2 : ℝ)⁻¹ * eLpNorm f 2 volume * eLpNorm g 2 volume := by
@@ -59,9 +59,9 @@ irreducible_def C7_3_1_2 (a : ℕ) : ℝ≥0 := 2 ^ (256 * (a : ℝ) ^ 3)
 
 /-- Second part of Lemma 7.3.1. -/
 lemma density_tree_bound2 -- some assumptions on f are superfluous
-    (hf : IsBounded (range f)) (h2f : HasCompactSupport f) (h3f : AEStronglyMeasurable f)
+    (hf : BoundedCompactSupport f)
     (h4f : ∀ x, ‖f x‖ ≤ F.indicator 1 x)
-    (hg : IsBounded (range g)) (h2g : HasCompactSupport g) (h3g : AEStronglyMeasurable g)
+    (hg : BoundedCompactSupport g)
     (hu : u ∈ t) :
     ‖∫ x, conj (g x) * carlesonSum (t u) f x‖₊ ≤
     C7_3_1_2 a * dens₁ (t u) ^ (2 : ℝ)⁻¹ * dens₂ (t u) ^ (2 : ℝ)⁻¹ *

--- a/Carleson/TileStructure.lean
+++ b/Carleson/TileStructure.lean
@@ -110,6 +110,7 @@ def carlesonOn (p : 𝔓 X) (f : X → ℂ) : X → ℂ :=
   indicator (E p)
     fun x ↦ ∫ y, exp (I * (Q x y - Q x x)) * K x y * ψ (D ^ (- 𝔰 p) * dist x y) * f y
 
+-- obsolete in favor of `AEStronglyMeasurable.carlesonOn`?
 lemma measurable_carlesonOn {p : 𝔓 X} {f : X → ℂ} (measf : Measurable f) :
     Measurable (carlesonOn p f) := by
   refine (StronglyMeasurable.integral_prod_right ?_).measurable.indicator measurableSet_E
@@ -130,10 +131,36 @@ We will use this in other places of the formalization as well. -/
 def carlesonSum (ℭ : Set (𝔓 X)) (f : X → ℂ) (x : X) : ℂ :=
   ∑ p ∈ {p | p ∈ ℭ}, carlesonOn p f x
 
+-- obsolete in favor of `AEStronglyMeasurable.carlesonSum`?
 @[fun_prop]
 lemma measurable_carlesonSum {ℭ : Set (𝔓 X)} {f : X → ℂ} (measf : Measurable f) :
     Measurable (carlesonSum ℭ f) :=
   Finset.measurable_sum _ fun _ _ ↦ measurable_carlesonOn measf
+
+--    fun x ↦ ∫ y, exp (I * (Q x y - Q x x)) * K x y * ψ (D ^ (- 𝔰 p) * dist x y) * f y
+lemma _root_.MeasureTheory.AEStronglyMeasurable.carlesonOn {p : 𝔓 X} {f : X → ℂ}
+    (hf : AEStronglyMeasurable f) : AEStronglyMeasurable (carlesonOn p f) := by
+  refine .indicator ?_ measurableSet_E
+  -- refine AEStronglyMeasurable.integral_prod_right ?_
+  refine .integral_prod_right'
+    (f := fun z ↦ exp (Complex.I * (Q z.1 z.2 - Q z.1 z.1)) * K z.1 z.2 *
+      ψ (D ^ (- 𝔰 p) * dist z.1 z.2) * f z.2) ?_
+  refine (((AEStronglyMeasurable.mul ?_ aestronglyMeasurable_K).mul ?_).mul ?_)
+  · apply Measurable.aestronglyMeasurable
+    have : Measurable fun (p : X × X) ↦ (p.1, p.1) := by fun_prop
+    refine ((Measurable.sub ?_ ?_).const_mul I).cexp <;> apply measurable_ofReal.comp
+    · exact measurable_Q₂
+    · exact measurable_Q₂.comp this
+  · apply Measurable.aestronglyMeasurable
+    apply measurable_ofReal.comp
+    apply Measurable.comp (f := fun x : X × X ↦ D ^ (-𝔰 p) * dist x.1 x.2) (g := ψ)
+    · exact measurable_const.max (measurable_const.min (Measurable.min (by fun_prop) (by fun_prop)))
+    · exact measurable_dist.const_mul _
+  · exact hf.snd
+
+lemma _root_.MeasureTheory.AEStronglyMeasurable.carlesonSum {ℭ : Set (𝔓 X)}
+    {f : X → ℂ} (hf : AEStronglyMeasurable f) : AEStronglyMeasurable (carlesonSum ℭ f) :=
+  Finset.aestronglyMeasurable_sum _ fun _ _ ↦ hf.carlesonOn
 
 lemma carlesonOn_def' (p : 𝔓 X) (f : X → ℂ) : carlesonOn p f =
     indicator (E p) fun x ↦ ∫ y, Ks (𝔰 p) x y * f y * exp (I * (Q x y - Q x x)) := by

--- a/Carleson/ToMathlib/BoundedCompactSupport.lean
+++ b/Carleson/ToMathlib/BoundedCompactSupport.lean
@@ -67,7 +67,6 @@ variable (hf : BoundedCompactSupport f)
 variable (hg : BoundedCompactSupport g)
 
 section Includehf
-/-! Results depending on `f` being bounded compactly supported. -/
 
 include hf
 
@@ -99,7 +98,6 @@ theorem mul_const (c : 𝕜) : BoundedCompactSupport (fun x ↦ (f x) * c) := so
 end Includehf
 
 section Includehfhg
-/-! Results depending on two functions `f`, `g` being bounded compactly supported. -/
 
 include hf hg
 
@@ -113,8 +111,6 @@ end Includehfhg
 theorem of_norm_le {g : X → ℝ} (hg : BoundedCompactSupport g)
     (hfg : ∀ x, ‖f x‖ ≤ g x) : BoundedCompactSupport f := sorry
 
--- standardize hypotheses: `∀ x, ‖f x‖ ≤ M * g x` with implicit `M`
--- vs. `∃ M, ∀ x, ‖f x‖ ≤ M * g x`
 -- this is a very common use case, so it deserves its own theorem
 theorem of_norm_le_const_mul {g : X → ℝ} {M : ℝ} (hg : BoundedCompactSupport g)
     (hfg : ∀ x, ‖f x‖ ≤ M * g x) : BoundedCompactSupport f := sorry
@@ -141,50 +137,6 @@ theorem prod_mul (hf : BoundedCompactSupport f) (hg : BoundedCompactSupport g) :
     BoundedCompactSupport (uncurry fun x y ↦ (f x) * (g y)) := sorry
 
 end Prod
-
-
------ Commented out below experiments with automating by typeclass inference abuse
------ This is not the right way of doing it but can work for easy cases
--- section PotentialDanger?
-
--- instance [BoundedCompactSupport f] [BoundedCompactSupport g] :
---     BoundedCompactSupport (f + g) := sorry
-
--- instance [hf : BoundedCompactSupport f] [hg : BoundedCompactSupport g]  :
---     BoundedCompactSupport (f * g) := mul_bdd hf hg.bounded
-
--- -- generalize to other types than `𝕜`
--- instance [BoundedCompactSupport f] (c : 𝕜) :
---     BoundedCompactSupport (c • f) := sorry
-
--- variable [BoundedCompactSupport f]
--- #synth BoundedCompactSupport ((5:𝕜)•f+f*f)
-
--- example : Integrable ((5:𝕜)•f+f*f) := BoundedCompactSupport.integrable (by infer_instance)
-
--- -- would be nice if this could work:
--- --variable {hg : IsBounded (range g)}
--- --#synth BoundedCompactSupport (f*g)
-
--- -- one could make `IsBounded` a typeclass too, and measurable and HasCompactSupport, ..
--- namespace Experimental
-
--- variable (f) in
--- class IsBounded : Prop where
---   intro : Bornology.IsBounded (range f)
-
--- instance [BoundedCompactSupport f] [IsBounded g] :
---     BoundedCompactSupport (f * g) := sorry
-
--- -- now this works
--- variable [IsBounded g]
--- #synth BoundedCompactSupport (f*g)
-
--- end Experimental
-
--- -- instance for fiberwise integral
-
--- end PotentialDanger?
 
 end BoundedCompactSupport
 

--- a/Carleson/ToMathlib/BoundedCompactSupport.lean
+++ b/Carleson/ToMathlib/BoundedCompactSupport.lean
@@ -34,10 +34,13 @@ namespace MeasureTheory
 open Bornology Function Set HasCompactSupport
 open scoped ENNReal
 
+section
+
 -- This setting should be enough for this project, but
 -- for mathlib should generalize to vector-valued, and use `MeasurableSpace X`, `Measure μ`
 variable {X 𝕜} [MeasureSpace X] [RCLike 𝕜] {f : X → 𝕜}
 variable [TopologicalSpace X] [IsFiniteMeasureOnCompacts (volume : Measure X)]
+variable [SigmaFinite (volume : Measure X)]
 
 variable (f) in
 /-- Bounded compactly supported measurable functions -/
@@ -158,13 +161,68 @@ section Prod
 
 variable {Y: Type*} [MeasureSpace Y] {g : Y → 𝕜}
 variable [TopologicalSpace Y] [IsFiniteMeasureOnCompacts (volume : Measure Y)]
+variable [SigmaFinite (volume : Measure Y)]
 
 /-- An elementary tensor of bounded compactly supported functions is
 bounded compactly supported. -/
 theorem prod_mul (hf : BoundedCompactSupport f) (hg : BoundedCompactSupport g) :
     BoundedCompactSupport (uncurry fun x y ↦ (f x) * (g y)) := sorry
 
+variable {F : X × Y → 𝕜}
+
+theorem swap (hF : BoundedCompactSupport F) : BoundedCompactSupport (F ∘ Prod.swap) :=
+  sorry
+
 end Prod
+
+end BoundedCompactSupport
+
+end
+
+namespace BoundedCompactSupport
+
+
+section Metric
+
+
+variable {X Y 𝕜: Type*} [RCLike 𝕜]
+variable [MeasureSpace X] {f : X → 𝕜} [PseudoMetricSpace X] [SigmaFinite (volume : Measure X)]
+variable [MeasureSpace Y] {g : Y → 𝕜} [PseudoMetricSpace Y] [SigmaFinite (volume : Measure Y)]
+
+variable (hf : BoundedCompactSupport f) (hg : BoundedCompactSupport g)
+
+section Prod
+
+variable {F : X × Y → 𝕜}
+
+-- theorem prod_left_ae (hF : BoundedCompactSupport F) :
+--     ∀ᵐ y, BoundedCompactSupport (fun x ↦ F (x, y)) := sorry
+
+-- theorem prod_right_ae (hF : BoundedCompactSupport F) :
+--     ∀ᵐ x, BoundedCompactSupport (fun y ↦ F (x, y)) := hF.swap.prod_left_ae
+
+-- theorem integral_prod_left (hF : BoundedCompactSupport F) :
+--     BoundedCompactSupport (fun x ↦ ∫ y, F (x, y)) := sorry
+-- --   have := hF.integrable.integrable_prod_left
+
+-- theorem integral_prod_right (hF : BoundedCompactSupport F) :
+--     BoundedCompactSupport (fun y ↦ ∫ x, F (x, y)) := hF.swap.integral_prod_left
+
+end Prod
+
+section
+include hf
+
+theorem isBoundedSupport' : IsBounded (tsupport f) :=
+  hf.hasCompactSupport.isBounded
+
+theorem isBoundedSupport : IsBounded (support f) :=
+  hf.isBoundedSupport'.subset <| subset_tsupport f
+
+end
+
+end Metric
+
 
 end BoundedCompactSupport
 

--- a/Carleson/ToMathlib/BoundedCompactSupport.lean
+++ b/Carleson/ToMathlib/BoundedCompactSupport.lean
@@ -31,7 +31,8 @@ namespace MeasureTheory
 open Bornology Function Set HasCompactSupport
 open scoped ENNReal
 
--- Can generalize to vector-valued, but for this project scalar-valued should be enough
+-- This setting should be enough for this project, but
+-- for mathlib should generalize to vector-valued, and use `MeasurableSpace X`, `Measure μ`
 variable {X 𝕜} [MeasureSpace X] [RCLike 𝕜] {f : X → 𝕜}
 variable [TopologicalSpace X] [IsFiniteMeasureOnCompacts (volume : Measure X)]
 
@@ -44,8 +45,7 @@ structure BoundedCompactSupport : Prop where
                                  -- e.g. `∃ M, ∀ᵐ x ∂μ, ‖f x‖ ≤ M`
   compact_support : HasCompactSupport f -- could use bounded support instead
   measurable : AEStronglyMeasurable f -- could use `Measurable` instead
-
--- Why is there no `IsEssBounded` predicate in mathlib?
+  -- or could use `Memℒp f ⊤` which also includes measurability
 
 -- /-- If `f` has bounded range, then it is bounded ae. -/
 -- -- not currently used, but maybe in the future

--- a/Carleson/ToMathlib/BoundedCompactSupport.lean
+++ b/Carleson/ToMathlib/BoundedCompactSupport.lean
@@ -1,0 +1,101 @@
+import Mathlib.Analysis.Convex.PartitionOfUnity
+import Mathlib.Analysis.Calculus.ContDiff.Basic
+import Mathlib.MeasureTheory.Integral.Average
+import Mathlib.MeasureTheory.Integral.Bochner
+import Mathlib.MeasureTheory.Measure.Haar.OfBasis
+import Mathlib.Topology.MetricSpace.Holder
+import Mathlib.Data.Set.Card
+import Mathlib.Data.Real.ENatENNReal
+import Carleson.ToMathlib.Misc
+
+/-!
+
+-- EXPERIMENTAL
+
+# Bounded compactly supported measurable functions
+
+Bounded compactly supported measurable functions are a very convenient class of functions:
+it is contained in all `Lᵖ` spaces (in particular they are `Integrable`)
+and it is closed under many common operations
+
+This makes it reasonable to bundle these three properties and prove basic properties.
+
+-/
+
+-- File has `sorry`s but all sorrys are easy
+
+namespace MeasureTheory
+
+open Bornology Set HasCompactSupport
+
+variable {X 𝕜: Type*} [MeasureSpace X] [RCLike 𝕜] {f : X → 𝕜}
+variable [TopologicalSpace X] [IsFiniteMeasureOnCompacts (volume : Measure X)]
+
+variable (f) in
+-- carefully make this a typeclass?
+class BoundedCompactSupport : Prop where
+  bounded : IsBounded (range f)
+  compact_support : HasCompactSupport f
+  measurable : AEStronglyMeasurable f
+
+namespace BoundedCompactSupport
+
+variable {f : X → 𝕜}
+variable {g : X → 𝕜}
+
+-- parameter `hf` explicit
+theorem integrable (hf : BoundedCompactSupport f) : Integrable f := by
+  exact memℒp_one_iff_integrable.mp <| hf.2.memℒp_of_isBounded hf.1 hf.3
+
+theorem mul_bdd
+    (hf : BoundedCompactSupport f) (hg : IsBounded (range g)) :
+    BoundedCompactSupport (f * g) := sorry
+
+theorem integrable_mul
+    (hf : BoundedCompactSupport f) (hg : Integrable g) : Integrable (f * g) := by
+  sorry -- doesn't need `hf.compact_support`
+
+section PotentialDanger?
+
+instance [BoundedCompactSupport f] [BoundedCompactSupport g] :
+    BoundedCompactSupport (f + g) := sorry
+
+instance [hf : BoundedCompactSupport f] [hg : BoundedCompactSupport g]  :
+    BoundedCompactSupport (f * g) := mul_bdd hf hg.bounded
+
+-- generalize to other types than `𝕜`
+instance [BoundedCompactSupport f] (c : 𝕜) :
+    BoundedCompactSupport (c • f) := sorry
+
+variable [BoundedCompactSupport f]
+#synth BoundedCompactSupport ((5:𝕜)•f+f*f)
+
+example : Integrable ((5:𝕜)•f+f*f) := BoundedCompactSupport.integrable (by infer_instance)
+
+-- would be nice if this could work:
+--variable {hg : IsBounded (range g)}
+--#synth BoundedCompactSupport (f*g)
+
+-- one could make `IsBounded` a typeclass too, and measurable and HasCompactSupport, ..
+namespace Experimental
+
+variable (f) in
+class IsBounded : Prop where
+  intro : Bornology.IsBounded (range f)
+
+instance [BoundedCompactSupport f] [IsBounded g] :
+    BoundedCompactSupport (f * g) := sorry
+
+-- now this works
+variable [IsBounded g]
+#synth BoundedCompactSupport (f*g)
+
+end Experimental
+
+-- instance for fiberwise integral
+
+end PotentialDanger?
+
+end BoundedCompactSupport
+
+end MeasureTheory

--- a/Carleson/ToMathlib/BoundedCompactSupport.lean
+++ b/Carleson/ToMathlib/BoundedCompactSupport.lean
@@ -99,6 +99,7 @@ theorem memℒp (p : ENNReal) : Memℒp f p :=
 /-- Bounded compactly supported functions are integrable. -/
 theorem integrable : Integrable f := memℒp_one_iff_integrable.mp <| memℒp hf 1
 
+-- needed
 theorem mul_ess_bdd (hg : eLpNorm g ⊤ < ⊤) : BoundedCompactSupport (f * g) := sorry
 
 theorem ess_bdd_mul (hg : eLpNorm g ⊤ < ⊤) : BoundedCompactSupport (g * f) := by
@@ -118,8 +119,10 @@ theorem bdd_mul (hg : IsBounded (range g)) : BoundedCompactSupport (g * f) :=
 -- for convenience
 theorem integrable_mul (hg : Integrable g) : Integrable (f * g) := sorry
 
+-- needed
 theorem conj : BoundedCompactSupport (star f) := sorry
 
+-- needed
 theorem norm : BoundedCompactSupport (‖f ·‖) := sorry
 
 theorem const_mul (c : 𝕜) : BoundedCompactSupport (fun x ↦ c * (f x)) := sorry
@@ -134,6 +137,7 @@ include hf hg
 
 theorem mul : BoundedCompactSupport (f * g) := mul_ess_bdd hf hg.memℒp_top.2
 
+-- prove when needed
 theorem add : BoundedCompactSupport (f + g) := sorry
 
 end Includehfhg
@@ -142,6 +146,7 @@ end Includehfhg
 theorem of_norm_le {g : X → ℝ} (hg : BoundedCompactSupport g)
     (hfg : ∀ x, ‖f x‖ ≤ g x) : BoundedCompactSupport f := sorry
 
+-- needed
 -- this is a very common use case, so it deserves its own theorem
 theorem of_norm_le_const_mul {g : X → ℝ} {M : ℝ} (hg : BoundedCompactSupport g)
     (hfg : ∀ x, ‖f x‖ ≤ M * g x) : BoundedCompactSupport f := sorry
@@ -150,6 +155,7 @@ section Sum
 
 variable {ι : Type*} {s : Finset ι} {F : ι → X → 𝕜}
 
+-- needed
 /-- A finite sum of bounded compactly supported functions is bounded compactly supported. -/
 theorem _root_.Finset.boundedCompactSupport_sum
     (hF : ∀ i ∈ s, BoundedCompactSupport (F i)) : BoundedCompactSupport (fun x ↦ ∑ i ∈ s, F i x) :=
@@ -163,6 +169,7 @@ variable {Y: Type*} [MeasureSpace Y] {g : Y → 𝕜}
 variable [TopologicalSpace Y] [IsFiniteMeasureOnCompacts (volume : Measure Y)]
 variable [SigmaFinite (volume : Measure Y)]
 
+-- needed
 /-- An elementary tensor of bounded compactly supported functions is
 bounded compactly supported. -/
 theorem prod_mul (hf : BoundedCompactSupport f) (hg : BoundedCompactSupport g) :
@@ -170,6 +177,7 @@ theorem prod_mul (hf : BoundedCompactSupport f) (hg : BoundedCompactSupport g) :
 
 variable {F : X × Y → 𝕜}
 
+-- prove when needed
 theorem swap (hF : BoundedCompactSupport F) : BoundedCompactSupport (F ∘ Prod.swap) :=
   sorry
 
@@ -184,7 +192,6 @@ namespace BoundedCompactSupport
 
 section Metric
 
-
 variable {X Y 𝕜: Type*} [RCLike 𝕜]
 variable [MeasureSpace X] {f : X → 𝕜} [PseudoMetricSpace X] [SigmaFinite (volume : Measure X)]
 variable [MeasureSpace Y] {g : Y → 𝕜} [PseudoMetricSpace Y] [SigmaFinite (volume : Measure Y)]
@@ -195,6 +202,7 @@ section Prod
 
 variable {F : X × Y → 𝕜}
 
+-- adapt and prove below when needed
 -- theorem prod_left_ae (hF : BoundedCompactSupport F) :
 --     ∀ᵐ y, BoundedCompactSupport (fun x ↦ F (x, y)) := sorry
 

--- a/Carleson/ToMathlib/BoundedCompactSupport.lean
+++ b/Carleson/ToMathlib/BoundedCompactSupport.lean
@@ -10,16 +10,19 @@ import Carleson.ToMathlib.Misc
 
 /-!
 
+EXPERIMENTAL
+
 # Bounded compactly supported measurable functions
 
-Bounded compactly supported measurable functions are a very convenient class of functions:
-it is contained in all `Lᵖ` spaces (in particular they are `Integrable`)
-and it is closed under many common operations
-
-Often it is enough to reason with bounded compactly supported functions (as done in the blueprint).
-Here we provide helper lemmas mostly meant to streamline integrability proofs.
+The purpose of this file is to provide helper lemmas to streamline proofs that
+functions are bounded compactly supported and measurable.
+Most functions we need to deal with are of this class.
+Hopefully this will be a useful way to streamline proofs of `L^p` membership,
+in particular integrability.
 
 Todo: make `Mathlib.Tactic.FunProp` work for this
+
+The `sorry`s in this file are supposed to be "easy".
 
 -/
 

--- a/Carleson/ToMathlib/BoundedCompactSupport.lean
+++ b/Carleson/ToMathlib/BoundedCompactSupport.lean
@@ -18,22 +18,22 @@ Bounded compactly supported measurable functions are a very convenient class of 
 it is contained in all `Lᵖ` spaces (in particular they are `Integrable`)
 and it is closed under many common operations
 
-This makes it reasonable to bundle these three properties and prove basic properties.
+Often it is enough to reason with bounded compactly supported functions (as done in the blueprint).
+Here we provide helper lemmas mostly meant to streamline integrability proofs.
 
 -/
 
--- File has `sorry`s but all sorrys are easy
-
 namespace MeasureTheory
 
-open Bornology Set HasCompactSupport
+open Bornology Function Set HasCompactSupport
+open scoped ENNReal
 
+-- should generalize, but this should be enough for this purpose
 variable {X 𝕜: Type*} [MeasureSpace X] [RCLike 𝕜] {f : X → 𝕜}
 variable [TopologicalSpace X] [IsFiniteMeasureOnCompacts (volume : Measure X)]
 
 variable (f) in
--- carefully make this a typeclass?
-class BoundedCompactSupport : Prop where
+structure BoundedCompactSupport : Prop where
   bounded : IsBounded (range f)
   compact_support : HasCompactSupport f
   measurable : AEStronglyMeasurable f
@@ -43,58 +43,92 @@ namespace BoundedCompactSupport
 variable {f : X → 𝕜}
 variable {g : X → 𝕜}
 
--- parameter `hf` explicit
-theorem integrable (hf : BoundedCompactSupport f) : Integrable f := by
-  exact memℒp_one_iff_integrable.mp <| hf.2.memℒp_of_isBounded hf.1 hf.3
+/-- Bounded compactly supported functions are in all `Lᵖ` spaces. -/
+theorem memℒp (hf : BoundedCompactSupport f) (p : ENNReal) : Memℒp f p :=
+  hf.2.memℒp_of_isBounded hf.1 hf.3
 
+/-- Bounded compactly supported functions are integrable. -/
+theorem integrable (hf : BoundedCompactSupport f) : Integrable f :=
+  memℒp_one_iff_integrable.mp <| memℒp hf 1
+
+/-- A bounded compactly supported function times a bounded function is
+bounded compactly supported. -/
 theorem mul_bdd
     (hf : BoundedCompactSupport f) (hg : IsBounded (range g)) :
     BoundedCompactSupport (f * g) := sorry
 
+theorem bdd_mul
+    (hf : IsBounded (range f)) (hg : BoundedCompactSupport g) :
+    BoundedCompactSupport (f * g) := by rw [mul_comm]; exact mul_bdd hg hf
+
+#check Integrable.bdd_mul
+-- for convenience
 theorem integrable_mul
     (hf : BoundedCompactSupport f) (hg : Integrable g) : Integrable (f * g) := by
-  sorry -- doesn't need `hf.compact_support`
+  sorry
 
-section PotentialDanger?
-
-instance [BoundedCompactSupport f] [BoundedCompactSupport g] :
-    BoundedCompactSupport (f + g) := sorry
-
-instance [hf : BoundedCompactSupport f] [hg : BoundedCompactSupport g]  :
+-- for convenience
+theorem mul
+    (hf : BoundedCompactSupport f) (hg : BoundedCompactSupport g) :
     BoundedCompactSupport (f * g) := mul_bdd hf hg.bounded
 
--- generalize to other types than `𝕜`
-instance [BoundedCompactSupport f] (c : 𝕜) :
-    BoundedCompactSupport (c • f) := sorry
+theorem add
+    (hf : BoundedCompactSupport f) (hg : BoundedCompactSupport g) :
+    BoundedCompactSupport (f + g) := sorry
 
-variable [BoundedCompactSupport f]
-#synth BoundedCompactSupport ((5:𝕜)•f+f*f)
+theorem conj
+    (hf : BoundedCompactSupport f) : BoundedCompactSupport (star f) := sorry
 
-example : Integrable ((5:𝕜)•f+f*f) := BoundedCompactSupport.integrable (by infer_instance)
 
--- would be nice if this could work:
---variable {hg : IsBounded (range g)}
---#synth BoundedCompactSupport (f*g)
+section Prod
 
--- one could make `IsBounded` a typeclass too, and measurable and HasCompactSupport, ..
-namespace Experimental
+variable {Y: Type*} [MeasureSpace Y] {g : Y → 𝕜}
+variable [TopologicalSpace Y] [IsFiniteMeasureOnCompacts (volume : Measure Y)]
 
-variable (f) in
-class IsBounded : Prop where
-  intro : Bornology.IsBounded (range f)
+#synth MeasureSpace (X × Y)
 
-instance [BoundedCompactSupport f] [IsBounded g] :
-    BoundedCompactSupport (f * g) := sorry
+end Prod
 
--- now this works
-variable [IsBounded g]
-#synth BoundedCompactSupport (f*g)
+-- section PotentialDanger?
 
-end Experimental
+-- instance [BoundedCompactSupport f] [BoundedCompactSupport g] :
+--     BoundedCompactSupport (f + g) := sorry
 
--- instance for fiberwise integral
+-- instance [hf : BoundedCompactSupport f] [hg : BoundedCompactSupport g]  :
+--     BoundedCompactSupport (f * g) := mul_bdd hf hg.bounded
 
-end PotentialDanger?
+-- -- generalize to other types than `𝕜`
+-- instance [BoundedCompactSupport f] (c : 𝕜) :
+--     BoundedCompactSupport (c • f) := sorry
+
+-- variable [BoundedCompactSupport f]
+-- #synth BoundedCompactSupport ((5:𝕜)•f+f*f)
+
+-- example : Integrable ((5:𝕜)•f+f*f) := BoundedCompactSupport.integrable (by infer_instance)
+
+-- -- would be nice if this could work:
+-- --variable {hg : IsBounded (range g)}
+-- --#synth BoundedCompactSupport (f*g)
+
+-- -- one could make `IsBounded` a typeclass too, and measurable and HasCompactSupport, ..
+-- namespace Experimental
+
+-- variable (f) in
+-- class IsBounded : Prop where
+--   intro : Bornology.IsBounded (range f)
+
+-- instance [BoundedCompactSupport f] [IsBounded g] :
+--     BoundedCompactSupport (f * g) := sorry
+
+-- -- now this works
+-- variable [IsBounded g]
+-- #synth BoundedCompactSupport (f*g)
+
+-- end Experimental
+
+-- -- instance for fiberwise integral
+
+-- end PotentialDanger?
 
 end BoundedCompactSupport
 

--- a/Carleson/ToMathlib/BoundedCompactSupport.lean
+++ b/Carleson/ToMathlib/BoundedCompactSupport.lean
@@ -49,12 +49,11 @@ variable (f) in
 /-- Bounded compactly supported measurable functions -/
 -- There are various alternative definitions one could use here
 -- After all it does seem to be better to use `IsBounded (range f)`
--- (and `AEStronglyMeasurable f`)
 -- Todo: Refactor accordingly
 structure BoundedCompactSupport : Prop where
   memℒp_top : Memℒp f ⊤ -- comment this out and uncomment the next two lines
   -- isBounded : IsBounded (range f)
-  -- aestronglyMeasurable : AEStronglyMeasurable f
+  -- aestronglyMeasurable : AEStronglyMeasurable f -- consider `StronglyMeasurable`
   hasCompactSupport : HasCompactSupport f
 
 lemma isBounded_range_iff_forall_norm_le {α β} [SeminormedAddCommGroup α] {f : β → α} :

--- a/Carleson/ToMathlib/BoundedCompactSupport.lean
+++ b/Carleson/ToMathlib/BoundedCompactSupport.lean
@@ -58,6 +58,10 @@ structure BoundedCompactSupport : Prop where
 --     _ ≤ ‖f x - f x₀‖ + ‖f x₀‖ := norm_add_le ..
 --     _ ≤ _ := by gcongr; sorry -- fix broke after copy to this context: exact hM x x₀
 
+-- in mathlib?
+lemma isBounded_range_iff_forall_norm_le {α β} [SeminormedAddCommGroup α] {f : β → α} :
+    IsBounded (range f) ↔ ∃ C, ∀ x, ‖f x‖ ≤ C := by convert isBounded_iff_forall_norm_le; simp
+
 namespace BoundedCompactSupport
 
 variable {f : X → 𝕜}

--- a/Carleson/ToMathlib/BoundedCompactSupport.lean
+++ b/Carleson/ToMathlib/BoundedCompactSupport.lean
@@ -141,7 +141,7 @@ theorem conj : BoundedCompactSupport (star f) where
       exact RCLike.continuous_conj.comp_aestronglyMeasurable hf.aestronglyMeasurable
     filter_upwards [hf.ae_le] with x hx
     exact trans (RCLike.norm_conj _) hx
-  hasCompactSupport := by -- mathlib should have a lemma `Memℒp.conj`?
+  hasCompactSupport := by -- mathlib should have a lemma `HasCompactSupport.conj`?
     suffices support (star f) = support f by
       rw [hasCompactSupport_def, this]; exact hf.hasCompactSupport
     apply support_eq_iff.mpr

--- a/Carleson/ToMathlib/BoundedCompactSupport.lean
+++ b/Carleson/ToMathlib/BoundedCompactSupport.lean
@@ -28,8 +28,8 @@ namespace MeasureTheory
 open Bornology Function Set HasCompactSupport
 open scoped ENNReal
 
--- should generalize, but this should be enough for this purpose
-variable {X 𝕜: Type*} [MeasureSpace X] [RCLike 𝕜] {f : X → 𝕜}
+-- can generalize to vector-valued, but for this project scalar-valued should be enough
+variable {X 𝕜} [MeasureSpace X] [RCLike 𝕜] {f : X → 𝕜}
 variable [TopologicalSpace X] [IsFiniteMeasureOnCompacts (volume : Measure X)]
 
 variable (f) in
@@ -43,49 +43,65 @@ namespace BoundedCompactSupport
 variable {f : X → 𝕜}
 variable {g : X → 𝕜}
 
+variable (hf : BoundedCompactSupport f)
+variable (hg : BoundedCompactSupport g)
+
+section Includehf
+/-! Results depending on `f` being bounded compactly supported. -/
+
+include hf
+
 /-- Bounded compactly supported functions are in all `Lᵖ` spaces. -/
-theorem memℒp (hf : BoundedCompactSupport f) (p : ENNReal) : Memℒp f p :=
-  hf.2.memℒp_of_isBounded hf.1 hf.3
+theorem memℒp (p : ENNReal) : Memℒp f p := hf.2.memℒp_of_isBounded hf.1 hf.3
 
 /-- Bounded compactly supported functions are integrable. -/
-theorem integrable (hf : BoundedCompactSupport f) : Integrable f :=
-  memℒp_one_iff_integrable.mp <| memℒp hf 1
+theorem integrable : Integrable f := memℒp_one_iff_integrable.mp <| memℒp hf 1
 
 /-- A bounded compactly supported function times a bounded function is
 bounded compactly supported. -/
-theorem mul_bdd
-    (hf : BoundedCompactSupport f) (hg : IsBounded (range g)) :
-    BoundedCompactSupport (f * g) := sorry
+theorem mul_bdd (hg : IsBounded (range g)) : BoundedCompactSupport (f * g) := sorry
 
-theorem bdd_mul
-    (hf : IsBounded (range f)) (hg : BoundedCompactSupport g) :
-    BoundedCompactSupport (f * g) := by rw [mul_comm]; exact mul_bdd hg hf
+theorem bdd_mul (hg : IsBounded (range g)) : BoundedCompactSupport (g * f) := by
+  rw [mul_comm]; exact mul_bdd hf hg
 
 #check Integrable.bdd_mul
 -- for convenience
-theorem integrable_mul
-    (hf : BoundedCompactSupport f) (hg : Integrable g) : Integrable (f * g) := by
-  sorry
+theorem integrable_mul (hg : Integrable g) : Integrable (f * g) := sorry
 
--- for convenience
-theorem mul
-    (hf : BoundedCompactSupport f) (hg : BoundedCompactSupport g) :
-    BoundedCompactSupport (f * g) := mul_bdd hf hg.bounded
+theorem conj : BoundedCompactSupport (star f) := sorry
 
-theorem add
-    (hf : BoundedCompactSupport f) (hg : BoundedCompactSupport g) :
-    BoundedCompactSupport (f + g) := sorry
+theorem norm : BoundedCompactSupport (‖f ·‖) := sorry
 
-theorem conj
-    (hf : BoundedCompactSupport f) : BoundedCompactSupport (star f) := sorry
+end Includehf
 
+section Includehfhg
+/-! Results depending on `f` and `g` being bounded compactly supported. -/
+
+include hf hg
+
+theorem mul : BoundedCompactSupport (f * g) := mul_bdd hf hg.bounded
+
+theorem add : BoundedCompactSupport (f + g) := sorry
+
+theorem const_mul (c : 𝕜) : BoundedCompactSupport (fun x ↦ c * (f x)) := sorry
+
+theorem mul_const (c : 𝕜) : BoundedCompactSupport (fun x ↦ (f x) * c) := sorry
+
+end Includehfhg
+
+/-- If `‖f‖` is bounded by `g` and `g` is bounded compactly supported, then so is `f`. -/
+theorem of_norm_le {g : X → ℝ} (hg : BoundedCompactSupport g)
+    (hfg : ∀ x, ‖f x‖ ≤ g x) : BoundedCompactSupport f := sorry
 
 section Prod
 
 variable {Y: Type*} [MeasureSpace Y] {g : Y → 𝕜}
 variable [TopologicalSpace Y] [IsFiniteMeasureOnCompacts (volume : Measure Y)]
 
-#synth MeasureSpace (X × Y)
+/-- An elementary tensor of bounded compactly supported functions is
+bounded compactly supported. -/
+theorem prod_mul (hf : BoundedCompactSupport f) (hg : BoundedCompactSupport g) :
+    BoundedCompactSupport (uncurry fun x y ↦ (f x) * (g y)) := sorry
 
 end Prod
 

--- a/Carleson/ToMathlib/Misc.lean
+++ b/Carleson/ToMathlib/Misc.lean
@@ -212,9 +212,9 @@ section
 
 open MeasureTheory Bornology
 variable {E X : Type*} {p : ℝ≥0∞} [NormedAddCommGroup E] [TopologicalSpace X] [MeasurableSpace X]
-  {μ : Measure X} [IsFiniteMeasureOnCompacts μ]
+  {μ : Measure X} [IsFiniteMeasureOnCompacts μ] {f : X → E}
 
-lemma _root_.HasCompactSupport.memℒp_of_isBounded {f : X → E} (hf : HasCompactSupport f)
+lemma _root_.HasCompactSupport.memℒp_of_isBounded (hf : HasCompactSupport f)
     (h2f : IsBounded (range f))
     (h3f : AEStronglyMeasurable f μ) {p : ℝ≥0∞} : Memℒp f p μ := by
   obtain ⟨C, hC⟩ := h2f.exists_norm_le

--- a/Carleson/ToMathlib/Misc.lean
+++ b/Carleson/ToMathlib/Misc.lean
@@ -214,12 +214,13 @@ open MeasureTheory Bornology
 variable {E X : Type*} {p : ℝ≥0∞} [NormedAddCommGroup E] [TopologicalSpace X] [MeasurableSpace X]
   {μ : Measure X} [IsFiniteMeasureOnCompacts μ] {f : X → E}
 
-lemma _root_.HasCompactSupport.memℒp_of_isBounded (hf : HasCompactSupport f)
-    (h2f : IsBounded (range f))
-    (h3f : AEStronglyMeasurable f μ) {p : ℝ≥0∞} : Memℒp f p μ := by
-  obtain ⟨C, hC⟩ := h2f.exists_norm_le
-  simp only [mem_range, forall_exists_index, forall_apply_eq_imp_iff] at hC
-  exact hf.memℒp_of_bound h3f C <| .of_forall hC
+---- now obsolete -> `BoundedCompactSupport.memℒp`
+-- lemma _root_.HasCompactSupport.memℒp_of_isBounded (hf : HasCompactSupport f)
+--     (h2f : IsBounded (range f))
+--     (h3f : AEStronglyMeasurable f μ) {p : ℝ≥0∞} : Memℒp f p μ := by
+--   obtain ⟨C, hC⟩ := h2f.exists_norm_le
+--   simp only [mem_range, forall_exists_index, forall_apply_eq_imp_iff] at hC
+--   exact hf.memℒp_of_bound h3f C <| .of_forall hC
 
 end
 

--- a/Carleson/ToMathlib/Misc.lean
+++ b/Carleson/ToMathlib/Misc.lean
@@ -321,3 +321,75 @@ lemma Real.self_lt_two_rpow (x : ℝ) : x < 2 ^ x := by
       _ < (⌊x⌋₊.succ : ℝ) := Nat.lt_succ_floor x
       _ ≤ 2 ^ (⌊x⌋₊ : ℝ) := by exact_mod_cast Nat.lt_pow_self one_lt_two _
       _ ≤ _ := rpow_le_rpow_of_exponent_le one_le_two (Nat.floor_le h)
+
+namespace Set
+
+open ComplexConjugate
+
+lemma indicator_eq_indicator_one_mul {ι M:Type*} [MulZeroOneClass M]
+    (s : Set ι) (f : ι → M) (x : ι) : s.indicator f x = s.indicator 1 x * f x := by
+  simp only [indicator]; split_ifs <;> simp
+
+lemma conj_indicator {α 𝕜 : Type*} [RCLike 𝕜] {f : α → 𝕜} (s : Set α) (x : α):
+    conj (s.indicator f x) = s.indicator (conj f) x := by
+  simp only [indicator]; split_ifs <;> simp
+
+end Set
+
+section Norm
+
+open Complex
+
+-- for mathlib?
+lemma norm_indicator_one_le {α E}
+    [SeminormedAddCommGroup E] [One E] [NormOneClass E] {s : Set α} (x : α) :
+    ‖s.indicator (1 : α → E) x‖ ≤ 1 :=
+  Trans.trans (norm_indicator_le_norm_self 1 x) norm_one
+
+lemma norm_exp_I_mul_ofReal (x : ℝ) : ‖exp (.I * x)‖ = 1 := by
+  rw [mul_comm, Complex.norm_exp_ofReal_mul_I]
+
+lemma norm_exp_I_mul_sub_ofReal (x y: ℝ) : ‖exp (.I * (x - y))‖ = 1 := by
+  rw [mul_comm, ← ofReal_sub, Complex.norm_exp_ofReal_mul_I]
+
+end Norm
+
+namespace MeasureTheory
+
+open Metric Bornology
+
+variable {X 𝕜: Type*}
+variable [RCLike 𝕜] {f : X → 𝕜}
+
+namespace HasCompactSupport
+
+variable [PseudoMetricSpace X]
+
+-- mathlib? also `ball` variant, remove `Nonempty`
+theorem of_support_subset_closedBall {x : X}
+ {r : ℝ} [ProperSpace X] [Nonempty X] (hf : support f ⊆ closedBall x r) :
+    HasCompactSupport f := by
+  apply HasCompactSupport.of_support_subset_isCompact ?_ hf
+  exact isCompact_closedBall ..
+
+theorem of_support_subset_isBounded {s : Set X}
+    [ProperSpace X] [Nonempty X] (hs : IsBounded s) (hf : support f ⊆ s) :
+    HasCompactSupport f := by
+  let x₀ : X := Classical.choice (by infer_instance)
+  obtain ⟨r₀, hr₀⟩ := hs.subset_closedBall x₀
+  exact HasCompactSupport.of_support_subset_closedBall <| Trans.trans hf hr₀
+
+end HasCompactSupport
+
+namespace Integrable
+
+variable [MeasureSpace X]
+
+-- must be in mathlib but can't find it
+theorem indicator_const {c : ℝ} {s: Set X}
+    (hs: MeasurableSet s) (h2s : volume s < ⊤) : Integrable (s.indicator (fun _ ↦ c)) :=
+  (integrable_indicator_iff hs).mpr <| integrableOn_const.mpr <| Or.inr h2s
+
+end Integrable
+
+end MeasureTheory

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -5039,9 +5039,9 @@ The adjoint of the operator $T_{\fp}$ defined in \eqref{definetp} is given by
 \end{lemma}
 
 \begin{proof}
-    By Cauchy-Schwarz and \Cref{densities-tree-bound}, we have for all bounded $f,g$ with bounded support that
+    By \Cref{densities-tree-bound}, we have for all bounded $f,g$ with bounded support that
     $$
-        \left| \int_X \overline{\sum_{\fp\in \fT(\fu)} T_{\fp}^* g} f \,\mathrm{d}\mu \right| = \left| \int_X g \sum_{\fp \in \fT(\fu)} T_{\fp} f \,\mathrm{d}\mu \right|
+        \left| \int_X \overline{\sum_{\fp\in \fT(\fu)} T_{\fp}^* g} f \,\mathrm{d}\mu \right| = \left| \int_X \overline{g} \sum_{\fp \in \fT(\fu)} T_{\fp} f \,\mathrm{d}\mu \right|
     $$
     \begin{equation}
         \label{eq-adjoint-bound}

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -5039,6 +5039,7 @@ The adjoint of the operator $T_{\fp}$ defined in \eqref{definetp} is given by
 \end{lemma}
 
 \begin{proof}
+    \leanok
     By \Cref{densities-tree-bound}, we have for all bounded $f,g$ with bounded support that
     $$
         \left| \int_X \overline{\sum_{\fp\in \fT(\fu)} T_{\fp}^* g} f \,\mathrm{d}\mu \right| = \left| \int_X \overline{g} \sum_{\fp \in \fT(\fu)} T_{\fp} f \,\mathrm{d}\mu \right|

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -3858,6 +3858,7 @@ Then
 \end{lemma}
 
 \begin{proof}
+\leanok
 By \Cref{monotone-cube-metrics}, we have
 \begin{equation}
      d_{\fp}(\fcc(\fp'),\mfa)
@@ -3866,7 +3867,7 @@ By \Cref{monotone-cube-metrics}, we have
 \end{equation}
 Together with \eqref{eqassumedismfa} and the triangle inequality, we obtain
 \begin{equation}\label{eqdistqpqp}
-    d_{\fp'}(\fcc(\fp'),\fcc(\fp))\le 2^{N+1} \, .
+    d_{\fp}(\fcc(\fp'),\fcc(\fp))\le 2^{N+1} \, .
 \end{equation}
 Now assume
 \begin{equation}
@@ -3883,7 +3884,7 @@ B(\pc(\fp'),4D^{\ps(\fp')})\, .
 Hence by the triangle inequality
 \begin{equation}
  B(\pc(\fp), 4D^{\ps(\fp')})
- \subset
+ \subseteq
 B(\pc(\fp'),8D^{\ps(\fp')})\, .
 \end{equation}
 Together with \eqref{ageo1} and monotonicity \eqref{monotonedb} of $d$


### PR DESCRIPTION
This proves Lemma 7.4.2 and various prerequisites that will also be useful for other lemmas. 
Main additions are:

In `ForestOperator/AlmostOrthogonality.lean`:
- `adjoint_tree_estimate`: Lemma 7.4.2
- `adjointCarleson_adjoint`: `adjointCarleson` is actually the adjoint of `carlesonOn`
- `BoundedCompactSupport.adjointCarleson`: `adjointCarleson` has bounded compact support if the input function does

In `TileStructure.lean`:
- `AEStronglyMeasurable.carlesonOn`: `carlesonOn` is a.e. strongly measurable
- `BoundedCompactSupport.carlesonOn`: `carlesonOn` has bounded compact support if the input function does

In `Psi.lean`:
- `exists_bound_of_norm_Ks`: existence of uniform bound for `‖Ks x y‖` if `x` is in a bounded set

The new file `BoundedCompactSupport.lean` defines a predicate for functions that are (essentially) bounded, a.e. strongly measurable and have compact support. It will be convenient to use this as an assumption on input functions in most lemmas and to use/expand helper lemmas in this file as needed.

(Edited 12/8/24)