### PR TITLE
redefine upperRadius

### DIFF
--- a/Carleson/Defs.lean
+++ b/Carleson/Defs.lean
@@ -193,6 +193,14 @@ def CZOperator (K : X → X → ℂ) (r : ℝ) (f : X → ℂ) (x : X) : ℂ :=
 def upperRadius [FunctionDistances ℝ X] (Q : X → Θ X) (θ : Θ X) (x : X) : ℝ :=
   sSup { r : ℝ | dist_{x, r} θ (Q x) < 1 }
 
+lemma le_upperRadius [FunctionDistances ℝ X] {Q : X → Θ X} {θ : Θ X} {x : X} {r : ℝ}
+    (hr : dist_{x, r} θ (Q x) < 1) : r ≤ upperRadius Q θ x := by
+  have bdd : BddAbove { r : ℝ | dist_{x, r} θ (Q x) < 1 } := by sorry
+  have : { r : ℝ | dist_{x, r} θ (Q x) < 1 }.Nonempty := ⟨r, hr⟩
+  rw [upperRadius, Real.le_sSup_iff bdd this]
+  intro ε hε
+  use r, hr, by linarith
+
 /-- The linearized maximally truncated nontangential Calderon Zygmund operator `T_Q^θ` -/
 def linearizedNontangentialOperator [FunctionDistances ℝ X] (Q : X → Θ X) (θ : Θ X)
     (K : X → X → ℂ) (f : X → ℂ) (x : X) : ℝ≥0∞ :=

--- a/Carleson/Defs.lean
+++ b/Carleson/Defs.lean
@@ -190,14 +190,14 @@ def CZOperator (K : X → X → ℂ) (r : ℝ) (f : X → ℂ) (x : X) : ℂ :=
   ∫ y in {y | dist x y ∈ Ici r}, K x y * f y
 
 /-- `R_Q(θ, x)` defined in (1.0.20). -/
-def upperRadius [FunctionDistances ℝ X] (Q : X → Θ X) (θ : Θ X) (x : X) : ℝ≥0∞ :=
-  sSup { r : ℝ≥0∞ | dist_{x, r.toReal} θ (Q x) < 1 }
+def upperRadius [FunctionDistances ℝ X] (Q : X → Θ X) (θ : Θ X) (x : X) : ℝ :=
+  sSup { r : ℝ | dist_{x, r} θ (Q x) < 1 }
 
 /-- The linearized maximally truncated nontangential Calderon Zygmund operator `T_Q^θ` -/
 def linearizedNontangentialOperator [FunctionDistances ℝ X] (Q : X → Θ X) (θ : Θ X)
     (K : X → X → ℂ) (f : X → ℂ) (x : X) : ℝ≥0∞ :=
   ⨆ (R₁ : ℝ) (x' : X) (_ : dist x x' ≤ R₁),
-  ‖∫ y in {y | ENNReal.ofReal (dist x' y) ∈ Ioo (ENNReal.ofReal R₁) (upperRadius Q θ x')},
+  ‖∫ y in {y | dist x' y ∈ Ioo R₁ (upperRadius Q θ x')},
     K x' y * f y‖₊
 
 /-- The maximally truncated nontangential Calderon Zygmund operator `T_*` -/

--- a/Carleson/Defs.lean
+++ b/Carleson/Defs.lean
@@ -196,10 +196,7 @@ def upperRadius [FunctionDistances ℝ X] (Q : X → Θ X) (θ : Θ X) (x : X) :
 lemma le_upperRadius [FunctionDistances ℝ X] {Q : X → Θ X} {θ : Θ X} {x : X} {r : ℝ}
     (hr : dist_{x, r} θ (Q x) < 1) : r ≤ upperRadius Q θ x := by
   have bdd : BddAbove { r : ℝ | dist_{x, r} θ (Q x) < 1 } := by sorry
-  have : { r : ℝ | dist_{x, r} θ (Q x) < 1 }.Nonempty := ⟨r, hr⟩
-  rw [upperRadius, Real.le_sSup_iff bdd this]
-  intro ε hε
-  use r, hr, by linarith
+  exact (Real.le_sSup_iff bdd ⟨r, hr⟩).mpr fun ε hε ↦ ⟨r, hr, add_lt_iff_neg_left.mpr hε⟩
 
 /-- The linearized maximally truncated nontangential Calderon Zygmund operator `T_Q^θ` -/
 def linearizedNontangentialOperator [FunctionDistances ℝ X] (Q : X → Θ X) (θ : Θ X)

--- a/Carleson/ForestOperator/PointwiseEstimate.lean
+++ b/Carleson/ForestOperator/PointwiseEstimate.lean
@@ -631,7 +631,7 @@ lemma second_tree_pointwise (hu : u ∈ t) (hL : L ∈ 𝓛 (t u)) (hx : x ∈ L
     le_iSup₂_of_le (𝔰 p') ⟨s_ineq, scale_mem_Icc.2⟩ <| le_iSup_of_le ?_ ?_
   · have : ((D : ℝ≥0∞) ^ (𝔰 p' - 1)).toReal = D ^ (s₂ - 1) := by
       rw [sp', ← ENNReal.toReal_zpow]; simp
-    apply le_sSup; rwa [mem_setOf, dist_congr rfl this]
+    apply le_upperRadius; convert d1
   · convert le_rfl; change (Icc (𝔰 p) _).toFinset = _; rw [sp, sp']
     apply subset_antisymm
     · rw [← Finset.toFinset_coe (t.σ u x), toFinset_subset_toFinset]


### PR DESCRIPTION
With the current definition of `upperRadius`, it will always be infinity. (Infinity will be in the set that we're taking a supremum of, due to the `toReal` causing infinity to be treated as 0.) This PR redefines `upperRadius` to avoid that problem, by taking a sup over reals instead. I think a real-valued `upperRadius` will also be nicer to work with.

In order for the real-valued sup to behave nicely, we need to know that the set we're taking the sup of is bounded. Our assumptions ensure that this is the case in non-trivial situations, but we might need an additional assumption to rule out trivial cases. Do any of the existing assumptions ensure that d_B is not identically 0?