### PR TITLE
fix: use `weak` flexible linter option

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -10,7 +10,7 @@ linter.style.longLine = false
 linter.oldObtain = true
 linter.refine = true
 linter.style.multiGoal = true
-linter.flexible = true
+weak.linter.flexible = true
 
 [[require]]
 name = "mathlib"


### PR DESCRIPTION
[Zulip](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/lake.20doesn't.20find.20option)

This allows project files that do not import the flexible linter to pass CI.