### PR TITLE
Translate spectral_projection_bound_lp to spectral_projection_bound

### DIFF
--- a/Carleson/Classical/Basic.lean
+++ b/Carleson/Classical/Basic.lean
@@ -7,19 +7,151 @@ import Mathlib.Analysis.Convolution
 
 import Carleson.Classical.Helper
 
-open Finset Real
+open Finset Real MeasureTheory AddCircle
 
 noncomputable section
+
+
+--TODO: to mathlib
+theorem AEEqFun.mk_sum.{u_3, u_2, u_1} {α : Type u_1} {E : Type u_2} {m0 : MeasurableSpace α}
+    {μ : Measure α} [inst : NormedAddCommGroup E] {ι : Type u_3} [DecidableEq ι] {s : Finset ι} {f : ι → α → E}
+    (hf : ∀ i ∈ s, AEStronglyMeasurable (f i) μ) :
+      AEEqFun.mk (∑ i ∈ s, f i) (Finset.aestronglyMeasurable_sum' s hf) = ∑ i ∈ s.attach, AEEqFun.mk (f ↑i) (hf i (Finset.coe_mem i)) := by
+  induction' s using Finset.induction_on with i s hi h
+  . simp_rw [Finset.attach_empty, Finset.sum_empty]
+    exact rfl
+  . simp_rw [Finset.attach_insert]
+    simp_rw [Finset.sum_insert hi]
+    have hi' : @Subtype.mk ι (fun x ↦ x ∈ insert i s) i (Finset.mem_insert_self i s) ∉ @Finset.image { x // x ∈ s } { x // x ∈ insert i s } (fun a b ↦ a.instDecidableEq b) (fun x ↦ ⟨↑x, Finset.mem_insert_of_mem x.property⟩) s.attach := by
+      simp [hi]
+    simp_rw [Finset.sum_insert hi']
+    rw [← AEEqFun.mk_add_mk _ _ (hf _ (Finset.mem_insert_self i s)) (Finset.aestronglyMeasurable_sum' s (fun j hj ↦ hf j (Finset.mem_insert_of_mem hj)))]
+    congr
+    -- use induction hypothesis here
+    rw [h (fun j hj ↦ hf j (Finset.mem_insert_of_mem hj))]
+
+    simp only [Finset.mem_attach, Subtype.mk.injEq, forall_const, Subtype.forall, imp_self,
+      implies_true, Finset.sum_image]
+
+--TODO: to mathlib
+lemma ContinuousMap.memℒp {α : Type*} {E : Type*} {m0 : MeasurableSpace α} {p : ENNReal} (μ : Measure α)
+    [NormedAddCommGroup E] [TopologicalSpace α] [BorelSpace α] [SecondCountableTopologyEither α E] [CompactSpace α]
+    [IsFiniteMeasure μ] (𝕜 : Type*) [Fact (1 ≤ p)] [NormedField 𝕜] [NormedSpace 𝕜 E] (f : C(α, E)) : Memℒp f p μ := by
+  have := Subtype.val_prop (ContinuousMap.toLp p μ 𝕜 f)
+  have := Lp.mem_Lp_iff_memℒp.mp this
+  rw [ContinuousMap.coe_toLp, memℒp_congr_ae (ContinuousMap.coeFn_toAEEqFun _ _)] at this
+  exact this
+
+--TODO: to mathlib
+lemma Memℒp.toLp_sum {α : Type*} {E : Type*} {m0 : MeasurableSpace α} {p : ENNReal}
+    {μ : Measure α} [NormedAddCommGroup E] {ι : Type*} [DecidableEq ι] (s : Finset ι) {f : ι → α → E} (hf : ∀ i ∈ s, Memℒp (f i) p μ) :
+    Memℒp.toLp (∑ i ∈ s, f i) (memℒp_finset_sum' s hf) = ∑ i : ↑s, (Memℒp.toLp (f i) (hf i (Finset.coe_mem i))) := by
+  rw [Finset.univ_eq_attach]
+  refine Lp.ext_iff.mpr ?_
+  unfold Memℒp.toLp
+  rw [Subtype.val]
+  rw [AddSubgroup.val_finset_sum]
+  refine AEEqFun.ext_iff.mp ?_
+  apply AEEqFun.mk_sum (fun i hi ↦ (hf i hi).aestronglyMeasurable)
+
+/-
+--TODO: move to AddCircle
+lemma AddCircle.coe_liftIoc_apply.{u_1, u_2} {𝕜 : Type u_1} {B : Type u_2} [LinearOrderedAddCommGroup 𝕜] {p : 𝕜}
+    [hp : Fact (0 < p)] {a : 𝕜} [Archimedean 𝕜] {f : 𝕜 → B} {x : AddCircle p} : liftIoc p a f x = f (x : 𝕜) := by
+  sorry
+-/
+
+--TODO: move to AddCircle
+lemma AddCircle.coe_eq_coe_iff_of_mem_Ioc.{u_1} {𝕜 : Type u_1} [LinearOrderedAddCommGroup 𝕜] {p : 𝕜} [hp : Fact (0 < p)]
+    {a : 𝕜} [Archimedean 𝕜] {x y : 𝕜} (hx : x ∈ Set.Ioc a (a + p)) (hy : y ∈ Set.Ioc a (a + p)) : (x : AddCircle p) = y ↔ x = y := by
+  refine ⟨fun h => ?_, by tauto⟩
+  suffices (⟨x, hx⟩ : Set.Ioc a (a + p)) = ⟨y, hy⟩ by exact Subtype.mk.inj this
+  apply_fun equivIoc p a at h
+  rw [← (equivIoc p a).right_inv ⟨x, hx⟩, ← (equivIoc p a).right_inv ⟨y, hy⟩]
+  exact h
+
+--TODO: move to AddCircle
+lemma AddCircle.eq_coe_Ioc.{u_1} {𝕜 : Type u_1} [LinearOrderedAddCommGroup 𝕜] {p : 𝕜} [hp : Fact (0 < p)] [Archimedean 𝕜]
+    (a : AddCircle p) : ∃ b ∈ Set.Ioc 0 p, ↑b = a := by
+  let b := QuotientAddGroup.equivIocMod hp.out 0 a
+  exact ⟨b.1, by simpa only [zero_add] using b.2,
+    (QuotientAddGroup.equivIocMod hp.out 0).symm_apply_apply a⟩
+
+--TODO: move to fourier file
+--TODO: I think the measurability assumptions might be unnecessary
+theorem fourierCoeff_eq_fourierCoeff_of_aeeq {T : ℝ} [hT : Fact (0 < T)] {n : ℤ} {f g : AddCircle T → ℂ}
+    (hf : AEStronglyMeasurable f haarAddCircle) (hg : AEStronglyMeasurable g haarAddCircle)
+    (h : f =ᶠ[ae haarAddCircle] g) : fourierCoeff f n = fourierCoeff g n := by
+  unfold fourierCoeff
+  apply integral_congr_ae
+  change @DFunLike.coe C(AddCircle T, ℂ) (AddCircle T) (fun x ↦ ℂ) ContinuousMap.instFunLike (fourier (-n)) * f =ᶠ[ae haarAddCircle] @DFunLike.coe C(AddCircle T, ℂ) (AddCircle T) (fun x ↦ ℂ) ContinuousMap.instFunLike (fourier (-n)) * g
+  have fourier_measurable : AEStronglyMeasurable (⇑(@fourier T (-n))) haarAddCircle := (ContinuousMap.measurable _).aestronglyMeasurable
+
+  rw [← @AEEqFun.mk_eq_mk _ _ _ _ _ _ _ (fourier_measurable.mul hf) (fourier_measurable.mul hg),
+      ← AEEqFun.mk_mul_mk _ _ fourier_measurable hf, ← AEEqFun.mk_mul_mk _ _ fourier_measurable hg]
+  congr 1
+  rwa [AEEqFun.mk_eq_mk]
 
 
 def partialFourierSum (N : ℕ) (f : ℝ → ℂ) (x : ℝ) : ℂ := ∑ n ∈ Icc (-(N : ℤ)) N,
     fourierCoeffOn Real.two_pi_pos f n * fourier n (x : AddCircle (2 * π))
 
---TODO: Add an AddCircle version?
-/-
-def AddCircle.partialFourierSum' {T : ℝ} [hT : Fact (0 < T)] (N : ℕ) (f : AddCircle T → ℂ) (x : AddCircle T) : ℂ :=
-    ∑ n in Icc (-Int.ofNat ↑N) N, fourierCoeff f n * fourier n x
--/
+def partialFourierSum' {T : ℝ} [hT : Fact (0 < T)] (N : ℕ) (f : AddCircle T → ℂ) : C(AddCircle T, ℂ) :=
+    ∑ n ∈ Finset.Icc (-Int.ofNat N) N, fourierCoeff f n • fourier n
+
+def partialFourierSumLp {T : ℝ} [hT : Fact (0 < T)] (p : ENNReal) [Fact (1 ≤ p)] (N : ℕ) (f : AddCircle T → ℂ) : Lp ℂ p (@haarAddCircle T hT) :=
+    ∑ n ∈ Finset.Icc (-Int.ofNat N) N, fourierCoeff f n • fourierLp p n
+
+
+lemma partialFourierSum_eq_partialFourierSum' [hT : Fact (0 < 2 * Real.pi)] (N : ℕ) (f : ℝ → ℂ) :
+    liftIoc (2 * Real.pi) 0 (partialFourierSum N f) = partialFourierSum' N (liftIoc (2 * Real.pi) 0 f) := by
+  ext x
+  unfold partialFourierSum partialFourierSum' liftIoc
+  simp only [
+    Function.comp_apply, Set.restrict_apply, Int.ofNat_eq_coe, ContinuousMap.coe_sum,
+    ContinuousMap.coe_smul, Finset.sum_apply, Pi.smul_apply, smul_eq_mul]
+  congr
+  ext n
+  rw [← liftIoc, fourierCoeff_liftIoc_eq]
+  congr 2
+  . rw [zero_add (2 * Real.pi)]
+  . rcases (eq_coe_Ioc x) with ⟨b, hb, rfl⟩
+    rw [← zero_add (2 * Real.pi)] at hb
+    rw [coe_eq_coe_iff_of_mem_Ioc (Subtype.coe_prop _) hb]
+    have : (liftIoc (2 * Real.pi) 0 (fun x ↦ x)) b = (fun x ↦ x) b := liftIoc_coe_apply hb
+    unfold liftIoc at this
+    rw [Function.comp_apply, Set.restrict_apply] at this
+    exact this
+
+lemma partialFourierSupLp_eq_partialFourierSupLp_of_aeeq {T : ℝ} [hT : Fact (0 < T)] {p : ENNReal} [Fact (1 ≤ p)] {N : ℕ} {f g : AddCircle T → ℂ}
+    (hf : AEStronglyMeasurable f haarAddCircle) (hg : AEStronglyMeasurable g haarAddCircle)
+    (h : f =ᶠ[ae haarAddCircle] g) : partialFourierSumLp p N f = partialFourierSumLp p N g := by
+  unfold partialFourierSumLp
+  congr
+  ext n : 1
+  congr 1
+  exact fourierCoeff_eq_fourierCoeff_of_aeeq hf hg h
+
+
+lemma partialFourierSum'_eq_partialFourierSumLp {T : ℝ} [hT : Fact (0 < T)] (p : ENNReal) [Fact (1 ≤ p)] (N : ℕ) (f : AddCircle T → ℂ) :
+    partialFourierSumLp p N f = Memℒp.toLp (partialFourierSum' N f) ((partialFourierSum' N f).memℒp haarAddCircle ℂ)  := by
+  unfold partialFourierSumLp partialFourierSum'
+  unfold fourierLp
+  simp_rw [ContinuousMap.coe_sum, ContinuousMap.coe_smul]
+  rw [Memℒp.toLp_sum _ (by intro n hn; apply Memℒp.const_smul (ContinuousMap.memℒp haarAddCircle ℂ (fourier n)))]
+  rw [Finset.univ_eq_attach]
+  rw [← Finset.sum_attach]
+  rfl
+
+
+lemma partialFourierSum_aeeq_partialFourierSumLp [hT : Fact (0 < 2 * Real.pi)] (p : ENNReal) [Fact (1 ≤ p)] (N : ℕ) (f : ℝ → ℂ) (h_mem_ℒp :  Memℒp (liftIoc (2 * Real.pi) 0 f) 2 haarAddCircle):
+    liftIoc (2 * Real.pi) 0 (partialFourierSum N f) =ᶠ[ae haarAddCircle] ↑↑(partialFourierSumLp p N (Memℒp.toLp (liftIoc (2 * Real.pi) 0 f) h_mem_ℒp)) := by
+  rw [partialFourierSupLp_eq_partialFourierSupLp_of_aeeq (Lp.aestronglyMeasurable _) h_mem_ℒp.aestronglyMeasurable (Memℒp.coeFn_toLp h_mem_ℒp)]
+  rw [partialFourierSum'_eq_partialFourierSumLp, partialFourierSum_eq_partialFourierSum']
+  symm
+  apply Memℒp.coeFn_toLp
+
+
 
 local notation "S_" => partialFourierSum
 

--- a/Carleson/Classical/HilbertStrongType.lean
+++ b/Carleson/Classical/HilbertStrongType.lean
@@ -67,22 +67,56 @@ lemma partial_sum_selfadjoint {f g : ℝ → ℂ} {n : ℕ}
     ∫ x in (0)..2 * π, conj (f x) * partialFourierSum n g x := by
   sorry
 
+
+--lemma eLpNorm_eq_norm {f : ℝ → ℂ} {p : ENNReal} (hf : Memℒp f p) :
+--    ‖Memℒp.toLp f hf‖ = eLpNorm f p := by
+--  sorry
+
+theorem AddCircle.haarAddCircle_eq_smul_volume {T : ℝ} [hT : Fact (0 < T)] :
+    (@haarAddCircle T _) = (ENNReal.ofReal T)⁻¹ • (volume : Measure (AddCircle T)) := by
+  rw [volume_eq_smul_haarAddCircle, ← smul_assoc, smul_eq_mul, ENNReal.inv_mul_cancel (by simp [hT.out]) ENNReal.ofReal_ne_top, one_smul]
+
 open AddCircle in
 /-- Lemma 11.1.11.
 The blueprint states this on `[-π, π]`, but I think we can consistently change this to `(0, 2π]`.
 -/
 -- todo: add lemma that relates `eLpNorm ((Ioc a b).indicator f)` to `∫ x in a..b, _`
-lemma spectral_projection_bound {f : ℝ → ℂ} {n : ℕ}
-    (hmf : Measurable f) (hf : eLpNorm f ∞ < ∞) (periodic_f : f.Periodic (2 * π)) :
+lemma spectral_projection_bound {f : ℝ → ℂ} {n : ℕ} (hmf : Measurable f) :
     eLpNorm ((Ioc 0 (2 * π)).indicator (partialFourierSum n f)) 2 ≤
     eLpNorm ((Ioc 0 (2 * π)).indicator f) 2 := by
-  -- Note: easiest proof might be by massaging the statement of `spectral_projection_bound_lp`
-  -- into this
+  -- Proof by massaging the statement of `spectral_projection_bound_lp` into this.
+  by_cases hf_L2 : eLpNorm ((Ioc 0 (2 * π)).indicator f) 2 = ⊤
+  . rw [hf_L2]
+    exact OrderTop.le_top _
+  push_neg at hf_L2
+  rw [← lt_top_iff_ne_top] at hf_L2
   have : Fact (0 < 2 * π) := ⟨by positivity⟩
+  have lift_memℒp : Memℒp (liftIoc (2 * π) 0 f) 2 haarAddCircle := by
+    unfold Memℒp
+    constructor
+    . rw [haarAddCircle_eq_smul_volume]
+      apply AEStronglyMeasurable.smul_measure
+      exact hmf.aestronglyMeasurable.liftIoc (2 * π) 0
+    . rw [haarAddCircle_eq_smul_volume, eLpNorm_smul_measure_of_ne_top (by trivial), eLpNorm_liftIoc _ _ hmf.aestronglyMeasurable, smul_eq_mul, zero_add]
+      apply ENNReal.mul_lt_top _ hf_L2
+      rw [← ENNReal.ofReal_inv_of_pos this.out]
+      apply ENNReal.rpow_lt_top_of_nonneg ENNReal.toReal_nonneg ENNReal.ofReal_ne_top
   let F : Lp ℂ 2 haarAddCircle :=
-    MemLp.toLp (AddCircle.liftIoc (2 * π) 0 f) sorry
-  have := spectral_projection_bound_lp (N := n) F
-  sorry
+    Memℒp.toLp (AddCircle.liftIoc (2 * π) 0 f) lift_memℒp
+
+  have lp_version := spectral_projection_bound_lp (N := n) F
+  rw [Lp.norm_def, Lp.norm_def,
+    ENNReal.toReal_le_toReal (Lp.eLpNorm_ne_top (partialFourierSumLp 2 n F)) (Lp.eLpNorm_ne_top F)] at lp_version
+
+  rw [← zero_add (2 * π), ← eLpNorm_liftIoc _ _ hmf.aestronglyMeasurable, ← eLpNorm_liftIoc _ _ partialFourierSum_uniformContinuous.continuous.aestronglyMeasurable, volume_eq_smul_haarAddCircle,
+    eLpNorm_smul_measure_of_ne_top (by trivial), eLpNorm_smul_measure_of_ne_top (by trivial),
+    smul_eq_mul, smul_eq_mul, ENNReal.mul_le_mul_left (by simp [Real.pi_pos]) (by simp)]
+  have ae_eq_right : ↑↑F =ᶠ[ae haarAddCircle] liftIoc (2 * π) 0 f := Memℒp.coeFn_toLp _
+  have ae_eq_left : ↑↑(partialFourierSumLp 2 n F) =ᶠ[ae haarAddCircle] liftIoc (2 * π) 0 (partialFourierSum n f) := by
+    exact Filter.EventuallyEq.symm (partialFourierSum_aeeq_partialFourierSumLp 2 n f lift_memℒp)
+  rw [← eLpNorm_congr_ae ae_eq_right, ← eLpNorm_congr_ae ae_eq_left]
+  exact lp_version
+
 
 /-- Lemma 11.3.1.
 The blueprint states this on `[-π, π]`, but I think we can consistently change this to `(0, 2π]`.

--- a/Carleson/Classical/SpectralProjectionBound.lean
+++ b/Carleson/Classical/SpectralProjectionBound.lean
@@ -21,14 +21,6 @@ lemma fourierCoeff_eq_innerProduct {T : ℝ} [hT : Fact (0 < T)] [h2 : Fact (1 �
   rw [← coe_fourierBasis, ← fourierBasis_repr]
   exact HilbertBasis.repr_apply_apply fourierBasis f n
 
-
-noncomputable section
-def partialFourierSumLp {T : ℝ} [hT : Fact (0 < T)] (p : ENNReal) [Fact (1 ≤ p)] (N : ℕ) (f : ↥(Lp ℂ 2 (@haarAddCircle T hT))) : Lp ℂ p (@haarAddCircle T hT) :=
-    ∑ n ∈ Finset.Icc (-Int.ofNat N) N, fourierCoeff f n • fourierLp p n
-
---TODO: add some lemma relating partialFourierSum and partialFourierSumLp
-
-
 lemma partialFourierSumL2_norm {T : ℝ} [hT : Fact (0 < T)] [h2 : Fact (1 ≤ (2 : ENNReal))] {f : ↥(Lp ℂ 2 haarAddCircle)} {N : ℕ} :
     ‖partialFourierSumLp 2 N f‖ ^ 2 = ∑ n ∈ Finset.Icc (-Int.ofNat N) N, ‖@fourierCoeff T hT _ _ _ f n‖ ^ 2 := by
   calc ‖partialFourierSumLp 2 N f‖ ^ 2


### PR DESCRIPTION
Proved `spectral_projection_bound`, a version of   of Lemma 11.1.11 by translating the version `spectral_projection_bound_lp`.