### PR TITLE
Draft PR for Lemma 10.1.2

### DIFF
--- a/Carleson/Defs.lean
+++ b/Carleson/Defs.lean
@@ -345,10 +345,10 @@ lemma integrableOn_K_Icc [IsOpenPosMeasure (volume : Measure X)]
 In the formalization `K x y` is defined everywhere, even for `x = y`. The assumptions on `K` show
 that `K x x = 0`. -/
 class IsTwoSidedKernel (a : outParam ℕ) (K : X → X → ℂ) extends IsOneSidedKernel a K where
-  norm_K_sub_le' {x x' y : X} (h : 2 * dist x x' ≤ dist x y) :
+  enorm_K_sub_le' {x x' y : X} (h : 2 * dist x x' ≤ dist x y) :
     ‖K x y - K x' y‖ₑ ≤ (edist x x' / edist x y) ^ (a : ℝ)⁻¹ * (C_K a / vol x y)
 
-export IsTwoSidedKernel (norm_K_sub_le')
+export IsTwoSidedKernel (enorm_K_sub_le')
 
 -- maybe show: `K` is a 2-sided kernel iff `K` and `fun x y ↦ K y x` are one-sided kernels.
 

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -1,8 +1,8 @@
 import Carleson.TwoSidedCarleson.WeakCalderonZygmund
 import Carleson.ToMathlib.Analysis.Convex.SpecificFunctions.Basic
+import Carleson.ToMathlib.ENorm
 
-
-open MeasureTheory Set Bornology Function ENNReal Metric
+open MeasureTheory Set Bornology Function ENNReal Metric Complex
 open scoped NNReal
 
 noncomputable section
@@ -114,12 +114,12 @@ theorem geometric_series_estimate {x : ℝ} (hx : 4 ≤ x) :
 irreducible_def C10_1_2 (a : ℕ) : ℝ≥0 := 2 ^ (a ^ 3 + 2 * a + 2)
 
 lemma czoperator_welldefined {g : X → ℂ} (hmg : Measurable g) (hg : eLpNorm g ∞ < ∞)
-    (h2g : volume (support g) < ∞) (hr : 0 < r) :
+    (h2g : volume (support g) < ∞) (hr : 0 < r) (x : X):
     IntegrableOn (fun y => K x y * g y) (ball x r)ᶜ volume := by
   sorry
 
 lemma czoperator_wd_2 {g : X → ℂ} {hmg : Measurable g} {hg : eLpNorm g ∞ < ∞}
-    {h2g : volume (support g) < ∞} {hr : 0 < r} (x : X):
+    {h2g : volume (support g) < ∞} {hr : 0 < r} (x : X) :
     IntegrableOn (fun y => K x y * g y) (ball x r)ᶜ volume := by
   sorry
 
@@ -146,6 +146,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
     C10_1_2 a * globalMaximalFunction volume 1 g x := by
   let bxrc := (ball x r)ᶜ
   let bx2r := ball x (2*r)
+
   -- Domain split x integral
   have dom_x : bxrc =  (bxrc ∩ bx2r) ∪ bx2rᶜ := by
     have tmp1 : bx2rᶜ = bxrc ∩ bx2rᶜ := by
@@ -216,28 +217,79 @@ theorem estimate_x_shift (ha : 4 ≤ a)
   let int10_1_3 := 0
   let int10_1_4 := 0
 
+  rw [← edist_nndist, edist_eq_enorm_sub, integral_x, integral_x_prime]
+
   -- Rewrite lhs according to 10.1.234 split
   conv =>
-    lhs
-    rw [nndist_dist, Complex.dist_eq, integral_x, integral_x_prime]
     arg 1; arg 1
-    conv =>
-      arg 2
-      calc _
-        _ = (∫ (y : X) in bxrc ∩ bx2r, K x y * g y)
+    calc _
+      _ = (∫ (y : X) in bxrc ∩ bx2r, K x y * g y)
                 + ((∫ (y : X) in bx2rᶜ, K x y * g y) - (∫ (y : X) in bx2rᶜ, K x' y * g y))
                 - (∫ (y : X) in bxprc ∩ bx2r, K x' y * g y) := by ring
-        _ = (∫ (y : X) in bxrc ∩ bx2r, K x y * g y)
+      _ = (∫ (y : X) in bxrc ∩ bx2r, K x y * g y)
                 + (∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y)
                 - (∫ (y : X) in bxprc ∩ bx2r, K x' y * g y) := by
-                  rw[← integral_sub]
-                  apply czoperator_wd_2; exact hmg; exact hg; exact h2g; simp; exact hr
-                  have tmp4 : IntegrableOn (fun y ↦ K x' y * g y) bxprc := by
-                    apply czoperator_wd_2; exact hmg; exact hg; exact h2g; exact hr
-                  apply IntegrableOn.mono_set tmp4 tmp2
+          rw[← integral_sub]
+          apply czoperator_welldefined hmg hg h2g (by simp; exact hr)
+          apply IntegrableOn.mono_set
+          swap; exact tmp2
+          apply czoperator_welldefined hmg hg h2g hr
 
+  trans ‖(∫ (y : X) in bxrc ∩ bx2r, K x y * g y) + ∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y‖ₑ +
+      ‖∫ (y : X) in bxprc ∩ bx2r, K x' y * g y‖ₑ
+  . apply enorm_sub_le
+
+  trans ‖∫ (y : X) in bxrc ∩ bx2r, K x y * g y‖ₑ + ‖ ∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y‖ₑ +
+      ‖∫ (y : X) in bxprc ∩ bx2r, K x' y * g y‖ₑ
+  . refine add_le_add ?_ ?_
+    apply @_root_.enorm_add_le
+    rfl
+
+
+  trans (∫⁻ (y : X) in bxrc ∩ bx2r, ‖ K x y * g y‖ₑ) + ‖ ∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y‖ₑ +
+      ‖∫ (y : X) in bxprc ∩ bx2r, K x' y * g y‖ₑ
+  . refine add_le_add_three ?_ ?_ ?_
+    apply enorm_integral_le_lintegral_enorm; rfl; rfl
+
+  trans (∫⁻ (y : X) in bxrc ∩ bx2r, ‖ K x y * g y‖ₑ) + ‖ ∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y‖ₑ +
+      ∫⁻ (y : X) in bxprc ∩ bx2r, ‖ K x' y * g y‖ₑ
+  . refine add_le_add_three ?_ ?_ ?_
+    rfl; rfl; apply enorm_integral_le_lintegral_enorm
+
+  -- LHS is now 10.1.234
 
   sorry
+/-
+
+  -- We could use globalMaximalFunction_lt_top here (HardyLittlewood commented out) but proof by cases works just as well
+  by_cases m_infinite : globalMaximalFunction volume 1 g x = ∞
+  . rw[m_infinite, ENNReal.mul_top]
+    apply OrderTop.le_top
+    simp only [ne_eq, coe_eq_zero]
+    with_unfolding_all simp only [C10_1_2]
+    simp
+
+  rw [← ne_eq] at m_infinite
+  conv =>
+    rhs
+    arg 2
+    calc globalMaximalFunction volume 1 g x
+      _ = ENNReal.toNNReal (globalMaximalFunction volume 1 g x) := by symm; apply ENNReal.coe_toNNReal; exact m_infinite
+
+  rw[← coe_mul]
+  norm_cast
+-/
+/-
+    trans (abs (∫ (y : X) in bxrc ∩ bx2r, K x y * g y)) + (abs (∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y)) +
+        (abs (∫ (y : X) in bxprc ∩ bx2r, K x' y * g y))
+    apply -/
+  /-calc _
+    _ ≤ (Complex.abs (∫ (y : X) in bxrc ∩ bx2r, K x y * g y))
+          + (Complex.abs (∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y))
+          + (Complex.abs (∫ (y : X) in bxprc ∩ bx2r, K x' y * g y)) := by sorry
+    -/
+
+  --sorry
 
 /- Breakdown from PDF
   Expand def

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -113,6 +113,7 @@ theorem geometric_series_estimate {x : ℝ} (hx : 4 ≤ x) :
 
 /-- The constant used in `estimate_x_shift`. -/
 irreducible_def C10_1_2 (a : ℕ) : ℝ≥0 := 2 ^ (a ^ 3 + 2 * a + 2)
+-- exact estimate from proof: C_K * (defaultA + 2 * defaultA²) ≤ C10_1_2
 
 -- Couldn't find this. Probably suboptimal formulation and location. Help appreciated.
 lemma czoperator_welldefined {g : X → ℂ} (hmg : Measurable g) (hg : eLpNorm g ∞ < ∞)
@@ -168,16 +169,16 @@ theorem estimate_x_shift (ha : 4 ≤ a)
     apply ball_subset
     calc dist x' x
     _ = dist x x' := by apply dist_comm
-    _ ≤ r := hx
-    _ = 2 * r - r := by ring
+    _ ≤ r         := hx
+    _ = 2 * r - r := by linarith
 
   -- Domain split x' integral
   have dom_x_prime : bxprc = (bxprc ∩ bx2r) ∪ bx2rᶜ := by
-    have tmp3 : bx2rᶜ = bxprc ∩ bx2rᶜ := by
-      rw [Set.right_eq_inter]
+    have : bx2rᶜ = bxprc ∩ bx2rᶜ := by
+      rw [right_eq_inter]
       exact tmp2
 
-    rw [tmp3]
+    rw [this]
     exact Eq.symm (inter_union_compl bxprc bx2r)
 
   -- Integral split x
@@ -214,7 +215,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
 
   -- Rewrite lhs according to 10.1.234 split
   conv =>
-    arg 1; arg 1
+    lhs; arg 1
     calc _
       _ = (∫ (y : X) in bxrc ∩ bx2r, K x y * g y)
                 + ((∫ (y : X) in bx2rᶜ, K x y * g y) - (∫ (y : X) in bx2rᶜ, K x' y * g y))
@@ -232,21 +233,21 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       ‖∫ (y : X) in bxprc ∩ bx2r, K x' y * g y‖ₑ
   . apply enorm_sub_le
 
-  trans ‖∫ (y : X) in bxrc ∩ bx2r, K x y * g y‖ₑ + ‖ ∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y‖ₑ +
+  trans ‖∫ (y : X) in bxrc ∩ bx2r, K x y * g y‖ₑ + ‖∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y‖ₑ +
       ‖∫ (y : X) in bxprc ∩ bx2r, K x' y * g y‖ₑ
   . refine add_le_add ?_ ?_
-    . apply @_root_.enorm_add_le
+    . apply enorm_add_le
     . rfl
 
-  trans (∫⁻ (y : X) in bxrc ∩ bx2r, ‖ K x y * g y‖ₑ) + ‖ ∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y‖ₑ +
+  trans (∫⁻ (y : X) in bxrc ∩ bx2r, ‖K x y * g y‖ₑ) + ‖∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y‖ₑ +
       ‖∫ (y : X) in bxprc ∩ bx2r, K x' y * g y‖ₑ
   . refine add_le_add_three ?_ ?_ ?_
     . apply enorm_integral_le_lintegral_enorm
     . rfl
     . rfl
 
-  trans (∫⁻ (y : X) in bxrc ∩ bx2r, ‖ K x y * g y‖ₑ) + ‖ ∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y‖ₑ +
-      ∫⁻ (y : X) in bxprc ∩ bx2r, ‖ K x' y * g y‖ₑ
+  trans (∫⁻ (y : X) in bxrc ∩ bx2r, ‖K x y * g y‖ₑ) + ‖∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y‖ₑ +
+      ∫⁻ (y : X) in bxprc ∩ bx2r, ‖K x' y * g y‖ₑ
   . refine add_le_add_three ?_ ?_ ?_
     . rfl
     . rfl
@@ -533,14 +534,14 @@ theorem estimate_x_shift (ha : 4 ≤ a)
 
     have : ContinuousSMul ℝ≥0∞ ℝ≥0∞ := by sorry -- This is surely an oversight somewhere? Not sure how to fix that...
     rw [tsum_smul_const, smul_eq_mul]
-    case hf => sorry
+    case hf => apply ENNReal.summable
 
     apply mul_le_mul
     case h₂ => rfl
     case b0 | c0 => simp only [zero_le]
 
     rw [tsum_const_smul, smul_eq_mul]
-    case hf => sorry
+    case hf => apply ENNReal.summable
 
     have : (2 : ℝ≥0∞) ^ (a ^ 3 + 2 * a) = 2 ^ (a ^ 3 + a) * 2 ^ a := by ring
     rw [this]
@@ -554,7 +555,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
 
     trans ∑' (i : ℕ), 2 ^ (-i / (a : ℝ))
     . apply tsum_le_tsum
-      case hf | hg => sorry
+      case hf | hg => apply ENNReal.summable
       intro i
       apply rpow_le_rpow_of_exponent_le
       . simp only [Nat.one_le_ofNat]
@@ -581,7 +582,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
 
 
 
-  have estimate_10_1_4 : (∫⁻ (y : X) in bxprc ∩ bx2r, ‖ K x' y * g y‖ₑ)
+  have estimate_10_1_4 : (∫⁻ (y : X) in bxprc ∩ bx2r, ‖K x' y * g y‖ₑ)
       ≤ 2 ^ (a ^ 3 + 2 * a) * globalMaximalFunction volume 1 g x := by
     simp only [enorm_mul]
 
@@ -682,35 +683,6 @@ theorem estimate_x_shift (ha : 4 ≤ a)
 
   apply le_of_eq
   ring
-
-/- Breakdown from PDF
-  Expand def
-x Split first domain in parts > set work
-    part 1 r < d x y < 2r
-    part 2 2r < d x y
-x Split 2nd domain in parts > set work
-    part 1 r < d x' y and r < d x y < 2r
-    part 2 r < d x' y and 2r < d x y which is 2r < d x y by triangle ineq
-x Split integrals accordingly (sum of disjoint) obtain 10.1.234
-
-x 10.1.2 estimate
-    Use def CZ kernel 1.0.14, def V, estimate 1/V by 1/B(x,r) 10.1.5
-    Doubling measure, larger domain pos function 10.1.6, Mg + def of integral of unit 10.1.7
-
-x 10.1.4 estimate
-    Use def CZ kernel 10.0.14, def V, estimate 1/V by 1/B(x',r)
-    Doubling measure twice, larger domain pos function, Mg + def integral of unit 10.1.8
-
-  10.1.3 estimate
-    Use def CZ kernel 10.0.1 (check hyp) 10.1.9
-    Split domain in infinite parts > set work 10.1.10
-    Estimate term 1/V by 1/B(x,2^j r), d xx'/d xy by 1/2^j 10.1.11
-    Doubling measure, larger domain pos function 10.1.12
-    Mg + def integral of unit + sum factor 10.1.13
-    Lemma 10.1.1 > 10.1.14
-
-x Total = sum of estimates ? 2(a3 + a) + 2(a3+2a) + 2(a3+2a) le 2(a3+2a+2)
--/
 
 /-- The constant used in `cotlar_control`. -/
 irreducible_def C10_1_3 (a : ℕ) : ℝ≥0 := 2 ^ (a ^ 3 + 4 * a + 1)

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -111,7 +111,7 @@ theorem geometric_series_estimate {x : ℝ} (hx : 4 ≤ x) :
   exact real_geometric_series_estimate hx
 
 /-- The constant used in `estimate_x_shift`. -/
-irreducible_def C10_1_2 (a : ℕ) : ℝ≥0 := 2 ^ (a ^ 3 + 2 * a + 1)
+irreducible_def C10_1_2 (a : ℕ) : ℝ≥0 := 2 ^ (a ^ 3 + 2 * a + 2)
 
 /-- Lemma 10.1.2 -/
 theorem estimate_x_shift (ha : 4 ≤ a)
@@ -120,6 +120,33 @@ theorem estimate_x_shift (ha : 4 ≤ a)
     nndist (czOperator K r g x) (czOperator K r g x') ≤
     C10_1_2 a * globalMaximalFunction volume 1 g x := by
   sorry
+/-! Breakdown from PDF
+  Split first domain in parts > set work
+    part 1 r < d x y < 2r
+    part 2 2r < d x y
+  Split 2nd domain in parts > set work
+    part 1 r < d x' y and r < d x y < 2r
+    part 2 r < d x' y and 2r < d x y which is 2r < d x y by triangle ineq
+  Split integrals accordingly (sum of disjoint) obtain 10.1.234
+
+  10.1.2 estimate
+    Use def CZ kernel 1.0.14, def V, estimate 1/V by 1/B(x,r) 10.1.5
+    Doubling measure, larger domain pos function 10.1.6, Mg + def of integral of unit 10.1.7
+
+  10.1.4 estimate
+    Use def CZ kernel 10.0.14, def V, estimate 1/V by 1/B(x',r)
+    Doubling measure twice, larger domain pos function, Mg + def integral of unit 10.1.8
+
+  10.1.3 estimate
+    Use def CZ kernel 10.0.1 (check hyp) 10.1.9
+    Split domain in infinite parts > set work 10.1.10
+    Estimate term 1/V by 1/B(x,2^j r), d xx'/d xy by 1/2^j 10.1.11
+    Doubling measure, larger domain pos function 10.1.12
+    Mg + def integral of unit + sum factor 10.1.13
+    Lemma 10.1.1 > 10.1.14
+
+  Total = sum of estimates ? 2(a3 + a) + 2(a3+2a) + 2(a3+2a) le 2(a3+2a+2)
+-/
 
 /-- The constant used in `cotlar_control`. -/
 irreducible_def C10_1_3 (a : ℕ) : ℝ≥0 := 2 ^ (a ^ 3 + 4 * a + 1)

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -138,10 +138,6 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       _ = (bxrc ∩ bx2r) ∪ bxrc ∩ bx2rᶜ := by rw[Set.inter_union_distrib_left bxrc bx2r bx2rᶜ]
       _ = (bxrc ∩ bx2r) ∪ bx2rᶜ        := by rw[← tmp1]
 
-  have integral_x : CZOperator K r g x = (∫ y in bx2rᶜ, K x y * g y) + (∫ y in (bxrc ∩ bx2r), K x y * g y) := by
-    --MeasureTheory.setIntegral_union
-    sorry
-
   let bxprc := (ball x' r)ᶜ
   have dom_x_prime : bxprc = (bxprc ∩ bx2r) ∪ bx2rᶜ := by
     have tmp2 : bx2rᶜ = bxprc ∩ bx2rᶜ := by
@@ -155,6 +151,20 @@ theorem estimate_x_shift (ha : 4 ≤ a)
 
     rw [tmp2]
     exact Eq.symm (inter_union_compl bxprc bx2r)
+
+  have integral_x : CZOperator K r g x = (∫ y in (bxrc ∩ bx2r), K x y * g y) + (∫ y in bx2rᶜ, K x y * g y) := by
+    calc CZOperator K r g x
+      _ = (∫ y in bxrc, K x y * g y) := by rfl
+      _ = (∫ y in (bxrc ∩ bx2r) ∪ bx2rᶜ , K x y * g y) := by nth_rw 1 [dom_x]
+
+    apply MeasureTheory.setIntegral_union
+    . rw [disjoint_compl_right_iff_subset]
+      exact inter_subset_right
+    . apply MeasurableSet.compl
+      apply measurableSet_ball
+    --. apply IntegrableOn.mono_set (IntegrableOn (fun y → K x y * g y) bxrc volume) bxrc (bxrc ∩ bx2r)
+    . sorry
+    sorry
 
   have integral_x_prime : CZOperator K r g x = (∫ y in bx2rᶜ, K x y * g y) + (∫ y in (bxprc ∩ bx2r), K x y * g y)  := by
     --MeasureTheory.setIntegral_union

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -113,6 +113,25 @@ theorem geometric_series_estimate {x : ℝ} (hx : 4 ≤ x) :
 /-- The constant used in `estimate_x_shift`. -/
 irreducible_def C10_1_2 (a : ℕ) : ℝ≥0 := 2 ^ (a ^ 3 + 2 * a + 2)
 
+lemma czoperator_welldefined {g : X → ℂ} (hmg : Measurable g) (hg : eLpNorm g ∞ < ∞)
+    (h2g : volume (support g) < ∞) (hr : 0 < r) :
+    IntegrableOn (fun y => K x y * g y) (ball x r)ᶜ volume := by
+  sorry
+
+/- This should go somewhere else
+
+But this version of setIntegral_union is easier to apply as it starts from the overall integral which
+is to be estimated.
+-/
+variable {α β E F : Type*} [MeasurableSpace α]
+variable {f : α → ℂ } {s t : Set α} {μ : Measure α}
+
+theorem MeasureTheory.setIntegral_union_2 (hst : Disjoint s t) (ht : MeasurableSet t) (hfst : IntegrableOn f (s ∪ t) μ) :
+    ∫ x in s ∪ t, f x ∂μ = ∫ x in s, f x ∂μ + ∫ x in t, f x ∂μ := by
+  let hfs : IntegrableOn f s μ := IntegrableOn.mono_set hfst subset_union_left
+  let hft : IntegrableOn f t μ := IntegrableOn.mono_set hfst subset_union_right
+  exact setIntegral_union hst ht hfs hft
+
 /-- Lemma 10.1.2 -/
 theorem estimate_x_shift (ha : 4 ≤ a)
     {g : X → ℂ} (hmg : Measurable g) (hg : eLpNorm g ∞ < ∞) (h2g : volume (support g) < ∞)
@@ -157,14 +176,15 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       _ = (∫ y in bxrc, K x y * g y) := by rfl
       _ = (∫ y in (bxrc ∩ bx2r) ∪ bx2rᶜ , K x y * g y) := by nth_rw 1 [dom_x]
 
-    apply MeasureTheory.setIntegral_union
+    apply MeasureTheory.setIntegral_union_2
     . rw [disjoint_compl_right_iff_subset]
       exact inter_subset_right
     . apply MeasurableSet.compl
       apply measurableSet_ball
-    --. apply IntegrableOn.mono_set (IntegrableOn (fun y → K x y * g y) bxrc volume) bxrc (bxrc ∩ bx2r)
-    . sorry
-    sorry
+    . rw [← dom_x]
+      unfold bxrc
+      apply czoperator_welldefined hmg hg h2g hr
+
 
   have integral_x_prime : CZOperator K r g x = (∫ y in bx2rᶜ, K x y * g y) + (∫ y in (bxprc ∩ bx2r), K x y * g y)  := by
     --MeasureTheory.setIntegral_union

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -264,6 +264,46 @@ theorem estimate_x_shift (ha : 4 ≤ a)
 -/
   have estimate_10_1_2 : (∫⁻ (y : X) in bxrc ∩ bx2r, ‖ K x y * g y‖ₑ)
       ≤ 2 ^ (a ^ 3 + a) * globalMaximalFunction volume 1 g x := by
+    simp only [enorm_mul]
+    have pointwise_1 : ∀(y : X), y ∈ bxrc ∩ bx2r → ‖K x y‖ₑ * ‖g y‖ₑ ≤ ENNReal.ofReal (C_K a) / volume (ball x r) * ‖g y‖ₑ := by
+      intro y
+      intro h
+      refine mul_le_mul' ?_ ?_
+      swap
+      . rfl
+      rw [← ofReal_norm_eq_enorm]
+
+      trans ENNReal.ofReal (C_K a / Real.vol x y)
+      rw [ofReal_le_ofReal_iff]
+      apply IsOneSidedKernel.norm_K_le_vol_inv
+      refine div_nonneg ?_ ?_
+      . refine LT.lt.le ?_
+        apply C_K_pos
+      . unfold Real.vol
+        simp
+
+      rw [ENNReal.ofReal_div_of_pos]
+      apply ENNReal.div_le_div_left
+      unfold Real.vol Measure.real
+      refine (le_ofReal_iff_toReal_le ?_ ?_).mpr ?_
+      . sorry
+      . simp
+
+      refine toReal_mono ?_ ?_
+      . sorry
+      refine measure_mono ?_
+      refine ball_subset_ball ?_
+
+      suffices y ∈ bxrc by
+        unfold bxrc ball at this
+        rw [compl_setOf] at this
+        rw [mem_setOf_eq] at this
+        simp only [not_lt] at this
+        rw [dist_comm] at this
+        exact this
+
+      exact mem_of_mem_inter_left h
+
 
     sorry
 

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -571,12 +571,14 @@ theorem estimate_x_shift (ha : 4 ≤ a)
 
     have : ContinuousSMul ℝ≥0∞ ℝ≥0∞ := by sorry -- This is surely an oversight somewhere? Not sure how to fix that...
     rw [tsum_smul_const, smul_eq_mul]
+    case hf => sorry
 
     apply mul_le_mul
     case h₂ => rfl
     case b0 | c0 => simp only [zero_le]
 
     rw [tsum_const_smul, smul_eq_mul]
+    case hf => sorry
 
     have : (2 : ℝ≥0∞) ^ (a ^ 3 + 2 * a) = 2 ^ (a ^ 3 + a) * 2 ^ a := by ring
     rw [this]
@@ -590,6 +592,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
 
     trans ∑' (i : ℕ), 2 ^ (-i / (a : ℝ))
     . apply tsum_le_tsum
+      case hf | hg => sorry
       intro i
       apply rpow_le_rpow_of_exponent_le
       . simp only [Nat.one_le_ofNat]
@@ -599,9 +602,18 @@ theorem estimate_x_shift (ha : 4 ≤ a)
             _ < 4 := by simp only [Nat.ofNat_pos]
             _ ≤ ↑a := by simp only [Nat.ofNat_le_cast, ha]
 
-    have : ∑' (i : ℕ), (2 : ℝ≥0∞) ^ (-i / (a : ℝ)) = ∑' (i : ℕ), (2 : ℝ≥0) ^ (-i / (a : ℝ)) := by sorry
+    have : ∑' (i : ℕ), (2 : ℝ≥0∞) ^ (-i / (a : ℝ)) = ∑' (i : ℕ), (2 : ℝ≥0) ^ (-i / (a : ℝ)) := by
+      rw [ENNReal.coe_tsum]
+      swap; sorry
+      conv =>
+        rhs; arg 1; intro i
+        rw [ENNReal.coe_rpow_of_ne_zero]
+        case h.h => apply OfNat.ofNat_ne_zero
+        rw [ENNReal.coe_ofNat]
+
     rw [this]
     rw [← coe_ofNat, ← coe_pow, coe_le_coe, ← NNReal.rpow_natCast]
+
     apply geometric_series_estimate
     . simp only [Nat.ofNat_le_cast, ha]
 

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -262,12 +262,20 @@ theorem estimate_x_shift (ha : 4 ≤ a)
     Use def CZ kernel 1.0.14, def V, estimate 1/V by 1/B(x,r) 10.1.5
     Doubling measure, larger domain pos function 10.1.6, Mg + def of integral of unit 10.1.7
 -/
+  have y_est : ∀(y : X), y ∈ bxrc → r ≤ dist x y := by
+    intro y h
+    unfold bxrc ball at h
+    rw [compl_setOf, mem_setOf_eq] at h
+    simp only [not_lt] at h
+    rw [dist_comm] at h
+    exact h
+
   have estimate_10_1_2 : (∫⁻ (y : X) in bxrc ∩ bx2r, ‖ K x y * g y‖ₑ)
       ≤ 2 ^ (a ^ 3 + a) * globalMaximalFunction volume 1 g x := by
     simp only [enorm_mul]
-    have pointwise_1 : ∀(y : X), y ∈ bxrc ∩ bx2r → ‖K x y‖ₑ * ‖g y‖ₑ ≤ ENNReal.ofReal (C_K a) / volume (ball x r) * ‖g y‖ₑ := by
-      intro y
-      intro h
+    have pointwise_1 : ∀(y : X), y ∈ bxrc ∩ bx2r → ‖K x y‖ₑ * ‖g y‖ₑ ≤
+        ENNReal.ofReal (C_K a) / volume (ball x r) * ‖g y‖ₑ := by
+      intro y h
       refine mul_le_mul' ?_ ?_
       swap
       . rfl
@@ -275,10 +283,10 @@ theorem estimate_x_shift (ha : 4 ≤ a)
 
       trans ENNReal.ofReal (C_K a / Real.vol x y)
       rw [ofReal_le_ofReal_iff]
-      apply IsOneSidedKernel.norm_K_le_vol_inv
+      apply IsOneSidedKernel.norm_K_le_vol_inv -- Applying this is a pain, should it be reformulated?
       refine div_nonneg ?_ ?_
       . refine LT.lt.le ?_
-        apply C_K_pos
+        exact C_K_pos a
       . unfold Real.vol
         simp
 
@@ -286,23 +294,29 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       apply ENNReal.div_le_div_left
       unfold Real.vol Measure.real
       refine (le_ofReal_iff_toReal_le ?_ ?_).mpr ?_
-      . sorry
+      . rw [← lt_top_iff_ne_top]
+        exact measure_ball_lt_top
       . simp
 
       refine toReal_mono ?_ ?_
-      . sorry
+      . rw [← lt_top_iff_ne_top]
+        exact measure_ball_lt_top
       refine measure_mono ?_
       refine ball_subset_ball ?_
 
-      suffices y ∈ bxrc by
-        unfold bxrc ball at this
-        rw [compl_setOf] at this
-        rw [mem_setOf_eq] at this
-        simp only [not_lt] at this
-        rw [dist_comm] at this
-        exact this
+      apply y_est
+      exact h.left
 
-      exact mem_of_mem_inter_left h
+      unfold Real.vol Measure.real
+      apply toReal_pos
+      . have p : volume (ball x (dist x y)) > 0 := by
+          apply measure_ball_pos
+          calc 0
+            _ < r := hr
+            _ ≤ dist x y := by apply y_est; exact h.left
+        exact Ne.symm (ne_of_lt p)
+      . rw [← lt_top_iff_ne_top]
+        exact measure_ball_lt_top
 
 
     sorry

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -122,7 +122,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
   let bxrc := (ball x r)ᶜ
   let bx2r := ball x (2*r)
   have dom_x : bxrc =  (bxrc ∩ bx2r) ∪ bx2rᶜ := by
-    have int1 : bx2rᶜ = bxrc ∩ bx2rᶜ := by
+    have tmp1 : bx2rᶜ = bxrc ∩ bx2rᶜ := by
       suffices bx2rᶜ ⊆ bxrc by
         rw [Set.right_eq_inter]
         exact this
@@ -132,21 +132,41 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       apply Metric.ball_subset_ball
       linarith
 
-    calc
-      bxrc = bxrc ∩ univ        := by rw[Set.inter_univ bxrc]
-      _ = bxrc ∩ (bx2r ∪ bx2rᶜ) := by rw[Set.union_compl_self bx2r]
+    calc bxrc
+      _ = bxrc ∩ univ                  := by rw[Set.inter_univ bxrc]
+      _ = bxrc ∩ (bx2r ∪ bx2rᶜ)        := by rw[Set.union_compl_self bx2r]
       _ = (bxrc ∩ bx2r) ∪ bxrc ∩ bx2rᶜ := by rw[Set.inter_union_distrib_left bxrc bx2r bx2rᶜ]
-      _ = (bxrc ∩ bx2r) ∪ bx2rᶜ := by rw[← int1]
+      _ = (bxrc ∩ bx2r) ∪ bx2rᶜ        := by rw[← tmp1]
+
+  have integral_x : CZOperator K r g x = (∫ y in bx2rᶜ, K x y * g y) + (∫ y in (bxrc ∩ bx2r), K x y * g y) := by
+    --MeasureTheory.setIntegral_union
+    sorry
+
+  let bxprc := (ball x' r)ᶜ
+  have dom_x_prime : bxprc = (bxprc ∩ bx2r) ∪ bx2rᶜ := by
+    have tmp2 : bx2rᶜ = bxprc ∩ bx2rᶜ := by
+      rw [Set.right_eq_inter, Set.compl_subset_compl]
+
+      apply ball_subset
+      calc dist x' x
+      _ = dist x x' := by apply dist_comm
+      _ ≤ r := hx
+      _ = 2 * r - r := by ring
+
+    rw [tmp2]
+    exact Eq.symm (inter_union_compl bxprc bx2r)
+
+  have integral_x_prime : CZOperator K r g x = (∫ y in bx2rᶜ, K x y * g y) + (∫ y in (bxprc ∩ bx2r), K x y * g y)  := by
+    --MeasureTheory.setIntegral_union
+    sorry
   sorry
-/-! Breakdown from PDF
+
+/- Breakdown from PDF
   Expand def
-  Split first domain in parts > set work
+x Split first domain in parts > set work
     part 1 r < d x y < 2r
     part 2 2r < d x y
--/
-
-/-!
-  Split 2nd domain in parts > set work
+x Split 2nd domain in parts > set work
     part 1 r < d x' y and r < d x y < 2r
     part 2 r < d x' y and 2r < d x y which is 2r < d x y by triangle ineq
   Split integrals accordingly (sum of disjoint) obtain 10.1.234

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -394,7 +394,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
 
     trans ∫⁻ (y : X) in bxprc ∩ bx2r, ENNReal.ofReal (C_K ↑a) / volume (ball x' r) * ‖g y‖ₑ
     . apply lintegral_mono_fn
-      -- I think a general lemma is missing to make this work on bxrc ∩ bx2r instead of X
+      -- I think a general lemma is missing to make this work on bxprc ∩ bx2r instead of X
       -- Then pointwise_1 with x₀ = x' proves it
       sorry
 
@@ -466,39 +466,23 @@ theorem estimate_x_shift (ha : 4 ≤ a)
     . exact estimate_10_1_3
     . exact estimate_10_1_4
 
-  conv =>
-    lhs
-    calc _
-      -- I can't seem to figure out how to do this in ENNReal...
-      _ = (2 ^ (a ^ 3 + a) + 2 ^ (a ^ 3 + 2 * a) + 2 ^ (a ^ 3 + 2 * a)) * globalMaximalFunction volume 1 g x := by sorry
+  rw [← distrib_three_right]
 
   refine mul_le_mul' ?_ ?_
-  swap
-  . unfold globalMaximalFunction
-    unfold defaultA
-    norm_cast
+  case refine_2 => rfl
 
   -- Now it is unavoidable to unfold C10_1_2
   with_unfolding_all simp only [C10_1_2]
   norm_cast
 
-  -- Note: It is unclear to me which tactic can avoid this manual computation
-  have tmp4 : 2 ^ (a ^ 3 + a) ≤ 2 ^ (a ^ 3 + 2 * a + 1) := by
-    rw [Nat.pow_le_pow_iff_right]
-    rw [Nat.add_assoc]
-    rw [Nat.add_le_add_iff_left]
-    refine Nat.le_add_right_of_le ?_
-    refine Nat.le_mul_of_pos_left a ?_
-    exact Nat.zero_lt_two
-    exact Nat.one_lt_two
-
   trans 2 ^ (a ^ 3 + 2 * a + 1) + 2 ^ (a ^ 3 + 2 * a) + 2 ^ (a ^ 3 + 2 * a)
   . apply Nat.add_le_add_iff_right.mpr
     apply Nat.add_le_add_iff_right.mpr
-    apply tmp4
+    rw [Nat.pow_le_pow_iff_right (h := Nat.one_lt_two)]
+    linarith
 
-  ring_nf
-  rfl
+  apply le_of_eq
+  ring
 
 /- Breakdown from PDF
   Expand def
@@ -514,7 +498,7 @@ x 10.1.2 estimate
     Use def CZ kernel 1.0.14, def V, estimate 1/V by 1/B(x,r) 10.1.5
     Doubling measure, larger domain pos function 10.1.6, Mg + def of integral of unit 10.1.7
 
-  10.1.4 estimate
+x 10.1.4 estimate
     Use def CZ kernel 10.0.14, def V, estimate 1/V by 1/B(x',r)
     Doubling measure twice, larger domain pos function, Mg + def integral of unit 10.1.8
 

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -139,7 +139,7 @@ theorem MeasureTheory.setIntegral_union_2 (hst : Disjoint s t) (ht : MeasurableS
 theorem estimate_x_shift (ha : 4 ≤ a)
     {g : X → ℂ} (hmg : Measurable g) (hg : eLpNorm g ∞ < ∞) (h2g : volume (support g) < ∞)
     (hr : 0 < r) (hx : dist x x' ≤ r) :
-    nndist (czOperator K r g x) (czOperator K r g x') ≤
+    edist (czOperator K r g x) (czOperator K r g x') ≤
     C10_1_2 a * globalMaximalFunction volume 1 g x := by
   let bxrc := (ball x r)ᶜ
   let bx2r := ball x (2*r)
@@ -148,23 +148,23 @@ theorem estimate_x_shift (ha : 4 ≤ a)
   have dom_x : bxrc =  (bxrc ∩ bx2r) ∪ bx2rᶜ := by
     have tmp1 : bx2rᶜ = bxrc ∩ bx2rᶜ := by
       suffices bx2rᶜ ⊆ bxrc by
-        rw [Set.right_eq_inter]
+        rw [right_eq_inter]
         exact this
       suffices ball x r ⊆ bx2r by
-        rw [Set.compl_subset_compl]
+        rw [compl_subset_compl]
         exact this
-      apply Metric.ball_subset_ball
+      apply ball_subset_ball
       linarith
 
     calc bxrc
-      _ = bxrc ∩ univ                  := by rw[Set.inter_univ bxrc]
-      _ = bxrc ∩ (bx2r ∪ bx2rᶜ)        := by rw[Set.union_compl_self bx2r]
-      _ = (bxrc ∩ bx2r) ∪ bxrc ∩ bx2rᶜ := by rw[Set.inter_union_distrib_left bxrc bx2r bx2rᶜ]
+      _ = bxrc ∩ univ                  := by rw[inter_univ bxrc]
+      _ = bxrc ∩ (bx2r ∪ bx2rᶜ)        := by rw[union_compl_self bx2r]
+      _ = (bxrc ∩ bx2r) ∪ bxrc ∩ bx2rᶜ := by rw[inter_union_distrib_left bxrc bx2r bx2rᶜ]
       _ = (bxrc ∩ bx2r) ∪ bx2rᶜ        := by rw[← tmp1]
 
-  set bxprc := (ball x' r)ᶜ
+  let bxprc := (ball x' r)ᶜ
   have tmp2 : bx2rᶜ ⊆ bxprc := by
-    rw [Set.compl_subset_compl]
+    rw [compl_subset_compl]
     apply ball_subset
     calc dist x' x
     _ = dist x x' := by apply dist_comm
@@ -181,8 +181,8 @@ theorem estimate_x_shift (ha : 4 ≤ a)
     exact Eq.symm (inter_union_compl bxprc bx2r)
 
   -- Integral split x
-  have integral_x : CZOperator K r g x = (∫ y in (bxrc ∩ bx2r), K x y * g y) + (∫ y in bx2rᶜ, K x y * g y) := by
-    calc CZOperator K r g x
+  have integral_x : czOperator K r g x = (∫ y in (bxrc ∩ bx2r), K x y * g y) + (∫ y in bx2rᶜ, K x y * g y) := by
+    calc czOperator K r g x
       _ = (∫ y in bxrc, K x y * g y) := by rfl
       _ = (∫ y in (bxrc ∩ bx2r) ∪ bx2rᶜ , K x y * g y) := by nth_rw 1 [dom_x]
 
@@ -196,8 +196,8 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       apply czoperator_welldefined hmg hg h2g hr
 
   -- Integral split x'
-  have integral_x_prime : CZOperator K r g x' = (∫ y in (bxprc ∩ bx2r), K x' y * g y) + (∫ y in bx2rᶜ, K x' y * g y) := by
-    calc CZOperator K r g x'
+  have integral_x_prime : czOperator K r g x' = (∫ y in (bxprc ∩ bx2r), K x' y * g y) + (∫ y in bx2rᶜ, K x' y * g y) := by
+    calc czOperator K r g x'
       _ = (∫ y in bxprc, K x' y * g y) := by rfl
       _ = (∫ y in (bxprc ∩ bx2r) ∪ bx2rᶜ , K x' y * g y) := by nth_rw 1 [dom_x_prime]
 
@@ -210,7 +210,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       unfold bxprc
       apply czoperator_welldefined hmg hg h2g hr
 
-  rw [← edist_nndist, edist_eq_enorm_sub, integral_x, integral_x_prime]
+  rw [edist_eq_enorm_sub, integral_x, integral_x_prime]
 
   -- Rewrite lhs according to 10.1.234 split
   conv =>
@@ -263,67 +263,34 @@ theorem estimate_x_shift (ha : 4 ≤ a)
     exact h
 
   have pointwise_1 {x₀ : X}: ∀(y : X), y ∈ (ball x₀ r)ᶜ  → ‖K x₀ y‖ₑ * ‖g y‖ₑ ≤
-      ENNReal.ofReal (C_K a) / volume (ball x₀ r) * ‖g y‖ₑ := by
+      C_K a / volume (ball x₀ r) * ‖g y‖ₑ := by
     intro y h
     refine mul_le_mul' ?_ ?_
-    swap
-    . rfl
-    rw [← ofReal_norm_eq_enorm]
+    case refine_2 => rfl
 
-    trans ENNReal.ofReal (C_K a / Real.vol x₀ y)
-    rw [ofReal_le_ofReal_iff]
-    apply IsOneSidedKernel.norm_K_le_vol_inv -- Applying this is a pain, should it be reformulated?
-    refine div_nonneg ?_ ?_
-    . refine LT.lt.le ?_
-      exact C_K_pos a
-    . unfold Real.vol
-      simp
+    trans C_K a / vol x₀ y
+    . apply enorm_K_le_vol_inv
 
-    rw [ENNReal.ofReal_div_of_pos]
-    apply ENNReal.div_le_div_left
-    unfold Real.vol Measure.real
-    refine (le_ofReal_iff_toReal_le ?_ ?_).mpr ?_
-    . rw [← lt_top_iff_ne_top]
-      exact measure_ball_lt_top
-    . simp
-
-    refine toReal_mono ?_ ?_
-    . rw [← lt_top_iff_ne_top]
-      exact measure_ball_lt_top
-    refine measure_mono ?_
-    refine ball_subset_ball ?_
-    . apply y_est
-      exact h
-
-    unfold Real.vol Measure.real
-    apply toReal_pos
-    . have p : volume (ball x₀ (dist x₀ y)) > 0 := by
-        apply measure_ball_pos
-        calc 0
-          _ < r := hr
-          _ ≤ dist x₀ y := by apply y_est; exact h
-      exact Ne.symm (ne_of_lt p)
-    . rw [← lt_top_iff_ne_top]
-      exact measure_ball_lt_top
+    refine ENNReal.div_le_div_left ?_ ?_
+    apply measure_mono
+    exact ball_subset_ball (y_est y h)
 
   have pointwise_2 : ∀(y : X), y ∈ (ball x (2 * r))ᶜ → ‖K x y - K x' y‖ₑ * ‖g y‖ₑ ≤
-      ((edist x x' / edist x y) ^ (a : ℝ)⁻¹ * ENNReal.ofReal (C_K a / Real.vol x y)) * ‖g y‖ₑ := by
+      ((edist x x' / edist x y) ^ (a : ℝ)⁻¹ * (C_K a / vol x y)) * ‖g y‖ₑ := by
     intro y h
     apply mul_le_mul
     case h₂ => rfl
     case c0 | b0 => simp only [zero_le]
-    apply norm_K_sub_le'
 
-    trans 2 * ENNReal.ofReal r
+    apply enorm_K_sub_le'
+
+    trans 2 * r
     . apply mul_le_mul
       case h₁ => rfl
-      case c0 | b0 => simp only [zero_le]
-      exact (edist_le_ofReal (le_of_lt hr)).mpr hx
+      case c0 | b0 => simp only [Nat.ofNat_nonneg, dist_nonneg]
+      exact hx
     . rw [mem_compl_iff, mem_ball, dist_comm] at h
-      rw [edist_dist, ← ENNReal.ofReal_ofNat, ← ENNReal.ofReal_mul, ofReal_le_ofReal_iff]
-      . exact le_of_not_lt h
-      . exact dist_nonneg
-      . exact zero_le_two
+      exact le_of_not_gt h
 
   have tmp5 {x₀ : X} {n : ℝ} : ∫⁻ (a : X) in ball x₀ (n * r), ‖g a‖ₑ = (⨍⁻ (a : X) in ball x₀ (n * r), ‖g a‖ₑ ∂volume)  * volume (ball x₀ (n * r)) := by
     have h_meas_finite : IsFiniteMeasure (volume.restrict (ball x₀ (n * r))) := by
@@ -336,7 +303,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       ≤ 2 ^ (a ^ 3 + a) * globalMaximalFunction volume 1 g x := by
     simp only [enorm_mul]
 
-    trans ∫⁻ (y : X) in bxrc ∩ bx2r, ENNReal.ofReal (C_K ↑a) / volume (ball x r) * ‖g y‖ₑ
+    trans ∫⁻ (y : X) in bxrc ∩ bx2r, C_K ↑a / volume (ball x r) * ‖g y‖ₑ
     . apply setLIntegral_mono
       . apply Measurable.comp
         . apply measurable_const_mul
@@ -351,7 +318,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
     rw [lintegral_const_mul] -- LHS = 10.1.5
     case hf => apply Measurable.enorm; exact hmg
 
-    trans ENNReal.ofReal (C_K ↑a) / volume (ball x r) * (globalMaximalFunction volume 1 g x * volume (ball x (2 * r)))
+    trans C_K ↑a / volume (ball x r) * (globalMaximalFunction volume 1 g x * volume (ball x (2 * r)))
     . apply mul_le_mul
       case h₁ => rfl
       case c0 | b0 => simp only [zero_le]
@@ -376,13 +343,13 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       exact mul_pos zero_lt_two hr
 
     calc _
-      _ = ENNReal.ofReal (C_K ↑a) / volume (ball x r) * volume (ball x (2 * r)) * globalMaximalFunction volume 1 g x := by rw [mul_assoc]; nth_rw 2 [mul_comm]
+      _ = C_K ↑a / volume (ball x r) * volume (ball x (2 * r)) * globalMaximalFunction volume 1 g x := by rw [mul_assoc]; nth_rw 2 [mul_comm]
 
     apply mul_le_mul
     case h₂ => rfl
     case c0 | b0 => simp only [zero_le]
 
-    trans ENNReal.ofReal (C_K ↑a) / volume (ball x r) * (defaultA a * volume (ball x r))
+    trans C_K ↑a / volume (ball x r) * (defaultA a * volume (ball x r))
     . apply mul_le_mul
       case h₁ => rfl
       case h₂ => apply measure_ball_two_le_same
@@ -417,17 +384,15 @@ theorem estimate_x_shift (ha : 4 ≤ a)
     . apply enorm_integral_le_lintegral_enorm
     simp only [enorm_mul]
 
-    trans ∫⁻ (y : X) in bx2rᶜ, ((edist x x' / edist x y) ^ (a : ℝ)⁻¹ * ENNReal.ofReal (C_K a / Real.vol x y)) * ‖g y‖ₑ
+    trans ∫⁻ (y : X) in bx2rᶜ, ((edist x x' / edist x y) ^ (a : ℝ)⁻¹ * (C_K a / vol x y)) * ‖g y‖ₑ
     . apply setLIntegral_mono
       . apply Measurable.mul -- Imagine there was a refine type 'measurability' tactic...
         . apply Measurable.mul
           . apply Measurable.pow_const
             apply Measurable.const_div
             exact Measurable.edist measurable_const measurable_id
-          . apply Measurable.comp (g := ENNReal.ofReal)
-            . exact ENNReal.measurable_ofReal
-            apply Measurable.const_div
-            sorry -- I hate Real.vol
+          . apply Measurable.const_div
+            sorry -- Measurable (vol x)
         . apply Measurable.comp
           exact MeasureTheory.measurable_enorm
           exact hmg
@@ -437,15 +402,14 @@ theorem estimate_x_shift (ha : 4 ≤ a)
     have rw_dom : bx2rᶜ = ⋃ (i : ℕ) , dom_i i:= by
       sorry
 
-    trans ∑' (i : ℕ), ∫⁻ (y : X) in dom_i i, ((edist x x' / edist x y) ^ (a : ℝ)⁻¹ * ENNReal.ofReal (C_K a / Real.vol x y)) * ‖g y‖ₑ
+    trans ∑' (i : ℕ), ∫⁻ (y : X) in dom_i i, ((edist x x' / edist x y) ^ (a : ℝ)⁻¹ * (C_K a / vol x y)) * ‖g y‖ₑ
     . rw [rw_dom]
       apply lintegral_iUnion_le
 
     -- Writing negative powers as positive powers of 1/2 to enable working with i : ℕ instead of -i : ℤ
     trans ∑' (i : ℕ), 2 ^ (a ^ 3 + a) * (1 / (2 : ℝ≥0) ) ^ ((i + 1) * (a : ℝ)⁻¹) * globalMaximalFunction volume 1 g x
     . apply tsum_le_tsum
-      case hf => sorry
-      case hg => sorry
+      case hf | hg => apply ENNReal.summable
 
       intro i
       have est_edist : ∀y ∈ dom_i i, (edist x x' / edist x y) ≤ (1 / (2 : ℝ≥0)) ^ (i + 1) := by
@@ -475,14 +439,16 @@ theorem estimate_x_shift (ha : 4 ≤ a)
         rw [nndist_dist]
         exact Real.toNNReal_le_toNNReal hx
 
-      have est_vol : ∀y ∈ dom_i i, (Real.vol x y).toNNReal ≥ volume (ball x (2 ^ (i + 1) * r)) := by
+      have est_vol : ∀y ∈ dom_i i, vol x y ≥ volume (ball x (2 ^ (i + 1) * r)) := by
         intro y
-        unfold dom_i Annulus.co Real.vol
+        unfold dom_i Annulus.co
         rw [mem_setOf, ← Ico_def, mem_setOf]
         intro hdist
-        sorry -- I really hate Real.vol and it should be changed
+        apply measure_mono
+        refine ball_subset_ball ?_
+        exact hdist.left
 
-      trans ∫⁻ (y : X) in dom_i i, (1 / (2 : ℝ≥0)) ^ ((i + 1) * (a : ℝ)⁻¹) * ((C_K a).toNNReal / volume (ball x (2 ^ (i + 1) * r))) * ‖g y‖ₑ
+      trans ∫⁻ (y : X) in dom_i i, (1 / (2 : ℝ≥0)) ^ ((i + 1) * (a : ℝ)⁻¹) * (C_K a / volume (ball x (2 ^ (i + 1) * r))) * ‖g y‖ₑ
       . apply setLIntegral_mono
         . apply Measurable.mul
           . simp only [defaultA, coe_ofNat, one_div, C_K, measurable_const]
@@ -498,17 +464,14 @@ theorem estimate_x_shift (ha : 4 ≤ a)
           . norm_cast
             exact est_edist y hy
           . simp only [inv_nonneg, Nat.cast_nonneg]
-        . rw [ofReal_div_of_pos]
-          swap; sorry --again Real.vol
-          rw [ENNReal.ofReal.eq_1]
-          apply ENNReal.div_le_div_left
+        . apply ENNReal.div_le_div_left
           apply est_vol
           exact hy
 
       rw [lintegral_const_mul]
       case hf => apply Measurable.enorm; exact hmg
 
-      trans (1 / (2 : ℝ≥0)) ^ ((i + 1) * (a : ℝ)⁻¹) * (↑(C_K ↑a).toNNReal / volume (ball x (2 ^ (i + 1) * r))) *
+      trans (1 / (2 : ℝ≥0)) ^ ((i + 1) * (a : ℝ)⁻¹) * (C_K ↑a / volume (ball x (2 ^ (i + 1) * r))) *
           ∫⁻ (y : X) in ball x (2 ^ (i + 2) * r), ‖g y‖ₑ
       . apply mul_le_mul
         case h₁ => rfl
@@ -522,7 +485,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
 
       nth_rw 5 [mul_comm]
       rw [← mul_assoc]
-      trans (1 / (2 : ℝ≥0)) ^ ((i + 1) * (a : ℝ)⁻¹) * (↑(C_K ↑a).toNNReal / volume (ball x (2 ^ (i + 1) * r))) *
+      trans (1 / (2 : ℝ≥0)) ^ ((i + 1) * (a : ℝ)⁻¹) * (C_K ↑a / volume (ball x (2 ^ (i + 1) * r))) *
           volume (ball x (2 ^ (i + 2) * r)) * globalMaximalFunction volume 1 g x
       . apply mul_le_mul
         case h₁ => rfl
@@ -539,7 +502,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       case h₂ => rfl
       case b0 | c0 => simp only [zero_le]
 
-      trans ↑(C_K ↑a).toNNReal / volume (ball x (2 ^ (i + 1) * r)) * (defaultA a * volume (ball x (2 ^ (i + 1) * r)))
+      trans C_K ↑a / volume (ball x (2 ^ (i + 1) * r)) * (defaultA a * volume (ball x (2 ^ (i + 1) * r)))
       . apply mul_le_mul
         case h₁ => rfl
         case b0 | c0 => simp only [zero_le]
@@ -564,8 +527,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
         apply measure_ball_lt_top
       simp only [C_K, defaultA, Nat.cast_pow, Nat.cast_ofNat, one_mul]
       norm_cast
-      rw [NNReal.toNNReal_coe_nat, pow_add]
-      simp only [Nat.cast_pow, Nat.cast_ofNat, Nat.cast_mul]
+      rw [pow_add]
 
     conv => lhs;arg 1;intro i; rw [← smul_eq_mul]; rw [← smul_eq_mul]
 
@@ -623,7 +585,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       ≤ 2 ^ (a ^ 3 + 2 * a) * globalMaximalFunction volume 1 g x := by
     simp only [enorm_mul]
 
-    trans ∫⁻ (y : X) in bxprc ∩ bx2r, ENNReal.ofReal (C_K ↑a) / volume (ball x' r) * ‖g y‖ₑ
+    trans ∫⁻ (y : X) in bxprc ∩ bx2r, C_K ↑a / volume (ball x' r) * ‖g y‖ₑ
     . apply setLIntegral_mono
       . apply Measurable.comp
         . apply measurable_const_mul
@@ -638,7 +600,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
     rw [lintegral_const_mul] -- LHS = 10.1.5 but for x'
     case hf => apply Measurable.enorm; exact hmg
 
-    trans ENNReal.ofReal (C_K ↑a) / volume (ball x' r) * (globalMaximalFunction volume 1 g x * volume (ball x' (4 * r)))
+    trans C_K ↑a / volume (ball x' r) * (globalMaximalFunction volume 1 g x * volume (ball x' (4 * r)))
     . apply mul_le_mul
       case h₁ => rfl
       case c0 | b0 => simp only [zero_le]
@@ -665,13 +627,13 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       linarith
 
     calc _
-      _ = ENNReal.ofReal (C_K ↑a) / volume (ball x' r) * volume (ball x' (4 * r)) * globalMaximalFunction volume 1 g x := by rw [mul_assoc]; nth_rw 2 [mul_comm]
+      _ = C_K ↑a / volume (ball x' r) * volume (ball x' (4 * r)) * globalMaximalFunction volume 1 g x := by rw [mul_assoc]; nth_rw 2 [mul_comm]
 
     apply mul_le_mul
     case h₂ => rfl
     case c0 | b0 => simp only [zero_le]
 
-    trans ENNReal.ofReal (C_K ↑a) / volume (ball x' r) * ((defaultA a) ^ 2 * volume (ball x' r))
+    trans C_K ↑a / volume (ball x' r) * ((defaultA a) ^ 2 * volume (ball x' r))
     . apply mul_le_mul
       case h₁ => rfl
       case h₂ => apply measure_ball_four_le_same'

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -567,10 +567,45 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       rw [NNReal.toNNReal_coe_nat, pow_add]
       simp only [Nat.cast_pow, Nat.cast_ofNat, Nat.cast_mul]
 
+    conv => lhs;arg 1;intro i; rw [← smul_eq_mul]; rw [← smul_eq_mul]
 
-    -- apply geometric_series_estimate
+    have : ContinuousSMul ℝ≥0∞ ℝ≥0∞ := by sorry -- This is surely an oversight somewhere? Not sure how to fix that...
+    rw [tsum_smul_const, smul_eq_mul]
 
-    sorry
+    apply mul_le_mul
+    case h₂ => rfl
+    case b0 | c0 => simp only [zero_le]
+
+    rw [tsum_const_smul, smul_eq_mul]
+
+    have : (2 : ℝ≥0∞) ^ (a ^ 3 + 2 * a) = 2 ^ (a ^ 3 + a) * 2 ^ a := by ring
+    rw [this]
+    apply mul_le_mul
+    case h₁ => rfl
+    case b0 | c0 => simp only [zero_le]
+
+    conv =>
+      lhs; arg 1; intro i
+      rw [coe_ofNat, one_div, inv_rpow, ← rpow_neg, ← div_eq_mul_inv]
+
+    trans ∑' (i : ℕ), 2 ^ (-i / (a : ℝ))
+    . apply tsum_le_tsum
+      intro i
+      apply rpow_le_rpow_of_exponent_le
+      . simp only [Nat.one_le_ofNat]
+      . rw [neg_div, neg_le_neg_iff, div_le_div_iff_of_pos_right]
+        . simp only [le_add_iff_nonneg_right, zero_le_one]
+        . calc (0 : ℝ)
+            _ < 4 := by simp only [Nat.ofNat_pos]
+            _ ≤ ↑a := by simp only [Nat.ofNat_le_cast, ha]
+
+    have : ∑' (i : ℕ), (2 : ℝ≥0∞) ^ (-i / (a : ℝ)) = ∑' (i : ℕ), (2 : ℝ≥0) ^ (-i / (a : ℝ)) := by sorry
+    rw [this]
+    rw [← coe_ofNat, ← coe_pow, coe_le_coe, ← NNReal.rpow_natCast]
+    apply geometric_series_estimate
+    . simp only [Nat.ofNat_le_cast, ha]
+
+
 
   have estimate_10_1_4 : (∫⁻ (y : X) in bxprc ∩ bx2r, ‖ K x' y * g y‖ₑ)
       ≤ 2 ^ (a ^ 3 + 2 * a) * globalMaximalFunction volume 1 g x := by

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -257,92 +257,86 @@ theorem estimate_x_shift (ha : 4 ≤ a)
 
   -- LHS is now 10.1.234
 
-/-
-  10.1.2 estimate
-    Use def CZ kernel 1.0.14, def V, estimate 1/V by 1/B(x,r) 10.1.5
-    Doubling measure, larger domain pos function 10.1.6, Mg + def of integral of unit 10.1.7
--/
-  have y_est : ∀(y : X), y ∈ bxrc → r ≤ dist x y := by
+  have y_est {x₀: X}: ∀(y : X), y ∈ (ball x₀ r)ᶜ → r ≤ dist x₀ y := by
     intro y h
-    unfold bxrc ball at h
+    unfold ball at h
     rw [compl_setOf, mem_setOf_eq] at h
     simp only [not_lt] at h
     rw [dist_comm] at h
     exact h
 
+  have pointwise_1 {x₀ : X}: ∀(y : X), y ∈ (ball x₀ r)ᶜ  → ‖K x₀ y‖ₑ * ‖g y‖ₑ ≤
+      ENNReal.ofReal (C_K a) / volume (ball x₀ r) * ‖g y‖ₑ := by
+    intro y h
+    refine mul_le_mul' ?_ ?_
+    swap
+    . rfl
+    rw [← ofReal_norm_eq_enorm]
+
+    trans ENNReal.ofReal (C_K a / Real.vol x₀ y)
+    rw [ofReal_le_ofReal_iff]
+    apply IsOneSidedKernel.norm_K_le_vol_inv -- Applying this is a pain, should it be reformulated?
+    refine div_nonneg ?_ ?_
+    . refine LT.lt.le ?_
+      exact C_K_pos a
+    . unfold Real.vol
+      simp
+
+    rw [ENNReal.ofReal_div_of_pos]
+    apply ENNReal.div_le_div_left
+    unfold Real.vol Measure.real
+    refine (le_ofReal_iff_toReal_le ?_ ?_).mpr ?_
+    . rw [← lt_top_iff_ne_top]
+      exact measure_ball_lt_top
+    . simp
+
+    refine toReal_mono ?_ ?_
+    . rw [← lt_top_iff_ne_top]
+      exact measure_ball_lt_top
+    refine measure_mono ?_
+    refine ball_subset_ball ?_
+    . apply y_est
+      exact h
+
+    unfold Real.vol Measure.real
+    apply toReal_pos
+    . have p : volume (ball x₀ (dist x₀ y)) > 0 := by
+        apply measure_ball_pos
+        calc 0
+          _ < r := hr
+          _ ≤ dist x₀ y := by apply y_est; exact h
+      exact Ne.symm (ne_of_lt p)
+    . rw [← lt_top_iff_ne_top]
+      exact measure_ball_lt_top
+
+  have tmp5 {n: ℝ} : ∫⁻ (a : X) in ball x (n * r), ‖g a‖ₑ = (⨍⁻ (a : X) in ball x (n * r), ‖g a‖ₑ ∂volume)  * volume (ball x (n * r)) := by
+    have h_meas_finite : IsFiniteMeasure (volume.restrict (ball x (n * r))) := by
+      refine isFiniteMeasure_restrict.mpr ?_
+      exact ne_of_lt measure_ball_lt_top
+    rw [← measure_mul_laverage]
+    simp only [defaultA, MeasurableSet.univ, Measure.restrict_apply, univ_inter, mul_comm]
+
   have estimate_10_1_2 : (∫⁻ (y : X) in bxrc ∩ bx2r, ‖ K x y * g y‖ₑ)
       ≤ 2 ^ (a ^ 3 + a) * globalMaximalFunction volume 1 g x := by
     simp only [enorm_mul]
-    have pointwise_1 : ∀(y : X), y ∈ bxrc ∩ bx2r → ‖K x y‖ₑ * ‖g y‖ₑ ≤
-        ENNReal.ofReal (C_K a) / volume (ball x r) * ‖g y‖ₑ := by
-      intro y h
-      refine mul_le_mul' ?_ ?_
-      swap
-      . rfl
-      rw [← ofReal_norm_eq_enorm]
-
-      trans ENNReal.ofReal (C_K a / Real.vol x y)
-      rw [ofReal_le_ofReal_iff]
-      apply IsOneSidedKernel.norm_K_le_vol_inv -- Applying this is a pain, should it be reformulated?
-      refine div_nonneg ?_ ?_
-      . refine LT.lt.le ?_
-        exact C_K_pos a
-      . unfold Real.vol
-        simp
-
-      rw [ENNReal.ofReal_div_of_pos]
-      apply ENNReal.div_le_div_left
-      unfold Real.vol Measure.real
-      refine (le_ofReal_iff_toReal_le ?_ ?_).mpr ?_
-      . rw [← lt_top_iff_ne_top]
-        exact measure_ball_lt_top
-      . simp
-
-      refine toReal_mono ?_ ?_
-      . rw [← lt_top_iff_ne_top]
-        exact measure_ball_lt_top
-      refine measure_mono ?_
-      refine ball_subset_ball ?_
-
-      apply y_est
-      exact h.left
-
-      unfold Real.vol Measure.real
-      apply toReal_pos
-      . have p : volume (ball x (dist x y)) > 0 := by
-          apply measure_ball_pos
-          calc 0
-            _ < r := hr
-            _ ≤ dist x y := by apply y_est; exact h.left
-        exact Ne.symm (ne_of_lt p)
-      . rw [← lt_top_iff_ne_top]
-        exact measure_ball_lt_top
 
     trans ∫⁻ (y : X) in bxrc ∩ bx2r, ENNReal.ofReal (C_K ↑a) / volume (ball x r) * ‖g y‖ₑ
     . apply lintegral_mono_fn
       -- I think a general lemma is missing to make this work on bxrc ∩ bx2r instead of X
-      -- Then pointwise_1 proves it
+      -- Then pointwise_1 with x₀ = x proves it
       sorry
 
     rw [lintegral_const_mul] -- LHS = 10.1.5
     case hf => apply Measurable.enorm; exact hmg
 
-    trans ENNReal.ofReal (C_K ↑a) / volume (ball x r) * (globalMaximalFunction volume 1 g x * volume ( ball x (2 * r)))
+    trans ENNReal.ofReal (C_K ↑a) / volume (ball x r) * (globalMaximalFunction volume 1 g x * volume (ball x (2 * r)))
     . apply mul_le_mul
       case h₁ => rfl
-      case b0 => simp
-      case c0 => simp
+      case c0 | b0 => simp only [zero_le]
 
       trans ∫⁻ (a : X) in bx2r, ‖g a‖ₑ
       . apply lintegral_mono_set
         exact inter_subset_right
-      have tmp5 : ∫⁻ (a : X) in bx2r, ‖g a‖ₑ = (⨍⁻ (a : X) in bx2r, ‖g a‖ₑ ∂volume)  * volume (ball x (2 * r)) := by
-        have h_meas_finite : IsFiniteMeasure (volume.restrict (ball x (2 * r))) := by
-          refine isFiniteMeasure_restrict.mpr ?_
-          exact ne_of_lt measure_ball_lt_top
-        rw [← measure_mul_laverage]
-        simp
-        apply mul_comm
 
       rw [tmp5]
       apply mul_le_mul
@@ -351,7 +345,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
         apply le_of_lt
         apply measure_ball_pos
         exact mul_pos zero_lt_two hr
-      case b0 => simp
+      case b0 => simp only [zero_le]
 
       conv in ‖ _ ‖ₑ =>
         rw [enorm_eq_nnnorm]
@@ -364,15 +358,13 @@ theorem estimate_x_shift (ha : 4 ≤ a)
 
     apply mul_le_mul
     case h₂ => rfl
-    case c0 => simp
-    case b0 => simp
+    case c0 | b0 => simp only [zero_le]
 
     trans ENNReal.ofReal (C_K ↑a) / volume (ball x r) * (defaultA a * volume (ball x r))
     . apply mul_le_mul
-      . rfl
-      . apply measure_ball_two_le_same
-      . simp
-      . simp
+      case h₁ => rfl
+      case h₂ => apply measure_ball_two_le_same
+      case c0 | b0 => simp only [zero_le]
 
     -- Somehow simp doesn't do it
     nth_rw 2 [mul_comm]
@@ -388,10 +380,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       . apply ne_of_lt
         apply measure_ball_lt_top
 
-    conv =>
-      lhs; arg 1; arg 1; arg 1; simp; norm_cast
-    rw [ENNReal.ofReal_natCast]
-    simp only [Nat.cast_pow, Nat.cast_ofNat, mul_one, defaultA]
+    simp only [mul_one, C_K]
     norm_cast
     rw [pow_add]
 
@@ -454,7 +443,7 @@ x Split 2nd domain in parts > set work
     part 2 r < d x' y and 2r < d x y which is 2r < d x y by triangle ineq
 x Split integrals accordingly (sum of disjoint) obtain 10.1.234
 
-  10.1.2 estimate
+x 10.1.2 estimate
     Use def CZ kernel 1.0.14, def V, estimate 1/V by 1/B(x,r) 10.1.5
     Doubling measure, larger domain pos function 10.1.6, Mg + def of integral of unit 10.1.7
 

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -132,8 +132,11 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       apply Metric.ball_subset_ball
       linarith
 
-
-    sorry
+    calc
+      bxrc = bxrc ∩ univ        := by rw[Set.inter_univ bxrc]
+      _ = bxrc ∩ (bx2r ∪ bx2rᶜ) := by rw[Set.union_compl_self bx2r]
+      _ = (bxrc ∩ bx2r) ∪ bxrc ∩ bx2rᶜ := by rw[Set.inter_union_distrib_left bxrc bx2r bx2rᶜ]
+      _ = (bxrc ∩ bx2r) ∪ bx2rᶜ := by rw[← int1]
   sorry
 /-! Breakdown from PDF
   Expand def

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -309,8 +309,8 @@ theorem estimate_x_shift (ha : 4 ≤ a)
     . rw [← lt_top_iff_ne_top]
       exact measure_ball_lt_top
 
-  have tmp5 {n: ℝ} : ∫⁻ (a : X) in ball x (n * r), ‖g a‖ₑ = (⨍⁻ (a : X) in ball x (n * r), ‖g a‖ₑ ∂volume)  * volume (ball x (n * r)) := by
-    have h_meas_finite : IsFiniteMeasure (volume.restrict (ball x (n * r))) := by
+  have tmp5 {x₀ : X} {n : ℝ} : ∫⁻ (a : X) in ball x₀ (n * r), ‖g a‖ₑ = (⨍⁻ (a : X) in ball x₀ (n * r), ‖g a‖ₑ ∂volume)  * volume (ball x₀ (n * r)) := by
+    have h_meas_finite : IsFiniteMeasure (volume.restrict (ball x₀ (n * r))) := by
       refine isFiniteMeasure_restrict.mpr ?_
       exact ne_of_lt measure_ball_lt_top
     rw [← measure_mul_laverage]
@@ -380,7 +380,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       . apply ne_of_lt
         apply measure_ball_lt_top
 
-    simp only [mul_one, C_K]
+    simp only [mul_one, C_K, defaultA]
     norm_cast
     rw [pow_add]
 
@@ -390,7 +390,74 @@ theorem estimate_x_shift (ha : 4 ≤ a)
 
   have estimate_10_1_4 : (∫⁻ (y : X) in bxprc ∩ bx2r, ‖ K x' y * g y‖ₑ)
       ≤ 2 ^ (a ^ 3 + 2 * a) * globalMaximalFunction volume 1 g x := by
-    sorry
+    simp only [enorm_mul]
+
+    trans ∫⁻ (y : X) in bxprc ∩ bx2r, ENNReal.ofReal (C_K ↑a) / volume (ball x' r) * ‖g y‖ₑ
+    . apply lintegral_mono_fn
+      -- I think a general lemma is missing to make this work on bxrc ∩ bx2r instead of X
+      -- Then pointwise_1 with x₀ = x' proves it
+      sorry
+
+    rw [lintegral_const_mul] -- LHS = 10.1.5 but for x'
+    case hf => apply Measurable.enorm; exact hmg
+
+    trans ENNReal.ofReal (C_K ↑a) / volume (ball x' r) * (globalMaximalFunction volume 1 g x * volume (ball x' (4 * r)))
+    . apply mul_le_mul
+      case h₁ => rfl
+      case c0 | b0 => simp only [zero_le]
+
+      trans ∫⁻ (a : X) in ball x' (4 * r), ‖g a‖ₑ
+      . apply lintegral_mono_set
+        trans bx2r
+        . exact inter_subset_right
+        . apply ball_subset
+          linarith
+
+      rw [tmp5]
+      apply mul_le_mul
+      case h₂ => rfl
+      case c0 =>
+        apply le_of_lt
+        apply measure_ball_pos
+        exact mul_pos zero_lt_four hr
+      case b0 => simp only [zero_le]
+
+      conv in ‖ _ ‖ₑ =>
+        rw [enorm_eq_nnnorm]
+      apply laverage_le_globalMaximalFunction -- Should this be rewritten to ‖ ‖ₑ instead?
+      linarith
+
+    calc _
+      _ = ENNReal.ofReal (C_K ↑a) / volume (ball x' r) * volume (ball x' (4 * r)) * globalMaximalFunction volume 1 g x := by rw [mul_assoc]; nth_rw 2 [mul_comm]
+
+    apply mul_le_mul
+    case h₂ => rfl
+    case c0 | b0 => simp only [zero_le]
+
+    trans ENNReal.ofReal (C_K ↑a) / volume (ball x' r) * ((defaultA a) ^ 2 * volume (ball x' r))
+    . apply mul_le_mul
+      case h₁ => rfl
+      case h₂ => apply measure_ball_four_le_same'
+      case c0 | b0 => simp only [zero_le]
+
+    -- Somehow simp doesn't do it
+    nth_rw 2 [mul_comm]
+    rw [← mul_assoc, div_eq_mul_inv]
+    nth_rw 2 [mul_assoc]
+    conv =>
+      lhs; arg 1; arg 2
+      rw [mul_comm]
+      apply ENNReal.mul_inv_cancel
+      . apply ne_of_gt
+        apply measure_ball_pos
+        exact hr
+      . apply ne_of_lt
+        apply measure_ball_lt_top
+
+    simp only [mul_one, C_K, defaultA]
+    norm_cast
+    apply le_of_eq
+    ring
 
   trans (2 ^ (a ^ 3 + a) * globalMaximalFunction volume 1 g x) + (2 ^ (a ^ 3 + 2 * a) * globalMaximalFunction volume 1 g x) +
       (2 ^ (a ^ 3 + 2 * a) * globalMaximalFunction volume 1 g x)

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -113,13 +113,9 @@ theorem geometric_series_estimate {x : ℝ} (hx : 4 ≤ x) :
 /-- The constant used in `estimate_x_shift`. -/
 irreducible_def C10_1_2 (a : ℕ) : ℝ≥0 := 2 ^ (a ^ 3 + 2 * a + 2)
 
+-- Couldn't find this. Probably suboptimal formulation and location. Help appreciated.
 lemma czoperator_welldefined {g : X → ℂ} (hmg : Measurable g) (hg : eLpNorm g ∞ < ∞)
     (h2g : volume (support g) < ∞) (hr : 0 < r) (x : X):
-    IntegrableOn (fun y => K x y * g y) (ball x r)ᶜ volume := by
-  sorry
-
-lemma czoperator_wd_2 {g : X → ℂ} {hmg : Measurable g} {hg : eLpNorm g ∞ < ∞}
-    {h2g : volume (support g) < ∞} {hr : 0 < r} (x : X) :
     IntegrableOn (fun y => K x y * g y) (ball x r)ᶜ volume := by
   sorry
 
@@ -242,24 +238,33 @@ theorem estimate_x_shift (ha : 4 ≤ a)
   trans ‖∫ (y : X) in bxrc ∩ bx2r, K x y * g y‖ₑ + ‖ ∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y‖ₑ +
       ‖∫ (y : X) in bxprc ∩ bx2r, K x' y * g y‖ₑ
   . refine add_le_add ?_ ?_
-    apply @_root_.enorm_add_le
-    rfl
-
+    . apply @_root_.enorm_add_le
+    . rfl
 
   trans (∫⁻ (y : X) in bxrc ∩ bx2r, ‖ K x y * g y‖ₑ) + ‖ ∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y‖ₑ +
       ‖∫ (y : X) in bxprc ∩ bx2r, K x' y * g y‖ₑ
   . refine add_le_add_three ?_ ?_ ?_
-    apply enorm_integral_le_lintegral_enorm; rfl; rfl
+    . apply enorm_integral_le_lintegral_enorm
+    . rfl
+    . rfl
 
   trans (∫⁻ (y : X) in bxrc ∩ bx2r, ‖ K x y * g y‖ₑ) + ‖ ∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y‖ₑ +
       ∫⁻ (y : X) in bxprc ∩ bx2r, ‖ K x' y * g y‖ₑ
   . refine add_le_add_three ?_ ?_ ?_
-    rfl; rfl; apply enorm_integral_le_lintegral_enorm
+    . rfl
+    . rfl
+    . apply enorm_integral_le_lintegral_enorm
 
   -- LHS is now 10.1.234
 
+/-
+  10.1.2 estimate
+    Use def CZ kernel 1.0.14, def V, estimate 1/V by 1/B(x,r) 10.1.5
+    Doubling measure, larger domain pos function 10.1.6, Mg + def of integral of unit 10.1.7
+-/
   have estimate_10_1_2 : (∫⁻ (y : X) in bxrc ∩ bx2r, ‖ K x y * g y‖ₑ)
       ≤ 2 ^ (a ^ 3 + a) * globalMaximalFunction volume 1 g x := by
+
     sorry
 
   have estimate_10_1_3 : ‖ ∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y‖ₑ
@@ -280,6 +285,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
   conv =>
     lhs
     calc _
+      -- I can't seem to figure out how to do this in ENNReal...
       _ = (2 ^ (a ^ 3 + a) + 2 ^ (a ^ 3 + 2 * a) + 2 ^ (a ^ 3 + 2 * a)) * globalMaximalFunction volume 1 g x := by sorry
 
   refine mul_le_mul' ?_ ?_
@@ -293,7 +299,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
   norm_cast
 
   -- Note: It is unclear to me which tactic can avoid this manual computation
-  have tmp3 : 2 ^ (a ^ 3 + a) ≤ 2 ^ (a ^ 3 + 2 * a + 1) := by
+  have tmp4 : 2 ^ (a ^ 3 + a) ≤ 2 ^ (a ^ 3 + 2 * a + 1) := by
     rw [Nat.pow_le_pow_iff_right]
     rw [Nat.add_assoc]
     rw [Nat.add_le_add_iff_left]
@@ -305,7 +311,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
   trans 2 ^ (a ^ 3 + 2 * a + 1) + 2 ^ (a ^ 3 + 2 * a) + 2 ^ (a ^ 3 + 2 * a)
   . apply Nat.add_le_add_iff_right.mpr
     apply Nat.add_le_add_iff_right.mpr
-    apply tmp3
+    apply tmp4
 
   ring_nf
   rfl

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -186,9 +186,20 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       apply czoperator_welldefined hmg hg h2g hr
 
 
-  have integral_x_prime : CZOperator K r g x = (∫ y in bx2rᶜ, K x y * g y) + (∫ y in (bxprc ∩ bx2r), K x y * g y)  := by
-    --MeasureTheory.setIntegral_union
-    sorry
+  have integral_x_prime : CZOperator K r g x' = (∫ y in (bxprc ∩ bx2r), K x' y * g y) + (∫ y in bx2rᶜ, K x' y * g y) := by
+    calc CZOperator K r g x'
+      _ = (∫ y in bxprc, K x' y * g y) := by rfl
+      _ = (∫ y in (bxprc ∩ bx2r) ∪ bx2rᶜ , K x' y * g y) := by nth_rw 1 [dom_x_prime]
+
+    apply MeasureTheory.setIntegral_union_2
+    . rw [disjoint_compl_right_iff_subset]
+      exact inter_subset_right
+    . apply MeasurableSet.compl
+      apply measurableSet_ball
+    . rw [← dom_x_prime]
+      unfold bxprc
+      apply czoperator_welldefined hmg hg h2g hr
+
   sorry
 
 /- Breakdown from PDF

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -359,16 +359,41 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       rw [dist_self]
       exact mul_pos zero_lt_two hr
 
+    calc _
+      _ = ENNReal.ofReal (C_K ↑a) / volume (ball x r) * volume (ball x (2 * r)) * globalMaximalFunction volume 1 g x := by rw [mul_assoc]; nth_rw 2 [mul_comm]
 
+    apply mul_le_mul
+    case h₂ => rfl
+    case c0 => simp
+    case b0 => simp
 
+    trans ENNReal.ofReal (C_K ↑a) / volume (ball x r) * (defaultA a * volume (ball x r))
+    . apply mul_le_mul
+      . rfl
+      . apply measure_ball_two_le_same
+      . simp
+      . simp
 
+    -- Somehow simp doesn't do it
+    nth_rw 2 [mul_comm]
+    rw [← mul_assoc, div_eq_mul_inv]
+    nth_rw 2 [mul_assoc]
+    conv =>
+      lhs; arg 1; arg 2
+      rw [mul_comm]
+      apply ENNReal.mul_inv_cancel
+      . apply ne_of_gt
+        apply measure_ball_pos
+        exact hr
+      . apply ne_of_lt
+        apply measure_ball_lt_top
 
-    trans ENNReal.ofReal (C_K ↑a) * (defaultA a) / volume (ball x (2 * r)) * ∫⁻ (a : X) in bxrc ∩ bx2r, ‖g a‖ₑ
-    . have double : volume (ball x (2 * r)) ≤ defaultA a * volume (ball x r) := by
-        sorry
-      sorry
-
-    sorry
+    conv =>
+      lhs; arg 1; arg 1; arg 1; simp; norm_cast
+    rw [ENNReal.ofReal_natCast]
+    simp only [Nat.cast_pow, Nat.cast_ofNat, mul_one, defaultA]
+    norm_cast
+    rw [pow_add]
 
   have estimate_10_1_3 : ‖ ∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y‖ₑ
       ≤ 2 ^ (a ^ 3 + 2 * a) * globalMaximalFunction volume 1 g x := by

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -1,6 +1,7 @@
 import Carleson.TwoSidedCarleson.WeakCalderonZygmund
 import Carleson.ToMathlib.Analysis.Convex.SpecificFunctions.Basic
 import Carleson.ToMathlib.ENorm
+import Carleson.ToMathlib.Annulus
 
 open MeasureTheory Set Bornology Function ENNReal Metric Complex
 open scoped NNReal
@@ -209,10 +210,6 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       unfold bxprc
       apply czoperator_welldefined hmg hg h2g hr
 
-  let int10_1_2 := 0
-  let int10_1_3 := 0
-  let int10_1_4 := 0
-
   rw [← edist_nndist, edist_eq_enorm_sub, integral_x, integral_x_prime]
 
   -- Rewrite lhs according to 10.1.234 split
@@ -340,10 +337,16 @@ theorem estimate_x_shift (ha : 4 ≤ a)
     simp only [enorm_mul]
 
     trans ∫⁻ (y : X) in bxrc ∩ bx2r, ENNReal.ofReal (C_K ↑a) / volume (ball x r) * ‖g y‖ₑ
-    . apply lintegral_mono_fn
-      -- I think a general lemma is missing to make this work on bxrc ∩ bx2r instead of X
-      -- Then pointwise_1 with x₀ = x proves it
-      sorry
+    . apply setLIntegral_mono
+      . apply Measurable.comp
+        . apply measurable_const_mul
+        . apply Measurable.comp
+          exact MeasureTheory.measurable_enorm
+          exact hmg
+      intro x
+      trans x ∈ bxrc
+      . exact fun a ↦ mem_of_mem_inter_left a
+      apply pointwise_1
 
     rw [lintegral_const_mul] -- LHS = 10.1.5
     case hf => apply Measurable.enorm; exact hmg
@@ -414,11 +417,158 @@ theorem estimate_x_shift (ha : 4 ≤ a)
     . apply enorm_integral_le_lintegral_enorm
     simp only [enorm_mul]
 
-    trans ∫⁻ (y : X) in bx2rᶜ, (edist x x' / edist x y) ^ (a : ℝ)⁻¹ * ENNReal.ofReal (C_K a / Real.vol x y) * ‖ g y‖ₑ
-    . apply lintegral_mono_fn
-      -- I think a general lemma is missing to make this work on bx2rc instead of X
-      -- Then pointwise_2 proves it
+    trans ∫⁻ (y : X) in bx2rᶜ, ((edist x x' / edist x y) ^ (a : ℝ)⁻¹ * ENNReal.ofReal (C_K a / Real.vol x y)) * ‖g y‖ₑ
+    . apply setLIntegral_mono
+      . apply Measurable.mul -- Imagine there was a refine type 'measurability' tactic...
+        . apply Measurable.mul
+          . apply Measurable.pow_const
+            apply Measurable.const_div
+            exact Measurable.edist measurable_const measurable_id
+          . apply Measurable.comp (g := ENNReal.ofReal)
+            . exact ENNReal.measurable_ofReal
+            apply Measurable.const_div
+            sorry -- I hate Real.vol
+        . apply Measurable.comp
+          exact MeasureTheory.measurable_enorm
+          exact hmg
+      apply pointwise_2
+
+    let dom_i (i : ℕ) := Annulus.co x (2^(i+1) * r) (2^(i+2) * r)
+    have rw_dom : bx2rᶜ = ⋃ (i : ℕ) , dom_i i:= by
       sorry
+
+    trans ∑' (i : ℕ), ∫⁻ (y : X) in dom_i i, ((edist x x' / edist x y) ^ (a : ℝ)⁻¹ * ENNReal.ofReal (C_K a / Real.vol x y)) * ‖g y‖ₑ
+    . rw [rw_dom]
+      apply lintegral_iUnion_le
+
+    -- Writing negative powers as positive powers of 1/2 to enable working with i : ℕ instead of -i : ℤ
+    trans ∑' (i : ℕ), 2 ^ (a ^ 3 + a) * (1 / (2 : ℝ≥0) ) ^ ((i + 1) * (a : ℝ)⁻¹) * globalMaximalFunction volume 1 g x
+    . apply tsum_le_tsum
+      case hf => sorry
+      case hg => sorry
+
+      intro i
+      have est_edist : ∀y ∈ dom_i i, (edist x x' / edist x y) ≤ (1 / (2 : ℝ≥0)) ^ (i + 1) := by
+        intro y
+        unfold dom_i Annulus.co
+        rw [mem_setOf, ← Ico_def, mem_setOf]
+        intro hdist
+        trans edist x x' / (2 ^ (i + 1) * r.toNNReal)
+        . apply ENNReal.div_le_div_left
+          rw [edist_dist, ENNReal.le_ofReal_iff_toReal_le]
+          case ha => norm_cast; apply coe_ne_top
+          case hb => exact dist_nonneg
+          simp only [toReal_mul, toReal_pow, toReal_ofNat, coe_toReal, Real.coe_toNNReal']
+          rw [(max_eq_left (le_of_lt hr))]
+          exact hdist.left
+        rw [ENNReal.div_le_iff_le_mul]
+        case hb0 => right; apply pow_ne_top; simp
+        case hbt => left; apply mul_ne_top; exact pow_ne_top ofNat_ne_top; exact coe_ne_top
+        rw [← mul_assoc]
+        rw [pow_mul_pow_eq_one]
+        case a =>
+          simp only [coe_ofNat, one_div]
+          apply ENNReal.inv_mul_cancel
+          . simp only [ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true]
+          . simp only [ne_eq, ofNat_ne_top, not_false_eq_true]
+        simp only [one_mul, edist_le_coe]
+        rw [nndist_dist]
+        exact Real.toNNReal_le_toNNReal hx
+
+      have est_vol : ∀y ∈ dom_i i, (Real.vol x y).toNNReal ≥ volume (ball x (2 ^ (i + 1) * r)) := by
+        intro y
+        unfold dom_i Annulus.co Real.vol
+        rw [mem_setOf, ← Ico_def, mem_setOf]
+        intro hdist
+        sorry -- I really hate Real.vol and it should be changed
+
+      trans ∫⁻ (y : X) in dom_i i, (1 / (2 : ℝ≥0)) ^ ((i + 1) * (a : ℝ)⁻¹) * ((C_K a).toNNReal / volume (ball x (2 ^ (i + 1) * r))) * ‖g y‖ₑ
+      . apply setLIntegral_mono
+        . apply Measurable.mul
+          . simp only [defaultA, coe_ofNat, one_div, C_K, measurable_const]
+          . exact Measurable.comp _root_.measurable_enorm hmg
+        intro y hy
+        apply mul_le_mul
+        case h₂ => rfl
+        case c0 | b0 => simp only [zero_le]
+        apply mul_le_mul
+        case c0 | b0 => simp only [zero_le]
+        . rw [rpow_mul]
+          apply rpow_le_rpow
+          . norm_cast
+            exact est_edist y hy
+          . simp only [inv_nonneg, Nat.cast_nonneg]
+        . rw [ofReal_div_of_pos]
+          swap; sorry --again Real.vol
+          rw [ENNReal.ofReal.eq_1]
+          apply ENNReal.div_le_div_left
+          apply est_vol
+          exact hy
+
+      rw [lintegral_const_mul]
+      case hf => apply Measurable.enorm; exact hmg
+
+      trans (1 / (2 : ℝ≥0)) ^ ((i + 1) * (a : ℝ)⁻¹) * (↑(C_K ↑a).toNNReal / volume (ball x (2 ^ (i + 1) * r))) *
+          ∫⁻ (y : X) in ball x (2 ^ (i + 2) * r), ‖g y‖ₑ
+      . apply mul_le_mul
+        case h₁ => rfl
+        case b0 | c0 => simp only [zero_le]
+        apply lintegral_mono_set
+        unfold dom_i
+        rw [Set.Annulus.co_eq]
+        exact inter_subset_left
+
+      rw [tmp5]
+
+      nth_rw 5 [mul_comm]
+      rw [← mul_assoc]
+      trans (1 / (2 : ℝ≥0)) ^ ((i + 1) * (a : ℝ)⁻¹) * (↑(C_K ↑a).toNNReal / volume (ball x (2 ^ (i + 1) * r))) *
+          volume (ball x (2 ^ (i + 2) * r)) * globalMaximalFunction volume 1 g x
+      . apply mul_le_mul
+        case h₁ => rfl
+        case b0 | c0 => simp only [zero_le]
+        apply laverage_le_globalMaximalFunction
+        simp only [dist_self, Nat.ofNat_pos, pow_pos, mul_pos_iff_of_pos_left, hr]
+
+      apply mul_le_mul
+      case h₂ => rfl
+      case b0 | c0 => simp only [zero_le]
+
+      rw [mul_assoc, mul_comm]
+      apply mul_le_mul
+      case h₂ => rfl
+      case b0 | c0 => simp only [zero_le]
+
+      trans ↑(C_K ↑a).toNNReal / volume (ball x (2 ^ (i + 1) * r)) * (defaultA a * volume (ball x (2 ^ (i + 1) * r)))
+      . apply mul_le_mul
+        case h₁ => rfl
+        case b0 | c0 => simp only [zero_le]
+        rw [pow_succ]
+        nth_rw 2 [mul_comm]
+        rw [mul_assoc]
+        apply measure_ball_two_le_same
+
+      apply le_of_eq
+      rw [div_eq_mul_inv]
+      nth_rw 4 [mul_comm]
+      rw [mul_assoc]
+      nth_rw 2 [← mul_assoc]
+      nth_rw 3 [mul_comm]
+      rw [ENNReal.mul_inv_cancel]
+      case h0 =>
+        apply ne_of_gt
+        apply measure_ball_pos
+        simp only [Nat.ofNat_pos, pow_pos, mul_pos_iff_of_pos_left, hr]
+      case ht =>
+        apply ne_of_lt
+        apply measure_ball_lt_top
+      simp only [C_K, defaultA, Nat.cast_pow, Nat.cast_ofNat, one_mul]
+      norm_cast
+      rw [NNReal.toNNReal_coe_nat, pow_add]
+      simp only [Nat.cast_pow, Nat.cast_ofNat, Nat.cast_mul]
+
+
+    -- apply geometric_series_estimate
 
     sorry
 
@@ -427,10 +577,16 @@ theorem estimate_x_shift (ha : 4 ≤ a)
     simp only [enorm_mul]
 
     trans ∫⁻ (y : X) in bxprc ∩ bx2r, ENNReal.ofReal (C_K ↑a) / volume (ball x' r) * ‖g y‖ₑ
-    . apply lintegral_mono_fn
-      -- I think a general lemma is missing to make this work on bxprc ∩ bx2r instead of X
-      -- Then pointwise_1 with x₀ = x' proves it
-      sorry
+    . apply setLIntegral_mono
+      . apply Measurable.comp
+        . apply measurable_const_mul
+        . apply Measurable.comp
+          exact MeasureTheory.measurable_enorm
+          exact hmg
+      intro x
+      trans x ∈ bxprc
+      . exact fun a ↦ mem_of_mem_inter_left a
+      apply pointwise_1
 
     rw [lintegral_const_mul] -- LHS = 10.1.5 but for x'
     case hf => apply Measurable.enorm; exact hmg

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -118,6 +118,11 @@ lemma czoperator_welldefined {g : X → ℂ} (hmg : Measurable g) (hg : eLpNorm 
     IntegrableOn (fun y => K x y * g y) (ball x r)ᶜ volume := by
   sorry
 
+lemma czoperator_wd_2 {g : X → ℂ} {hmg : Measurable g} {hg : eLpNorm g ∞ < ∞}
+    {h2g : volume (support g) < ∞} {hr : 0 < r} (x : X):
+    IntegrableOn (fun y => K x y * g y) (ball x r)ᶜ volume := by
+  sorry
+
 /- This should go somewhere else
 
 But this version of setIntegral_union is easier to apply as it starts from the overall integral which
@@ -131,6 +136,7 @@ theorem MeasureTheory.setIntegral_union_2 (hst : Disjoint s t) (ht : MeasurableS
   let hfs : IntegrableOn f s μ := IntegrableOn.mono_set hfst subset_union_left
   let hft : IntegrableOn f t μ := IntegrableOn.mono_set hfst subset_union_right
   exact setIntegral_union hst ht hfs hft
+/- End of somewhere else -/
 
 /-- Lemma 10.1.2 -/
 theorem estimate_x_shift (ha : 4 ≤ a)
@@ -140,6 +146,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
     C10_1_2 a * globalMaximalFunction volume 1 g x := by
   let bxrc := (ball x r)ᶜ
   let bx2r := ball x (2*r)
+  -- Domain split x integral
   have dom_x : bxrc =  (bxrc ∩ bx2r) ∪ bx2rᶜ := by
     have tmp1 : bx2rᶜ = bxrc ∩ bx2rᶜ := by
       suffices bx2rᶜ ⊆ bxrc by
@@ -157,20 +164,25 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       _ = (bxrc ∩ bx2r) ∪ bxrc ∩ bx2rᶜ := by rw[Set.inter_union_distrib_left bxrc bx2r bx2rᶜ]
       _ = (bxrc ∩ bx2r) ∪ bx2rᶜ        := by rw[← tmp1]
 
-  let bxprc := (ball x' r)ᶜ
+  set bxprc := (ball x' r)ᶜ
+  have tmp2 : bx2rᶜ ⊆ bxprc := by
+    rw [Set.compl_subset_compl]
+    apply ball_subset
+    calc dist x' x
+    _ = dist x x' := by apply dist_comm
+    _ ≤ r := hx
+    _ = 2 * r - r := by ring
+
+  -- Domain split x' integral
   have dom_x_prime : bxprc = (bxprc ∩ bx2r) ∪ bx2rᶜ := by
-    have tmp2 : bx2rᶜ = bxprc ∩ bx2rᶜ := by
-      rw [Set.right_eq_inter, Set.compl_subset_compl]
+    have tmp3 : bx2rᶜ = bxprc ∩ bx2rᶜ := by
+      rw [Set.right_eq_inter]
+      exact tmp2
 
-      apply ball_subset
-      calc dist x' x
-      _ = dist x x' := by apply dist_comm
-      _ ≤ r := hx
-      _ = 2 * r - r := by ring
-
-    rw [tmp2]
+    rw [tmp3]
     exact Eq.symm (inter_union_compl bxprc bx2r)
 
+  -- Integral split x
   have integral_x : CZOperator K r g x = (∫ y in (bxrc ∩ bx2r), K x y * g y) + (∫ y in bx2rᶜ, K x y * g y) := by
     calc CZOperator K r g x
       _ = (∫ y in bxrc, K x y * g y) := by rfl
@@ -185,7 +197,7 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       unfold bxrc
       apply czoperator_welldefined hmg hg h2g hr
 
-
+  -- Integral split x'
   have integral_x_prime : CZOperator K r g x' = (∫ y in (bxprc ∩ bx2r), K x' y * g y) + (∫ y in bx2rᶜ, K x' y * g y) := by
     calc CZOperator K r g x'
       _ = (∫ y in bxprc, K x' y * g y) := by rfl
@@ -200,6 +212,31 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       unfold bxprc
       apply czoperator_welldefined hmg hg h2g hr
 
+  let int10_1_2 := 0
+  let int10_1_3 := 0
+  let int10_1_4 := 0
+
+  -- Rewrite lhs according to 10.1.234 split
+  conv =>
+    lhs
+    rw [nndist_dist, Complex.dist_eq, integral_x, integral_x_prime]
+    arg 1; arg 1
+    conv =>
+      arg 2
+      calc _
+        _ = (∫ (y : X) in bxrc ∩ bx2r, K x y * g y)
+                + ((∫ (y : X) in bx2rᶜ, K x y * g y) - (∫ (y : X) in bx2rᶜ, K x' y * g y))
+                - (∫ (y : X) in bxprc ∩ bx2r, K x' y * g y) := by ring
+        _ = (∫ (y : X) in bxrc ∩ bx2r, K x y * g y)
+                + (∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y)
+                - (∫ (y : X) in bxprc ∩ bx2r, K x' y * g y) := by
+                  rw[← integral_sub]
+                  apply czoperator_wd_2; exact hmg; exact hg; exact h2g; simp; exact hr
+                  have tmp4 : IntegrableOn (fun y ↦ K x' y * g y) bxprc := by
+                    apply czoperator_wd_2; exact hmg; exact hg; exact h2g; exact hr
+                  apply IntegrableOn.mono_set tmp4 tmp2
+
+
   sorry
 
 /- Breakdown from PDF
@@ -210,7 +247,7 @@ x Split first domain in parts > set work
 x Split 2nd domain in parts > set work
     part 1 r < d x' y and r < d x y < 2r
     part 2 r < d x' y and 2r < d x y which is 2r < d x y by triangle ineq
-  Split integrals accordingly (sum of disjoint) obtain 10.1.234
+x Split integrals accordingly (sum of disjoint) obtain 10.1.234
 
   10.1.2 estimate
     Use def CZ kernel 1.0.14, def V, estimate 1/V by 1/B(x,r) 10.1.5

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -318,6 +318,55 @@ theorem estimate_x_shift (ha : 4 ≤ a)
       . rw [← lt_top_iff_ne_top]
         exact measure_ball_lt_top
 
+    trans ∫⁻ (y : X) in bxrc ∩ bx2r, ENNReal.ofReal (C_K ↑a) / volume (ball x r) * ‖g y‖ₑ
+    . apply lintegral_mono_fn
+      -- I think a general lemma is missing to make this work on bxrc ∩ bx2r instead of X
+      -- Then pointwise_1 proves it
+      sorry
+
+    rw [lintegral_const_mul] -- LHS = 10.1.5
+    case hf => apply Measurable.enorm; exact hmg
+
+    trans ENNReal.ofReal (C_K ↑a) / volume (ball x r) * (globalMaximalFunction volume 1 g x * volume ( ball x (2 * r)))
+    . apply mul_le_mul
+      case h₁ => rfl
+      case b0 => simp
+      case c0 => simp
+
+      trans ∫⁻ (a : X) in bx2r, ‖g a‖ₑ
+      . apply lintegral_mono_set
+        exact inter_subset_right
+      have tmp5 : ∫⁻ (a : X) in bx2r, ‖g a‖ₑ = (⨍⁻ (a : X) in bx2r, ‖g a‖ₑ ∂volume)  * volume (ball x (2 * r)) := by
+        have h_meas_finite : IsFiniteMeasure (volume.restrict (ball x (2 * r))) := by
+          refine isFiniteMeasure_restrict.mpr ?_
+          exact ne_of_lt measure_ball_lt_top
+        rw [← measure_mul_laverage]
+        simp
+        apply mul_comm
+
+      rw [tmp5]
+      apply mul_le_mul
+      case h₂ => rfl
+      case c0 =>
+        apply le_of_lt
+        apply measure_ball_pos
+        exact mul_pos zero_lt_two hr
+      case b0 => simp
+
+      conv in ‖ _ ‖ₑ =>
+        rw [enorm_eq_nnnorm]
+      apply laverage_le_globalMaximalFunction -- Should this be rewritten to ‖ ‖ₑ instead?
+      rw [dist_self]
+      exact mul_pos zero_lt_two hr
+
+
+
+
+
+    trans ENNReal.ofReal (C_K ↑a) * (defaultA a) / volume (ball x (2 * r)) * ∫⁻ (a : X) in bxrc ∩ bx2r, ‖g a‖ₑ
+    . have double : volume (ball x (2 * r)) ≤ defaultA a * volume (ball x r) := by
+        sorry
+      sorry
 
     sorry
 

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -226,10 +226,10 @@ theorem estimate_x_shift (ha : 4 ≤ a)
                 + (∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y)
                 - (∫ (y : X) in bxprc ∩ bx2r, K x' y * g y) := by
           rw[← integral_sub]
-          apply czoperator_welldefined hmg hg h2g (by simp; exact hr)
-          apply IntegrableOn.mono_set
-          swap; exact tmp2
-          apply czoperator_welldefined hmg hg h2g hr
+          . apply czoperator_welldefined hmg hg h2g (mul_pos zero_lt_two hr)
+          . apply IntegrableOn.mono_set
+            swap; exact tmp2
+            apply czoperator_welldefined hmg hg h2g hr
 
   trans ‖(∫ (y : X) in bxrc ∩ bx2r, K x y * g y) + ∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y‖ₑ +
       ‖∫ (y : X) in bxprc ∩ bx2r, K x' y * g y‖ₑ
@@ -309,6 +309,25 @@ theorem estimate_x_shift (ha : 4 ≤ a)
     . rw [← lt_top_iff_ne_top]
       exact measure_ball_lt_top
 
+  have pointwise_2 : ∀(y : X), y ∈ (ball x (2 * r))ᶜ → ‖K x y - K x' y‖ₑ * ‖g y‖ₑ ≤
+      ((edist x x' / edist x y) ^ (a : ℝ)⁻¹ * ENNReal.ofReal (C_K a / Real.vol x y)) * ‖g y‖ₑ := by
+    intro y h
+    apply mul_le_mul
+    case h₂ => rfl
+    case c0 | b0 => simp only [zero_le]
+    apply norm_K_sub_le'
+
+    trans 2 * ENNReal.ofReal r
+    . apply mul_le_mul
+      case h₁ => rfl
+      case c0 | b0 => simp only [zero_le]
+      exact (edist_le_ofReal (le_of_lt hr)).mpr hx
+    . rw [mem_compl_iff, mem_ball, dist_comm] at h
+      rw [edist_dist, ← ENNReal.ofReal_ofNat, ← ENNReal.ofReal_mul, ofReal_le_ofReal_iff]
+      . exact le_of_not_lt h
+      . exact dist_nonneg
+      . exact zero_le_two
+
   have tmp5 {x₀ : X} {n : ℝ} : ∫⁻ (a : X) in ball x₀ (n * r), ‖g a‖ₑ = (⨍⁻ (a : X) in ball x₀ (n * r), ‖g a‖ₑ ∂volume)  * volume (ball x₀ (n * r)) := by
     have h_meas_finite : IsFiniteMeasure (volume.restrict (ball x₀ (n * r))) := by
       refine isFiniteMeasure_restrict.mpr ?_
@@ -386,6 +405,21 @@ theorem estimate_x_shift (ha : 4 ≤ a)
 
   have estimate_10_1_3 : ‖ ∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y‖ₑ
       ≤ 2 ^ (a ^ 3 + 2 * a) * globalMaximalFunction volume 1 g x := by
+    conv =>
+      arg 1; arg 1; arg 2
+      intro y
+      rw [← mul_sub_right_distrib]
+
+    trans ∫⁻ (y : X) in bx2rᶜ, ‖ (K x y - K x' y) * g y‖ₑ
+    . apply enorm_integral_le_lintegral_enorm
+    simp only [enorm_mul]
+
+    trans ∫⁻ (y : X) in bx2rᶜ, (edist x x' / edist x y) ^ (a : ℝ)⁻¹ * ENNReal.ofReal (C_K a / Real.vol x y) * ‖ g y‖ₑ
+    . apply lintegral_mono_fn
+      -- I think a general lemma is missing to make this work on bx2rc instead of X
+      -- Then pointwise_2 proves it
+      sorry
+
     sorry
 
   have estimate_10_1_4 : (∫⁻ (y : X) in bxprc ∩ bx2r, ‖ K x' y * g y‖ₑ)

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -119,11 +119,30 @@ theorem estimate_x_shift (ha : 4 ≤ a)
     (hr : 0 < r) (hx : dist x x' ≤ r) :
     nndist (czOperator K r g x) (czOperator K r g x') ≤
     C10_1_2 a * globalMaximalFunction volume 1 g x := by
+  let bxrc := (ball x r)ᶜ
+  let bx2r := ball x (2*r)
+  have dom_x : bxrc =  (bxrc ∩ bx2r) ∪ bx2rᶜ := by
+    have int1 : bx2rᶜ = bxrc ∩ bx2rᶜ := by
+      suffices bx2rᶜ ⊆ bxrc by
+        rw [Set.right_eq_inter]
+        exact this
+      suffices ball x r ⊆ bx2r by
+        rw [Set.compl_subset_compl]
+        exact this
+      apply Metric.ball_subset_ball
+      linarith
+
+
+    sorry
   sorry
 /-! Breakdown from PDF
+  Expand def
   Split first domain in parts > set work
     part 1 r < d x y < 2r
     part 2 2r < d x y
+-/
+
+/-!
   Split 2nd domain in parts > set work
     part 1 r < d x' y and r < d x y < 2r
     part 2 r < d x' y and 2r < d x y which is 2r < d x y by triangle ineq

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -258,38 +258,57 @@ theorem estimate_x_shift (ha : 4 ≤ a)
 
   -- LHS is now 10.1.234
 
-  sorry
-/-
+  have estimate_10_1_2 : (∫⁻ (y : X) in bxrc ∩ bx2r, ‖ K x y * g y‖ₑ)
+      ≤ 2 ^ (a ^ 3 + a) * globalMaximalFunction volume 1 g x := by
+    sorry
 
-  -- We could use globalMaximalFunction_lt_top here (HardyLittlewood commented out) but proof by cases works just as well
-  by_cases m_infinite : globalMaximalFunction volume 1 g x = ∞
-  . rw[m_infinite, ENNReal.mul_top]
-    apply OrderTop.le_top
-    simp only [ne_eq, coe_eq_zero]
-    with_unfolding_all simp only [C10_1_2]
-    simp
+  have estimate_10_1_3 : ‖ ∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y‖ₑ
+      ≤ 2 ^ (a ^ 3 + 2 * a) * globalMaximalFunction volume 1 g x := by
+    sorry
 
-  rw [← ne_eq] at m_infinite
+  have estimate_10_1_4 : (∫⁻ (y : X) in bxprc ∩ bx2r, ‖ K x' y * g y‖ₑ)
+      ≤ 2 ^ (a ^ 3 + 2 * a) * globalMaximalFunction volume 1 g x := by
+    sorry
+
+  trans (2 ^ (a ^ 3 + a) * globalMaximalFunction volume 1 g x) + (2 ^ (a ^ 3 + 2 * a) * globalMaximalFunction volume 1 g x) +
+      (2 ^ (a ^ 3 + 2 * a) * globalMaximalFunction volume 1 g x)
+  . refine add_le_add_three ?_ ?_ ?_
+    . exact estimate_10_1_2
+    . exact estimate_10_1_3
+    . exact estimate_10_1_4
+
   conv =>
-    rhs
-    arg 2
-    calc globalMaximalFunction volume 1 g x
-      _ = ENNReal.toNNReal (globalMaximalFunction volume 1 g x) := by symm; apply ENNReal.coe_toNNReal; exact m_infinite
+    lhs
+    calc _
+      _ = (2 ^ (a ^ 3 + a) + 2 ^ (a ^ 3 + 2 * a) + 2 ^ (a ^ 3 + 2 * a)) * globalMaximalFunction volume 1 g x := by sorry
 
-  rw[← coe_mul]
+  refine mul_le_mul' ?_ ?_
+  swap
+  . unfold globalMaximalFunction
+    unfold defaultA
+    norm_cast
+
+  -- Now it is unavoidable to unfold C10_1_2
+  with_unfolding_all simp only [C10_1_2]
   norm_cast
--/
-/-
-    trans (abs (∫ (y : X) in bxrc ∩ bx2r, K x y * g y)) + (abs (∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y)) +
-        (abs (∫ (y : X) in bxprc ∩ bx2r, K x' y * g y))
-    apply -/
-  /-calc _
-    _ ≤ (Complex.abs (∫ (y : X) in bxrc ∩ bx2r, K x y * g y))
-          + (Complex.abs (∫ (y : X) in bx2rᶜ, K x y * g y - K x' y * g y))
-          + (Complex.abs (∫ (y : X) in bxprc ∩ bx2r, K x' y * g y)) := by sorry
-    -/
 
-  --sorry
+  -- Note: It is unclear to me which tactic can avoid this manual computation
+  have tmp3 : 2 ^ (a ^ 3 + a) ≤ 2 ^ (a ^ 3 + 2 * a + 1) := by
+    rw [Nat.pow_le_pow_iff_right]
+    rw [Nat.add_assoc]
+    rw [Nat.add_le_add_iff_left]
+    refine Nat.le_add_right_of_le ?_
+    refine Nat.le_mul_of_pos_left a ?_
+    exact Nat.zero_lt_two
+    exact Nat.one_lt_two
+
+  trans 2 ^ (a ^ 3 + 2 * a + 1) + 2 ^ (a ^ 3 + 2 * a) + 2 ^ (a ^ 3 + 2 * a)
+  . apply Nat.add_le_add_iff_right.mpr
+    apply Nat.add_le_add_iff_right.mpr
+    apply tmp3
+
+  ring_nf
+  rfl
 
 /- Breakdown from PDF
   Expand def
@@ -317,7 +336,7 @@ x Split integrals accordingly (sum of disjoint) obtain 10.1.234
     Mg + def integral of unit + sum factor 10.1.13
     Lemma 10.1.1 > 10.1.14
 
-  Total = sum of estimates ? 2(a3 + a) + 2(a3+2a) + 2(a3+2a) le 2(a3+2a+2)
+x Total = sum of estimates ? 2(a3 + a) + 2(a3+2a) + 2(a3+2a) le 2(a3+2a+2)
 -/
 
 /-- The constant used in `cotlar_control`. -/


### PR DESCRIPTION
This draft PR contains a first stab at lemma 10.1.2 from the blueprint. There are still some sorries left.

I will follow up on Zulip to discuss more; link to thread will follow.

This is my first PR trying to contribute to a Lean project, so bear with me while I figure things out. Please feel free to liberally improve/correct/suggest/explain/whatever. I'm here to learn, and while this lemma has been a journey, it should only mark the beginning.

Remaining sorries:
- [ ] L122 `czoperator_welldefined`: I am not sure if this is already proven somewhere
- [ ] L396 `Measurable (vol x)`: Again may already be proven (though `vol` was very recently added in favour of `Real.vol`)
- [ ] L404 `rw_dom`: Some set work on proving a ball is a union of annuli
- [ ] L535 `ContinuousSMul ℝ≥0∞ ℝ≥0∞`: I feel this should be an oversight that is easily fixed somewhere
- [ ] L570 `Summable`: It's a geometric series, but I didn't know how to approach. May be able to put this in `ℝ≥0∞` to use `ENNReal.summable`

I have been reluctant to change other files since I am new to Lean and associated etiquette. Here are some other suggestions/ideas/observations:
- The use of ENorm, `vol`, and constants in `ℝ≥0` made my life much easier so I am happy with that.
- L342 `laverage_le_globalMaximalFunction` worked well, but it uses `‖ _ ‖₊` instead of `‖ _ ‖ₑ`
- I used `mul_le_mul` a lot but it seems that in NNReal/ENNReal it can be simplified to avoid `case c0 | b0` (e.g. L349 is typical)
- It was a pain to prove measurability of the integrands, although it was a 'simple' composition
- L132 I made `setIntegral_union_2` because I struggled a lot to split an integral using `setIntegral_union` because of the IntegrableOn conditions on the parts instead of the whole
- Am I adding too many intermediate steps into the context? Does this affect performance?
- I am not 100% sure where the assumptions on `g` are actually used (and which). Is it for `czoperator_welldefined`?

Overall I have the feeling, based on the amount of work and the number of intermediate steps needed, that it might be wise to have a discussion on approach (e.g. which general lemmas) for chapter 10 before distributing the work further to individual contributors. And a word of caution that the blueprintś 