### PR TITLE
chore(WeakType): generalise to enorm classes, part 1

### DIFF
--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -566,22 +566,20 @@ end ContinuousENorm
 
 section NormedGroup
 
--- todo: generalize various results to ENorm.
-
 variable {f g : α → ε}
 section
 variable [TopologicalSpace ε] [ContinuousENorm ε]
 
-lemma distribution_eq_nnnorm {f : α → E} : distribution f t μ =  μ { x | t < ‖f x‖₊ } := rfl
+-- TODO: generalise this to the ENorm context: requires generalising the HasSMul context for •
 
 lemma distribution_smul_left {f : α → E} {c : 𝕜} (hc : c ≠ 0) :
-    distribution (c • f) t μ = distribution f (t / ‖c‖₊) μ := by
-  simp_rw [distribution_eq_nnnorm]
-  have h₀ : ofNNReal ‖c‖₊ ≠ 0 := ENNReal.coe_ne_zero.mpr (nnnorm_ne_zero_iff.mpr hc)
+    distribution (c • f) t μ = distribution f (t / ‖c‖ₑ) μ := by
+  have h₀ : ‖c‖ₑ ≠ 0 := enorm_ne_zero.mpr hc
+  unfold distribution
   congr with x
   simp only [Pi.smul_apply, mem_setOf_eq]
-  rw [← @ENNReal.mul_lt_mul_right (t / ‖c‖₊) _ (‖c‖₊) h₀ coe_ne_top,
-    ENNNorm_absolute_homogeneous _, mul_comm, ENNReal.div_mul_cancel h₀ coe_ne_top]
+  rw [← @ENNReal.mul_lt_mul_right (t / ‖c‖ₑ) _ (‖c‖ₑ) h₀ coe_ne_top,
+    enorm_absolute_homogeneous _, mul_comm, ENNReal.div_mul_cancel h₀ coe_ne_top]
 
 lemma HasStrongType.const_smul {𝕜 E' α α' : Type*} [NormedAddCommGroup E']
     {_x : MeasurableSpace α} {_x' : MeasurableSpace α'} {T : (α → ε) → (α' → E')}
@@ -621,7 +619,7 @@ end
 lemma distribution_add_le [TopologicalSpace ε] [ENormedAddMonoid ε] :
     distribution (f + g) (t + s) μ ≤ distribution f t μ + distribution g s μ :=
   calc
-    _ ≤ μ ({x | t < ↑‖f x‖ₑ} ∪ {x | s < ↑‖g x‖ₑ}) := by
+    _ ≤ μ ({x | t < ‖f x‖ₑ} ∪ {x | s < ‖g x‖ₑ}) := by
       refine measure_mono fun x h ↦ ?_
       simp only [mem_union, mem_setOf_eq, Pi.add_apply] at h ⊢
       contrapose! h

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -530,17 +530,9 @@ lemma HasBoundedStrongType.hasBoundedWeakType [Zero ε₁] (hp' : 1 ≤ p')
   fun f hf h2f h3f ↦
     ⟨(h f hf h2f h3f).1, wnorm_le_eLpNorm (h f hf h2f h3f).1 hp' |>.trans (h f hf h2f h3f).2⟩
 
-end ContinuousENorm
-
-section NormedGroup
-
--- todo: generalize various results to ENorm.
+section distribution
 
 variable {f g : α → ε}
-section
-variable [TopologicalSpace ε] [ContinuousENorm ε]
-
-lemma distribution_eq_nnnorm {f : α → E} : distribution f t μ =  μ { x | t < ‖f x‖₊ } := rfl
 
 @[gcongr]
 lemma distribution_mono_left (h : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ ‖g x‖ₑ) :
@@ -562,6 +554,26 @@ lemma distribution_mono (h₁ : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ ‖g x‖ₑ) (
 lemma distribution_snormEssSup : distribution f (eLpNormEssSup f μ) μ = 0 :=
   meas_essSup_lt -- meas_eLpNormEssSup_lt
 
+lemma distribution_add_le' {A : ℝ≥0∞} {g₁ g₂ : α → ε}
+    (h : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ A * (‖g₁ x‖ₑ + ‖g₂ x‖ₑ)) :
+    distribution f (A * (t + s)) μ ≤ distribution g₁ t μ + distribution g₂ s μ := by
+  apply distribution_add_le_of_enorm
+  simp (discharger := positivity) [← ofReal_mul, ← ofReal_add, h]
+
+end distribution
+
+end ContinuousENorm
+
+section NormedGroup
+
+-- todo: generalize various results to ENorm.
+
+variable {f g : α → ε}
+section
+variable [TopologicalSpace ε] [ContinuousENorm ε]
+
+lemma distribution_eq_nnnorm {f : α → E} : distribution f t μ =  μ { x | t < ‖f x‖₊ } := rfl
+
 lemma distribution_smul_left {f : α → E} {c : 𝕜} (hc : c ≠ 0) :
     distribution (c • f) t μ = distribution f (t / ‖c‖₊) μ := by
   simp_rw [distribution_eq_nnnorm]
@@ -570,12 +582,6 @@ lemma distribution_smul_left {f : α → E} {c : 𝕜} (hc : c ≠ 0) :
   simp only [Pi.smul_apply, mem_setOf_eq]
   rw [← @ENNReal.mul_lt_mul_right (t / ‖c‖₊) _ (‖c‖₊) h₀ coe_ne_top,
     ENNNorm_absolute_homogeneous _, mul_comm, ENNReal.div_mul_cancel h₀ coe_ne_top]
-
-lemma distribution_add_le' {A : ℝ≥0∞} {g₁ g₂ : α → ε}
-    (h : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ A * (‖g₁ x‖ₑ + ‖g₂ x‖ₑ)) :
-    distribution f (A * (t + s)) μ ≤ distribution g₁ t μ + distribution g₂ s μ := by
-  apply distribution_add_le_of_enorm
-  simp (discharger := positivity) [← ofReal_mul, ← ofReal_add, h]
 
 lemma HasStrongType.const_smul {𝕜 E' α α' : Type*} [NormedAddCommGroup E']
     {_x : MeasurableSpace α} {_x' : MeasurableSpace α'} {T : (α → ε) → (α' → E')}

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -12,7 +12,6 @@ open NNReal ENNReal NormedSpace MeasureTheory Set Filter Topology Function
 
 section move
 
-
 variable {α 𝕜 E : Type*} {m : MeasurableSpace α}
   {μ : Measure α} [NontriviallyNormedField 𝕜]
   [NormedAddCommGroup E] [NormedSpace 𝕜 E]
@@ -20,6 +19,9 @@ variable {α 𝕜 E : Type*} {m : MeasurableSpace α}
 
 -- todo: move/rename/and perhaps reformulate in terms of ‖.‖ₑ
 lemma ENNNorm_absolute_homogeneous {c : 𝕜} (z : E) : ofNNReal ‖c • z‖₊ = ↑‖c‖₊ * ↑‖z‖₊ :=
+  (toReal_eq_toReal_iff' coe_ne_top coe_ne_top).mp (norm_smul c z)
+
+lemma enorm_absolute_homogeneous {c : 𝕜} (z : E) : ‖c • z‖ₑ = ‖c‖ₑ * ‖z‖ₑ :=
   (toReal_eq_toReal_iff' coe_ne_top coe_ne_top).mp (norm_smul c z)
 
 lemma ENNNorm_add_le (y z : E) : ofNNReal ‖y + z‖₊ ≤ ↑‖y‖₊ + ↑‖z‖₊ :=

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -629,24 +629,22 @@ lemma distribution_add_le [TopologicalSpace ε] [ENormedAddMonoid ε] :
     _ ≤ _ := measure_union_le _ _
 
 lemma _root_.ContinuousLinearMap.distribution_le {f : α → E₁} {g : α → E₂} :
-    distribution (fun x ↦ L (f x) (g x)) (‖L‖₊ * t * s) μ ≤
+    distribution (fun x ↦ L (f x) (g x)) (‖L‖ₑ * t * s) μ ≤
     distribution f t μ + distribution g s μ := by
   unfold distribution
-  have h₀ : {x | ↑‖L‖₊ * t * s < ↑‖(fun x ↦ (L (f x)) (g x)) x‖₊} ⊆
-      {x | t < ↑‖f x‖₊} ∪ {x | s < ↑‖g x‖₊} := fun z hz ↦ by
+  have h₀ : {x | ‖L‖ₑ * t * s < ‖(fun x ↦ (L (f x)) (g x)) x‖ₑ} ⊆
+      {x | t < ‖f x‖ₑ} ∪ {x | s < ‖g x‖ₑ} := fun z hz ↦ by
     simp only [mem_union, mem_setOf_eq, Pi.add_apply] at hz ⊢
     contrapose! hz
     calc
-      (‖(L (f z)) (g z)‖₊ : ℝ≥0∞) ≤ ‖L‖₊ * ‖f z‖₊ * ‖g z‖₊ := by
-        refine (toNNReal_le_toNNReal coe_ne_top coe_ne_top).mp ?_
-        simp only [toNNReal_coe, coe_mul, toNNReal_mul]
+      ‖(L (f z)) (g z)‖ₑ ≤ ‖L‖ₑ * ‖f z‖ₑ * ‖g z‖ₑ := by
         calc
-          _ ≤ ↑‖L (f z)‖₊ * ↑‖g z‖₊ := ContinuousLinearMap.le_opNNNorm (L (f z)) (g z)
-          _ ≤ ‖L‖₊ * ‖f z‖₊ * ‖g z‖₊ :=
-            mul_le_mul' (ContinuousLinearMap.le_opNNNorm L (f z)) (by rfl)
-      _ ≤ _ := mul_le_mul' (mul_le_mul_left' hz.1 ↑‖L‖₊) hz.2
+          _ ≤ ‖L (f z)‖ₑ * ‖g z‖ₑ := ContinuousLinearMap.le_opENorm (L (f z)) (g z)
+          _ ≤ ‖L‖ₑ * ‖f z‖ₑ * ‖g z‖ₑ :=
+            mul_le_mul' (ContinuousLinearMap.le_opENorm L (f z)) (by rfl)
+      _ ≤ _ := mul_le_mul' (mul_le_mul_left' hz.1 ‖L‖ₑ) hz.2
   calc
-    _ ≤ μ ({x | t < ↑‖f x‖₊} ∪ {x | s < ↑‖g x‖₊}) := measure_mono h₀
+    _ ≤ μ ({x | t < ‖f x‖ₑ} ∪ {x | s < ‖g x‖ₑ}) := measure_mono h₀
     _ ≤ _ := measure_union_le _ _
 
 section BorelSpace

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -560,6 +560,16 @@ lemma distribution_add_le' {A : ℝ≥0∞} {g₁ g₂ : α → ε}
   apply distribution_add_le_of_enorm
   simp (discharger := positivity) [← ofReal_mul, ← ofReal_add, h]
 
+lemma distribution_add_le {ε} [TopologicalSpace ε] [ENormedAddMonoid ε] {f g : α → ε} :
+    distribution (f + g) (t + s) μ ≤ distribution f t μ + distribution g s μ :=
+  calc
+    _ ≤ μ ({x | t < ‖f x‖ₑ} ∪ {x | s < ‖g x‖ₑ}) := by
+      refine measure_mono fun x h ↦ ?_
+      simp only [mem_union, mem_setOf_eq, Pi.add_apply] at h ⊢
+      contrapose! h
+      exact (ENormedAddMonoid.enorm_add_le _ _).trans (add_le_add h.1 h.2)
+    _ ≤ _ := measure_union_le _ _
+
 end distribution
 
 end ContinuousENorm
@@ -615,16 +625,6 @@ lemma HasWeakType.const_mul {E' α α' : Type*} [NormedRing E']
 
 
 end
-
-lemma distribution_add_le [TopologicalSpace ε] [ENormedAddMonoid ε] :
-    distribution (f + g) (t + s) μ ≤ distribution f t μ + distribution g s μ :=
-  calc
-    _ ≤ μ ({x | t < ‖f x‖ₑ} ∪ {x | s < ‖g x‖ₑ}) := by
-      refine measure_mono fun x h ↦ ?_
-      simp only [mem_union, mem_setOf_eq, Pi.add_apply] at h ⊢
-      contrapose! h
-      exact (ENormedAddMonoid.enorm_add_le _ _).trans (add_le_add h.1 h.2)
-    _ ≤ _ := measure_union_le _ _
 
 lemma _root_.ContinuousLinearMap.distribution_le {f : α → E₁} {g : α → E₂} :
     distribution (fun x ↦ L (f x) (g x)) (‖L‖ₑ * t * s) μ ≤


### PR DESCRIPTION
- Some results were already stated about enorms, but still put in the NormedSpace section: move them to clarify.
- Add one enorm counterpart of a lemma, and use it to generalise two more lemmas.

