### PR TITLE
proof of spectral_projection_bound in blueprint

### DIFF
--- a/Carleson/Classical/HilbertStrongType.lean
+++ b/Carleson/Classical/HilbertStrongType.lean
@@ -78,7 +78,7 @@ theorem AddCircle.haarAddCircle_eq_smul_volume {T : ℝ} [hT : Fact (0 < T)] :
     ENNReal.inv_mul_cancel (by simp [hT.out]) ENNReal.ofReal_ne_top, one_smul]
 
 open AddCircle in
-/-- Lemma 11.1.11.
+/-- Lemma 11.1.10.
 The blueprint states this on `[-π, π]`, but I think we can consistently change this to `(0, 2π]`.
 -/
 -- todo: add lemma that relates `eLpNorm ((Ioc a b).indicator f)` to `∫ x in a..b, _`

--- a/Carleson/Classical/HilbertStrongType.lean
+++ b/Carleson/Classical/HilbertStrongType.lean
@@ -74,7 +74,8 @@ lemma partial_sum_selfadjoint {f g : ℝ → ℂ} {n : ℕ}
 
 theorem AddCircle.haarAddCircle_eq_smul_volume {T : ℝ} [hT : Fact (0 < T)] :
     (@haarAddCircle T _) = (ENNReal.ofReal T)⁻¹ • (volume : Measure (AddCircle T)) := by
-  rw [volume_eq_smul_haarAddCircle, ← smul_assoc, smul_eq_mul, ENNReal.inv_mul_cancel (by simp [hT.out]) ENNReal.ofReal_ne_top, one_smul]
+  rw [volume_eq_smul_haarAddCircle, ← smul_assoc, smul_eq_mul,
+    ENNReal.inv_mul_cancel (by simp [hT.out]) ENNReal.ofReal_ne_top, one_smul]
 
 open AddCircle in
 /-- Lemma 11.1.11.
@@ -97,7 +98,8 @@ lemma spectral_projection_bound {f : ℝ → ℂ} {n : ℕ} (hmf : Measurable f)
     . rw [haarAddCircle_eq_smul_volume]
       apply AEStronglyMeasurable.smul_measure
       exact hmf.aestronglyMeasurable.liftIoc (2 * π) 0
-    . rw [haarAddCircle_eq_smul_volume, eLpNorm_smul_measure_of_ne_top (by trivial), eLpNorm_liftIoc _ _ hmf.aestronglyMeasurable, smul_eq_mul, zero_add]
+    . rw [haarAddCircle_eq_smul_volume, eLpNorm_smul_measure_of_ne_top (by trivial),
+        eLpNorm_liftIoc _ _ hmf.aestronglyMeasurable, smul_eq_mul, zero_add]
       apply ENNReal.mul_lt_top _ hf_L2
       rw [← ENNReal.ofReal_inv_of_pos this.out]
       apply ENNReal.rpow_lt_top_of_nonneg ENNReal.toReal_nonneg ENNReal.ofReal_ne_top
@@ -106,14 +108,18 @@ lemma spectral_projection_bound {f : ℝ → ℂ} {n : ℕ} (hmf : Measurable f)
 
   have lp_version := spectral_projection_bound_lp (N := n) F
   rw [Lp.norm_def, Lp.norm_def,
-    ENNReal.toReal_le_toReal (Lp.eLpNorm_ne_top (partialFourierSumLp 2 n F)) (Lp.eLpNorm_ne_top F)] at lp_version
+    ENNReal.toReal_le_toReal (Lp.eLpNorm_ne_top (partialFourierSumLp 2 n F)) (Lp.eLpNorm_ne_top F)]
+    at lp_version
 
-  rw [← zero_add (2 * π), ← eLpNorm_liftIoc _ _ hmf.aestronglyMeasurable, ← eLpNorm_liftIoc _ _ partialFourierSum_uniformContinuous.continuous.aestronglyMeasurable, volume_eq_smul_haarAddCircle,
+  rw [← zero_add (2 * π), ← eLpNorm_liftIoc _ _ hmf.aestronglyMeasurable,
+    ← eLpNorm_liftIoc _ _ partialFourierSum_uniformContinuous.continuous.aestronglyMeasurable,
+    volume_eq_smul_haarAddCircle,
     eLpNorm_smul_measure_of_ne_top (by trivial), eLpNorm_smul_measure_of_ne_top (by trivial),
     smul_eq_mul, smul_eq_mul, ENNReal.mul_le_mul_left (by simp [Real.pi_pos]) (by simp)]
-  have ae_eq_right : ↑↑F =ᶠ[ae haarAddCircle] liftIoc (2 * π) 0 f := MemLp.coeFn_toLp _
-  have ae_eq_left : ↑↑(partialFourierSumLp 2 n F) =ᶠ[ae haarAddCircle] liftIoc (2 * π) 0 (partialFourierSum n f) := by
-    exact Filter.EventuallyEq.symm (partialFourierSum_aeeq_partialFourierSumLp 2 n f lift_MemLp)
+  have ae_eq_right : F =ᶠ[ae haarAddCircle] liftIoc (2 * π) 0 f := MemLp.coeFn_toLp _
+  have ae_eq_left : partialFourierSumLp 2 n F =ᶠ[ae haarAddCircle]
+      liftIoc (2 * π) 0 (partialFourierSum n f) :=
+    Filter.EventuallyEq.symm (partialFourierSum_aeeq_partialFourierSumLp 2 n f lift_MemLp)
   rw [← eLpNorm_congr_ae ae_eq_right, ← eLpNorm_congr_ae ae_eq_left]
   exact lp_version
 

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -8193,7 +8193,6 @@ The following lemma will be proved in \Cref{10projection}.
 \leanok
 \lean{spectral_projection_bound}
 \uses{partial-sum-projection,partial-sum-selfadjoint}
-%\lean{spectral_projection_bound}
     Let $f$ be a bounded $2\pi$-periodic measurable function. Then, for all $N\ge 0$
    \begin{equation}\label{snbound}
    \|S_Nf\|_{L^2[-\pi, \pi]} \le \|f\|_{L^2[-\pi, \pi]}.
@@ -8762,134 +8761,28 @@ $$
 \end{proof}
 
 
-
-
 \section{Partial sums as orthogonal projections}
 \label{10projection}
 
 This subsection proves \Cref{spectral-projection-bound}
-
-
-
-
-
-
-\begin{lemma}[partial sum projection]
-\label{partial-sum-projection}
-\leanok
-\lean{partial_sum_projection}
-\uses{mean-zero-oscillation}
-  Let $f$ be a bounded $2\pi$-periodic measurable function. Then, for all $N\ge 0$
-   \begin{equation}\label{projection}
-   S_N(S_N f)=S_Nf\, .
-   \end{equation}
-   \end{lemma}
-\begin{proof}
-Let $N>0$ be given. With $K_N$ as in \Cref{Dirichlet-kernel},
-\begin{equation*}
-S_N (S_Nf) (x)=
-\frac{1}{2\pi} \int_0^{2\pi} S_Nf(y)K_N(x-y)\, dy
-\end{equation*}
-\begin{equation}\label{eqhil1}
-=
-\frac{1}{(2\pi)^2}\int_0^{2\pi} \int_0^{2\pi} f(y')K_N(y-y') K_N(x-y)\, \, dy' dy\, .
-\end{equation}
-We have by \Cref{Dirichlet-kernel}
-\begin{equation*}
-\frac{1}{2\pi}\int_0^{2\pi} K_N(y-y') K_N(x-y)\, dy
-\end{equation*}
-\begin{equation*}
-=\frac{1}{2\pi}\sum_{n=-N}^N\sum_{n'=-N}^N
-\int_0^{2\pi} e^{in(y-y')}e^{in'(x-y)}\, dy
-\end{equation*}
-\begin{equation}\label{eqhil6}
-=\frac{1}{2\pi}\sum_{n=-N}^N\sum_{n'=-N}^N
-e^{i(n'x-ny')}\int_0^{2\pi} e^{i(n-n')y}\, dy\, .
-\end{equation}
-By \Cref{mean-zero-oscillation}, the summands for $n\neq n'$ vanish.
-We obtain for \eqref{eqhil6}
-\begin{equation}\label{eqhil2}
-=\frac{1}{2\pi}\sum_{n=-N}^N
-e^{in(x-y')}\int_0^{2\pi} \, dy=K_N(x-y')\, .
-\end{equation}
-Applying Fubini in \eqref{eqhil1} and using
-\eqref{eqhil2} gives
-\begin{equation}
-S_N(S_Nf)(x)=
-\frac{1}{2\pi} \int_0^{2\pi} f(y')K(x-y') \, dy'=S_N f(x)
-\end{equation}
-This proves the lemma.
-\end{proof}
-\begin{lemma}[partial sum selfadjoint]
-\label{partial-sum-selfadjoint}
-\leanok
-\lean{partial_sum_selfadjoint}
-\uses{Dirichlet-kernel}
-    We have for any $2\pi$-periodic bounded measurable $g,f$ that
-    \begin{equation}
-       \int_0^{2\pi} \overline{S_Nf(x)} g(x)=\int_0^{2\pi} \overline{f(x)} S_Ng(x)\, dx\, .
-    \end{equation}
-\end{lemma}
-\begin{proof}
-  We have with $K_N$ as in \Cref{Dirichlet-kernel} for every $x$
-  \begin{equation}
-      \overline{K_N(x)}=\sum_{n=-N}^N\overline{ e^{in x}}=
-      {\sum_{n=-N}^N e^{-in x}}=K_N(-x)\, .
-  \end{equation}
- Further, with \Cref{Dirichlet-kernel} and Fubini
-\begin{equation*}
-\int_0^{2\pi} \overline{S_Nf(x)} g(x)
-= \frac 1{2\pi} \int_0^{2\pi} \int_{-\pi}^{\pi}\overline{f(y) K_N(x-y)} g(x)\, dy dx
- \end{equation*}
- \begin{equation}
-=
-\frac 1{2\pi} \int_0^{2\pi} \int_{-\pi}^{\pi}\overline{f(y)} K_N(y-x)
-g(x)\, dx dy
-=\int_0^{2\pi} \overline{f(x)} S_Ng(x)\, dx
-\, .
-\end{equation}
- This proves the lemma.
-\end{proof}
-
 
 We turn to the proof of Lemma
 \ref{spectral-projection-bound}.
 
 \begin{proof}[Proof of \Cref{spectral-projection-bound}]
 \proves{spectral-projection-bound}
+\leanok
 
-We have with \Cref{partial-sum-selfadjoint}, then \Cref{partial-sum-projection} and the \Cref{partial-sum-selfadjoint} again
-\begin{equation*}
- \int_0^{2\pi} S_Nf(x)\overline{S_Nf(x)}\, dx
- \int_0^{2\pi} f(x)\overline{S_N(S_Nf)(x)}\, dx
-\end{equation*}
-\begin{equation}\label{eqhil7}
- =\int_0^{2\pi} f(x)\overline{S_Nf(x)}\, dx=
- \int_0^{2\pi} S_N f(x)\overline{f(x)}\, dx\, .
-\end{equation}
+The functions $e_n:x\mapsto e^{inx}$ form an orthonormal basis in $L^2[-\pi, \pi]$.
+Therefore we have
+\begin{align*}
+    \|S_Nf\|^2_{L^2[-\pi, \pi]}
+    &= \|\sum_{n=-N}^N \langle\widehat{f}_n, e_n\rangle_{L^2[-\pi, \pi]}\|^2_{L^2[-\pi, \pi]} \\
+    &= \sum_{n=-N}^N |\widehat{f}_n| \\
+    &\le \sum_{n\in \mathbb{Z}} |\widehat{f}_n| \\
+    &= \|f\|_{L^2[-\pi, \pi]}.
+\end{align*}
 
-We have by the distributive law
-\begin{equation}\label{diffnorm}
-    \int_0^{2\pi} (f(x)-S_Nf(x))(\overline{f(x)-S_Nf(x)})\, dx=
-\end{equation}
-\begin{equation*}
- \int_0^{2\pi} f(x)\overline{f(x)}
-    -S_Nf(x)\overline{f(x)}
-   -f(x)\overline{S_Nf(x)}
-     + S_Nf(x)\overline{S_Nf(x)}\, dx
-\end{equation*}
-Using the various identities expressed in \eqref{eqhil7}, this becomes
-\begin{equation}
- =\int_0^{2\pi} f(x)\overline{f(x)}\, dx
-    -
-   \int_0^{2\pi} S_Nf(x)\overline{S_Nf(x)}\, dx\, .
-\end{equation}
-As \eqref{diffnorm} has nonnegative integrand and is thus nonnegative, we conclude
-\begin{equation}
-  \int_0^{2\pi} S_Nf(x)\overline{S_Nf(x)}\, dx\le
- \int_0^{2\pi} f(x)\overline{f(x)})\, dx\, .
-\end{equation}
-As both sides are positive, we may take the square root of this inequality.
 This completes the proof of the lemma.
 \end{proof}
 

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -8770,7 +8770,8 @@ This subsection proves \Cref{spectral-projection-bound}
 \proves{spectral-projection-bound}
 \leanok
 
-The functions $e_n:x\mapsto e^{inx}$ form an orthonormal basis in $L^2[-\pi, \pi]$.
+The functions $e_n:x\mapsto e^{inx}$ form an orthonormal basis in $L^2[-\pi, \pi]$
+(this is already in Mathlib).
 Therefore we have
 \begin{align*}
     \|S_Nf\|^2_{L^2[-\pi, \pi]}

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -8766,9 +8766,6 @@ $$
 
 This subsection proves \Cref{spectral-projection-bound}
 
-We turn to the proof of Lemma
-\ref{spectral-projection-bound}.
-
 \begin{proof}[Proof of \Cref{spectral-projection-bound}]
 \proves{spectral-projection-bound}
 \leanok
@@ -8785,9 +8782,6 @@ Therefore we have
 
 This completes the proof of the lemma.
 \end{proof}
-
-
-
 
 \section{The error bound}
 \label{10difference}

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -8091,26 +8091,8 @@ It is proved in \Cref{10vandercorput}.
 \end{lemma}
 
 
-We close this section with six lemmas that are used
+We close this section with five lemmas that are used
 across the following subsections.
-
-\begin{lemma}[mean zero oscillation]
-\label{mean-zero-oscillation}
-\leanok
-\lean{mean_zero_oscillation}
-Let $n\in \mathbb{Z}$ with $n\neq 0$, then
-\begin{equation}
-\int_0^{2\pi} e^{inx}\, dx=0\,.
-\end{equation}
-\end{lemma}
-\begin{proof}
-\leanok
-We have
-\begin{equation*}
-\int_0^{2\pi} e^{inx}\, dx=\left[ \frac 1{in}e^{inx}\right]_0^{2\pi}=\frac 1{in}(e^{2\pi i n}-e^{2\pi i 0})=\frac 1{in}(1-1)=0\, . \qedhere
-\end{equation*}
-
-\end{proof}
 
 \begin{lemma}[Dirichlet kernel]
 \label{Dirichlet-kernel}


### PR DESCRIPTION
align the blueprint proof with the Lean proof (which could use some facts that were already in Mathlib).
Remove some blueprint lemmas now unused in the new proof.
Add a `\leanok`.