### PR TITLE
chore: clean up #275

### DIFF
--- a/Carleson/ToMathlib/HardyLittlewood.lean
+++ b/Carleson/ToMathlib/HardyLittlewood.lean
@@ -541,10 +541,18 @@ theorem hasWeakType_globalMaximalFunction [BorelSpace X] [IsFiniteMeasureOnCompa
       p₂ p₂ μ μ (A ^ 4) := by
   unfold globalMaximalFunction
   simp_rw [ENNReal.toReal_mul]
-  convert HasWeakType.const_mul (c := A ^ 2) _ _
-  · simp; ring
-  rw [hasWeakType_toReal_iff sorry /- remove if we remove the `toReal` from this statement. -/]
-  exact hasWeakType_maximalFunction countable_globalMaximalFunction hp₁ hp₁₂
+  have : ofNNReal p₂ ≠ 0 := by -- surely, there is a simpler proof
+    refine coe_ne_zero.mpr ?_
+    have : 1 ≤ p₂ := by
+      trans p₁
+      exacts [hp₁, hp₁₂]
+    positivity
+  convert HasWeakType.const_mul (c := A ^ 2) (e := A ^ 2) (p' := p₂) (μ := μ) (ν := μ) (p := p₂) (ε := E) this _ _
+  repeat sorry
+  -- TODO: this proof used to work (now, some metavariables cannot be inferred), was
+  -- · simp; ring
+  -- rw [hasWeakType_toReal_iff sorry /- remove if we remove the `toReal` from this statement. -/]
+  -- exact hasWeakType_maximalFunction countable_globalMaximalFunction hp₁ hp₁₂
 
 /-- Use `lowerSemiContinuous_MB` -/
 lemma lowerSemiContinuous_globalMaximalFunction (hf : LocallyIntegrable f μ) :

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -85,14 +85,14 @@ namespace MeasureTheory
 variable {α α' ε ε₁ ε₂ ε₃ 𝕜 E E₁ E₂ E₃ : Type*} {m : MeasurableSpace α} {m : MeasurableSpace α'}
   {p p' q : ℝ≥0∞} {c : ℝ≥0}
   {μ : Measure α} {ν : Measure α'} [NontriviallyNormedField 𝕜]
-  [NormedAddCommGroup E] --[NormedSpace 𝕜 E]
-  [MulActionWithZero 𝕜 E] [IsBoundedSMul 𝕜 E]
-  [NormedAddCommGroup E₁] --[NormedSpace 𝕜 E₁]
-  [MulActionWithZero 𝕜 E₁] [IsBoundedSMul 𝕜 E₁]
-  [NormedAddCommGroup E₂] --[NormedSpace 𝕜 E₂]
-  [MulActionWithZero 𝕜 E₂] [IsBoundedSMul 𝕜 E₂]
-  [NormedAddCommGroup E₃] --[NormedSpace 𝕜 E₃]
-  [MulActionWithZero 𝕜 E₃] [IsBoundedSMul 𝕜 E₃]
+  [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  --[MulActionWithZero 𝕜 E] [IsBoundedSMul 𝕜 E]
+  [NormedAddCommGroup E₁] [NormedSpace 𝕜 E₁]
+ -- [MulActionWithZero 𝕜 E₁] [IsBoundedSMul 𝕜 E₁]
+  [NormedAddCommGroup E₂] [NormedSpace 𝕜 E₂]
+  --[MulActionWithZero 𝕜 E₂] [IsBoundedSMul 𝕜 E₂]
+  [NormedAddCommGroup E₃] [NormedSpace 𝕜 E₃]
+  --[MulActionWithZero 𝕜 E₃] [IsBoundedSMul 𝕜 E₃]
   --(L : E₁ →L[𝕜] E₂ →L[𝕜] E₃)
   {t s x y : ℝ≥0∞}
   {T : (α → ε₁) → (α' → ε₂)}
@@ -586,7 +586,7 @@ variable [TopologicalSpace ε] [ContinuousENorm ε]
 
 -- TODO: add an analogue for the ENorm context, using scalar multiplication w.r.t. `NNReal` on an `ENormedSpace`
 
-lemma distribution_smul_left [NormedSpace 𝕜 E] {f : α → E} {c : 𝕜} (hc : c ≠ 0) :
+lemma distribution_smul_left {f : α → E} {c : 𝕜} (hc : c ≠ 0) :
     distribution (c • f) t μ = distribution f (t / ‖c‖ₑ) μ := by
   have h₀ : ‖c‖ₑ ≠ 0 := enorm_ne_zero.mpr hc
   unfold distribution
@@ -611,7 +611,10 @@ lemma HasStrongType.const_mul {E' α α' : Type*} [NormedRing E']
     HasStrongType (fun f x ↦ e * T f x) p p' μ ν (‖e‖₊ * c) :=
   h.const_smul e
 
-lemma wnorm_const_smul_le {𝕜 E α : Type*} [NormedAddCommGroup E] {_x : MeasurableSpace α}
+variable [MulActionWithZero 𝕜 E] [IsBoundedSMul 𝕜 E]
+  -- [MulActionWithZero 𝕜 E₁] [IsBoundedSMul 𝕜 E₁] [MulActionWithZero 𝕜 E₂] [IsBoundedSMul 𝕜 E₂]
+
+lemma wnorm_const_smul_le {α : Type*} {_ : MeasurableSpace α}
     {p : ℝ≥0∞} (hp : p ≠ 0) {μ : Measure α} {f : α → E}
     [NontriviallyNormedField 𝕜] [MulActionWithZero 𝕜 E] [IsBoundedSMul 𝕜 E] (k : 𝕜) :
     wnorm (k • f) p μ ≤ ‖k‖₊ * wnorm f p μ := by

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -557,7 +557,7 @@ lemma distribution_add_le' {A : ℝ≥0∞} {g₁ g₂ : α → ε}
 lemma distribution_add_le {ε} [TopologicalSpace ε] [ENormedAddMonoid ε] {f g : α → ε} :
     distribution (f + g) (t + s) μ ≤ distribution f t μ + distribution g s μ :=
   calc
-    _ ≤ μ ({x | t < ↑‖f x‖ₑ} ∪ {x | s < ↑‖g x‖ₑ}) := by
+    _ ≤ μ ({x | t < ‖f x‖ₑ} ∪ {x | s < ‖g x‖ₑ}) := by
       refine measure_mono fun x h ↦ ?_
       simp only [mem_union, mem_setOf_eq, Pi.add_apply] at h ⊢
       contrapose! h

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -611,12 +611,13 @@ lemma HasStrongType.const_mul {E' α α' : Type*} [NormedRing E']
     HasStrongType (fun f x ↦ e * T f x) p p' μ ν (‖e‖₊ * c) :=
   h.const_smul e
 
-variable [MulActionWithZero 𝕜 E] [IsBoundedSMul 𝕜 E]
+--variable [MulActionWithZero 𝕜 E] [IsBoundedSMul 𝕜 E]
   -- [MulActionWithZero 𝕜 E₁] [IsBoundedSMul 𝕜 E₁] [MulActionWithZero 𝕜 E₂] [IsBoundedSMul 𝕜 E₂]
 
+omit [NontriviallyNormedField 𝕜] in
 lemma wnorm_const_smul_le {α : Type*} {_ : MeasurableSpace α}
     {p : ℝ≥0∞} (hp : p ≠ 0) {μ : Measure α} {f : α → E}
-    [NontriviallyNormedField 𝕜] [MulActionWithZero 𝕜 E] [IsBoundedSMul 𝕜 E] (k : 𝕜) :
+    [NontriviallyNormedField 𝕜] [NormedSpace 𝕜 E]  (k : 𝕜) :
     wnorm (k • f) p μ ≤ ‖k‖₊ * wnorm f p μ := by
     unfold wnorm
     by_cases ptop : p = ⊤
@@ -630,7 +631,7 @@ lemma wnorm_const_smul_le {α : Type*} {_ : MeasurableSpace α}
       intro _
       right
       exact toReal_pos hp ptop
-    simp [distribution_smul_left k_zero] -- change: this lemma doesn't fire any more, right?
+    simp [distribution_smul_left k_zero]
     intro t
     rw [ENNReal.mul_iSup]
     have knorm_ne_zero : ‖k‖₊ ≠ 0 := nnnorm_ne_zero_iff.mpr k_zero
@@ -640,24 +641,16 @@ lemma wnorm_const_smul_le {α : Type*} {_ : MeasurableSpace α}
       simp [mul_assoc]
       congr
       exact coe_div knorm_ne_zero
-    have : t * distribution (k • f) (t) μ ^ p.toReal⁻¹ =
-        ↑‖k‖₊ * ((↑t / ↑‖k‖₊) * distribution f (↑t / ↑‖k‖₊) μ ^ p.toReal⁻¹) := by
-      rw [← this]
-      congr 1
-      apply distribution_smul_left k_zero
-      sorry
-    rw [this]
+    erw [this]
     apply le_iSup_of_le (↑t / ↑‖k‖₊)
     apply le_of_eq
     congr <;> exact (coe_div knorm_ne_zero).symm
 
-#exit
-
 lemma HasWeakType.const_smul {𝕜 E' α α' : Type*} [NormedAddCommGroup E']
     {_x : MeasurableSpace α} {_x' : MeasurableSpace α'} {T : (α → ε) → (α' → E')}
     {p p' : ℝ≥0∞} (hp' : p' ≠ 0) {μ : Measure α} {ν : Measure α'} {c : ℝ≥0}
-    (h : HasWeakType T p p' μ ν c) [NontriviallyNormedField 𝕜] [MulActionWithZero 𝕜 E']
-    [IsBoundedSMul 𝕜 E'] (k : 𝕜) : HasWeakType (k • T) p p' μ ν (‖k‖₊ * c) := by
+    (h : HasWeakType T p p' μ ν c) [NontriviallyNormedField 𝕜] [NormedSpace 𝕜 E'] (k : 𝕜) :
+    HasWeakType (k • T) p p' μ ν (‖k‖₊ * c) := by
   intro f hf
   refine ⟨aestronglyMeasurable_const.smul (h f hf).1, ?_⟩
   calc wnorm ((k • T) f) p' ν
@@ -678,10 +671,8 @@ end
 
 
 
-variable [NormedSpace 𝕜 E] [NormedSpace 𝕜 E₁] [NormedSpace 𝕜 E₂] [NormedSpace 𝕜 E₃]
-  (L : E₁ →L[𝕜] E₂ →L[𝕜] E₃)
+variable (L : E₁ →L[𝕜] E₂ →L[𝕜] E₃)
 
--- TODO: reorganize variables so that everything makes sense
 lemma _root_.ContinuousLinearMap.distribution_le {f : α → E₁} {g : α → E₂} :
     distribution (fun x ↦ L (f x) (g x)) (‖L‖ₑ * t * s) μ ≤
     distribution f t μ + distribution g s μ := by

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -85,17 +85,7 @@ namespace MeasureTheory
 variable {α α' ε ε₁ ε₂ ε₃ 𝕜 E E₁ E₂ E₃ : Type*} {m : MeasurableSpace α} {m : MeasurableSpace α'}
   {p p' q : ℝ≥0∞} {c : ℝ≥0}
   {μ : Measure α} {ν : Measure α'} [NontriviallyNormedField 𝕜]
-  [NormedAddCommGroup E] [NormedSpace 𝕜 E]
-  --[MulActionWithZero 𝕜 E] [IsBoundedSMul 𝕜 E]
-  [NormedAddCommGroup E₁] [NormedSpace 𝕜 E₁]
- -- [MulActionWithZero 𝕜 E₁] [IsBoundedSMul 𝕜 E₁]
-  [NormedAddCommGroup E₂] [NormedSpace 𝕜 E₂]
-  --[MulActionWithZero 𝕜 E₂] [IsBoundedSMul 𝕜 E₂]
-  [NormedAddCommGroup E₃] [NormedSpace 𝕜 E₃]
-  --[MulActionWithZero 𝕜 E₃] [IsBoundedSMul 𝕜 E₃]
-  --(L : E₁ →L[𝕜] E₂ →L[𝕜] E₃)
-  {t s x y : ℝ≥0∞}
-  {T : (α → ε₁) → (α' → ε₂)}
+  {t s x y : ℝ≥0∞} {T : (α → ε₁) → (α' → ε₂)}
 
 section ENorm
 
@@ -586,8 +576,7 @@ section
 
 variable [TopologicalSpace ε] [ContinuousENorm ε]
 
-omit [NontriviallyNormedField 𝕜] [NormedSpace 𝕜 E]
-variable [NontriviallyNormedField 𝕜] [MulActionWithZero 𝕜 E] [IsBoundedSMul 𝕜 E]
+variable [NormedAddCommGroup E] [MulActionWithZero 𝕜 E] [IsBoundedSMul 𝕜 E]
   {E' : Type*} [NormedAddCommGroup E'] [MulActionWithZero 𝕜 E'] [IsBoundedSMul 𝕜 E']
 
 -- TODO: add an analogue for the ENorm context, using scalar multiplication w.r.t. `NNReal` on an `ENormedSpace`
@@ -665,6 +654,9 @@ lemma HasWeakType.const_mul {α α' : Type*}
 
 end
 
+variable [NormedAddCommGroup E₁] [NormedSpace 𝕜 E₁] [NormedAddCommGroup E₂] [NormedSpace 𝕜 E₂]
+  [NormedAddCommGroup E₃] [NormedSpace 𝕜 E₃]
+
 lemma _root_.ContinuousLinearMap.distribution_le {f : α → E₁} {g : α → E₂} (L : E₁ →L[𝕜] E₂ →L[𝕜] E₃) :
     distribution (fun x ↦ L (f x) (g x)) (‖L‖ₑ * t * s) μ ≤
     distribution f t μ + distribution g s μ := by
@@ -684,7 +676,8 @@ lemma _root_.ContinuousLinearMap.distribution_le {f : α → E₁} {g : α → E
 
 section BorelSpace
 
-variable [TopologicalSpace ε] [ContinuousENorm ε] [MeasurableSpace E] [BorelSpace E]
+variable [TopologicalSpace ε] [ContinuousENorm ε]
+  [MeasurableSpace E] [NormedAddCommGroup E] [BorelSpace E]
 
 /-- The layer-cake theorem, or Cavalieri's principle for functions into a normed group. -/
 lemma lintegral_norm_pow_eq_distribution {f : α → E} (hf : AEMeasurable f μ) {p : ℝ} (hp : 0 < p) :

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -582,6 +582,7 @@ section NormedGroup
 
 variable {f g : α → ε}
 section
+
 variable [TopologicalSpace ε] [ContinuousENorm ε]
 
 -- TODO: add an analogue for the ENorm context, using scalar multiplication w.r.t. `NNReal` on an `ENormedSpace`
@@ -612,7 +613,7 @@ lemma HasStrongType.const_mul {E' α α' : Type*} [NormedRing E']
   h.const_smul e
 
 lemma wnorm_const_smul_le {α : Type*} {_ : MeasurableSpace α} {p : ℝ≥0∞} (hp : p ≠ 0)
-    {μ : Measure α} {f : α → E} (k : 𝕜) : wnorm (k • f) p μ ≤ ‖k‖₊ * wnorm f p μ := by
+    {μ : Measure α} {f : α → E} (k : 𝕜) : wnorm (k • f) p μ ≤ ‖k‖ₑ * wnorm f p μ := by
   by_cases ptop : p = ⊤
   · simp [ptop]
     apply eLpNormEssSup_const_smul_le
@@ -628,8 +629,8 @@ lemma wnorm_const_smul_le {α : Type*} {_ : MeasurableSpace α} {p : ℝ≥0∞}
   intro t
   rw [ENNReal.mul_iSup]
   have knorm_ne_zero : ‖k‖₊ ≠ 0 := nnnorm_ne_zero_iff.mpr k_zero
-  have : ↑t * distribution f (↑t / ↑‖k‖₊) μ ^ p.toReal⁻¹ =
-    ↑‖k‖₊ * ((↑t / ↑‖k‖₊) * distribution f (↑t / ↑‖k‖₊) μ ^ p.toReal⁻¹) := by
+  have : t * distribution f (t / ‖k‖ₑ) μ ^ p.toReal⁻¹ =
+    ‖k‖ₑ * ((t / ‖k‖ₑ) * distribution f (t / ‖k‖ₑ) μ ^ p.toReal⁻¹) := by
     nth_rewrite 1 [← mul_div_cancel₀ t knorm_ne_zero]
     simp [mul_assoc]
     congr
@@ -647,11 +648,11 @@ lemma HasWeakType.const_smul {𝕜 E' α α' : Type*} [NormedAddCommGroup E']
   intro f hf
   refine ⟨aestronglyMeasurable_const.smul (h f hf).1, ?_⟩
   calc wnorm ((k • T) f) p' ν
-    _ ≤ ↑‖k‖₊ * wnorm (T f) p' ν := by simp [wnorm_const_smul_le hp']
-    _ ≤ ↑‖k‖₊ * (c * eLpNorm f p μ) := by
+    _ ≤ ‖k‖ₑ * wnorm (T f) p' ν := by simp [wnorm_const_smul_le hp']
+    _ ≤ ‖k‖ₑ * (c * eLpNorm f p μ) := by
       gcongr
       apply (h f hf).2
-    _ = ↑(‖k‖₊ * c) * eLpNorm f p μ := by simp [coe_mul, mul_assoc]
+    _ = (‖k‖ₑ * c) * eLpNorm f p μ := by simp [coe_mul, mul_assoc]
 
 
 lemma HasWeakType.const_mul {E' α α' : Type*} [NontriviallyNormedField E']

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -630,7 +630,7 @@ lemma wnorm_const_smul_le {α : Type*} {_ : MeasurableSpace α}
       intro _
       right
       exact toReal_pos hp ptop
-    simp [distribution_smul_left k_zero]
+    simp [distribution_smul_left k_zero] -- change: this lemma doesn't fire any more, right?
     intro t
     rw [ENNReal.mul_iSup]
     have knorm_ne_zero : ‖k‖₊ ≠ 0 := nnnorm_ne_zero_iff.mpr k_zero
@@ -640,10 +640,18 @@ lemma wnorm_const_smul_le {α : Type*} {_ : MeasurableSpace α}
       simp [mul_assoc]
       congr
       exact coe_div knorm_ne_zero
+    have : t * distribution (k • f) (t) μ ^ p.toReal⁻¹ =
+        ↑‖k‖₊ * ((↑t / ↑‖k‖₊) * distribution f (↑t / ↑‖k‖₊) μ ^ p.toReal⁻¹) := by
+      rw [← this]
+      congr 1
+      apply distribution_smul_left k_zero
+      sorry
     rw [this]
     apply le_iSup_of_le (↑t / ↑‖k‖₊)
     apply le_of_eq
     congr <;> exact (coe_div knorm_ne_zero).symm
+
+#exit
 
 lemma HasWeakType.const_smul {𝕜 E' α α' : Type*} [NormedAddCommGroup E']
     {_x : MeasurableSpace α} {_x' : MeasurableSpace α'} {T : (α → ε) → (α' → E')}

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -660,12 +660,12 @@ lemma HasWeakType.const_smul {𝕜 E' α α' : Type*} [NormedAddCommGroup E']
     [IsBoundedSMul 𝕜 E'] (k : 𝕜) : HasWeakType (k • T) p p' μ ν (‖k‖₊ * c) := by
   intro f hf
   refine ⟨aestronglyMeasurable_const.smul (h f hf).1, ?_⟩
-  calc
-    wnorm ((k • T) f) p' ν ≤ ↑‖k‖₊ * wnorm (T f) p' ν := by simp[wnorm_const_smul_le hp']
-    _                      ≤ ↑‖k‖₊ * (c * eLpNorm f p μ) := by
+  calc wnorm ((k • T) f) p' ν
+    _ ≤ ↑‖k‖₊ * wnorm (T f) p' ν := by simp [wnorm_const_smul_le hp']
+    _ ≤ ↑‖k‖₊ * (c * eLpNorm f p μ) := by
       gcongr
       apply (h f hf).2
-    _                      = ↑(‖k‖₊ * c) * eLpNorm f p μ := by simp [coe_mul, mul_assoc]
+    _ = ↑(‖k‖₊ * c) * eLpNorm f p μ := by simp [coe_mul, mul_assoc]
 
 
 lemma HasWeakType.const_mul {E' α α' : Type*} [NontriviallyNormedField E']

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -611,40 +611,33 @@ lemma HasStrongType.const_mul {E' α α' : Type*} [NormedRing E']
     HasStrongType (fun f x ↦ e * T f x) p p' μ ν (‖e‖₊ * c) :=
   h.const_smul e
 
---variable [MulActionWithZero 𝕜 E] [IsBoundedSMul 𝕜 E]
-  -- [MulActionWithZero 𝕜 E₁] [IsBoundedSMul 𝕜 E₁] [MulActionWithZero 𝕜 E₂] [IsBoundedSMul 𝕜 E₂]
-
-omit [NontriviallyNormedField 𝕜] in
-lemma wnorm_const_smul_le {α : Type*} {_ : MeasurableSpace α}
-    {p : ℝ≥0∞} (hp : p ≠ 0) {μ : Measure α} {f : α → E}
-    [NontriviallyNormedField 𝕜] [NormedSpace 𝕜 E]  (k : 𝕜) :
-    wnorm (k • f) p μ ≤ ‖k‖₊ * wnorm f p μ := by
-    unfold wnorm
-    by_cases ptop : p = ⊤
-    · simp [ptop]
-      apply eLpNormEssSup_const_smul_le
-    simp [ptop]
-    unfold wnorm'
-    by_cases k_zero : k = 0
-    · unfold distribution
-      simp [k_zero]
-      intro _
-      right
-      exact toReal_pos hp ptop
-    simp [distribution_smul_left k_zero]
-    intro t
-    rw [ENNReal.mul_iSup]
-    have knorm_ne_zero : ‖k‖₊ ≠ 0 := nnnorm_ne_zero_iff.mpr k_zero
-    have : ↑t * distribution f (↑t / ↑‖k‖₊) μ ^ p.toReal⁻¹ =
-      ↑‖k‖₊ * ((↑t / ↑‖k‖₊) * distribution f (↑t / ↑‖k‖₊) μ ^ p.toReal⁻¹) := by
-      nth_rewrite 1 [← mul_div_cancel₀ t knorm_ne_zero]
-      simp [mul_assoc]
-      congr
-      exact coe_div knorm_ne_zero
-    erw [this]
-    apply le_iSup_of_le (↑t / ↑‖k‖₊)
-    apply le_of_eq
-    congr <;> exact (coe_div knorm_ne_zero).symm
+lemma wnorm_const_smul_le {α : Type*} {_ : MeasurableSpace α} {p : ℝ≥0∞} (hp : p ≠ 0)
+    {μ : Measure α} {f : α → E} (k : 𝕜) : wnorm (k • f) p μ ≤ ‖k‖₊ * wnorm f p μ := by
+  by_cases ptop : p = ⊤
+  · simp [ptop]
+    apply eLpNormEssSup_const_smul_le
+  simp [wnorm, ptop]
+  unfold wnorm'
+  by_cases k_zero : k = 0
+  · unfold distribution
+    simp [k_zero]
+    intro _
+    right
+    exact toReal_pos hp ptop
+  simp [distribution_smul_left k_zero]
+  intro t
+  rw [ENNReal.mul_iSup]
+  have knorm_ne_zero : ‖k‖₊ ≠ 0 := nnnorm_ne_zero_iff.mpr k_zero
+  have : ↑t * distribution f (↑t / ↑‖k‖₊) μ ^ p.toReal⁻¹ =
+    ↑‖k‖₊ * ((↑t / ↑‖k‖₊) * distribution f (↑t / ↑‖k‖₊) μ ^ p.toReal⁻¹) := by
+    nth_rewrite 1 [← mul_div_cancel₀ t knorm_ne_zero]
+    simp [mul_assoc]
+    congr
+    exact coe_div knorm_ne_zero
+  erw [this]
+  apply le_iSup_of_le (↑t / ↑‖k‖₊)
+  apply le_of_eq
+  congr <;> exact (coe_div knorm_ne_zero).symm
 
 lemma HasWeakType.const_smul {𝕜 E' α α' : Type*} [NormedAddCommGroup E']
     {_x : MeasurableSpace α} {_x' : MeasurableSpace α'} {T : (α → ε) → (α' → E')}

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -14,15 +14,14 @@ section move
 
 variable {α 𝕜 E : Type*} {m : MeasurableSpace α}
   {μ : Measure α} [NontriviallyNormedField 𝕜]
-  [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  [NormedAddCommGroup E] [MulActionWithZero 𝕜 E] [IsBoundedSMul 𝕜 E]
   {p : ℝ≥0∞}
 
 -- todo: move/rename/and perhaps reformulate in terms of ‖.‖ₑ
 lemma ENNNorm_absolute_homogeneous {c : 𝕜} (z : E) : ofNNReal ‖c • z‖₊ = ↑‖c‖₊ * ↑‖z‖₊ :=
   (toReal_eq_toReal_iff' coe_ne_top coe_ne_top).mp (norm_smul c z)
 
-
-lemma enorm_absolute_homogeneous {𝕜 : Type*} [NontriviallyNormedField 𝕜] [MulActionWithZero 𝕜 E] [IsBoundedSMul 𝕜 E] {c : 𝕜} (z : E) : ‖c • z‖ₑ = ‖c‖ₑ * ‖z‖ₑ :=
+lemma enorm_absolute_homogeneous {c : 𝕜} (z : E) : ‖c • z‖ₑ = ‖c‖ₑ * ‖z‖ₑ :=
   (toReal_eq_toReal_iff' coe_ne_top coe_ne_top).mp (norm_smul c z)
 
 lemma ENNNorm_add_le (y z : E) : ofNNReal ‖y + z‖₊ ≤ ↑‖y‖₊ + ↑‖z‖₊ :=

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -623,8 +623,7 @@ lemma wnorm_const_smul_le {α : Type*} {_ : MeasurableSpace α} {p : ℝ≥0∞}
   by_cases ptop : p = ⊤
   · simp [ptop]
     apply eLpNormEssSup_const_smul_le
-  simp [wnorm, ptop]
-  unfold wnorm'
+  simp [wnorm, ptop, wnorm']
   by_cases k_zero : k = 0
   · unfold distribution
     simp [k_zero]
@@ -670,7 +669,6 @@ end
 lemma _root_.ContinuousLinearMap.distribution_le {f : α → E₁} {g : α → E₂} (L : E₁ →L[𝕜] E₂ →L[𝕜] E₃) :
     distribution (fun x ↦ L (f x) (g x)) (‖L‖ₑ * t * s) μ ≤
     distribution f t μ + distribution g s μ := by
-  unfold distribution
   have h₀ : {x | ‖L‖ₑ * t * s < ‖(fun x ↦ (L (f x)) (g x)) x‖ₑ} ⊆
       {x | t < ‖f x‖ₑ} ∪ {x | s < ‖g x‖ₑ} := fun z hz ↦ by
     simp only [mem_union, mem_setOf_eq, Pi.add_apply] at hz ⊢

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -21,7 +21,8 @@ variable {α 𝕜 E : Type*} {m : MeasurableSpace α}
 lemma ENNNorm_absolute_homogeneous {c : 𝕜} (z : E) : ofNNReal ‖c • z‖₊ = ↑‖c‖₊ * ↑‖z‖₊ :=
   (toReal_eq_toReal_iff' coe_ne_top coe_ne_top).mp (norm_smul c z)
 
-lemma enorm_absolute_homogeneous {c : 𝕜} (z : E) : ‖c • z‖ₑ = ‖c‖ₑ * ‖z‖ₑ :=
+
+lemma enorm_absolute_homogeneous {𝕜 : Type*} [NontriviallyNormedField 𝕜] [MulActionWithZero 𝕜 E] [IsBoundedSMul 𝕜 E] {c : 𝕜} (z : E) : ‖c • z‖ₑ = ‖c‖ₑ * ‖z‖ₑ :=
   (toReal_eq_toReal_iff' coe_ne_top coe_ne_top).mp (norm_smul c z)
 
 lemma ENNNorm_add_le (y z : E) : ofNNReal ‖y + z‖₊ ≤ ↑‖y‖₊ + ↑‖z‖₊ :=
@@ -581,9 +582,14 @@ end ContinuousENorm
 section NormedGroup
 
 variable {f g : α → ε}
+
 section
 
 variable [TopologicalSpace ε] [ContinuousENorm ε]
+
+omit [NontriviallyNormedField 𝕜] [NormedSpace 𝕜 E]
+variable [NontriviallyNormedField 𝕜] [MulActionWithZero 𝕜 E] [IsBoundedSMul 𝕜 E]
+  {E' : Type*} [NormedAddCommGroup E'] [MulActionWithZero 𝕜 E'] [IsBoundedSMul 𝕜 E']
 
 -- TODO: add an analogue for the ENorm context, using scalar multiplication w.r.t. `NNReal` on an `ENormedSpace`
 
@@ -596,10 +602,10 @@ lemma distribution_smul_left {f : α → E} {c : 𝕜} (hc : c ≠ 0) :
   rw [← @ENNReal.mul_lt_mul_right (t / ‖c‖ₑ) _ (‖c‖ₑ) h₀ coe_ne_top,
     enorm_absolute_homogeneous _, mul_comm, ENNReal.div_mul_cancel h₀ coe_ne_top]
 
-lemma HasStrongType.const_smul {𝕜 E' α α' : Type*} [NormedAddCommGroup E']
-    {_x : MeasurableSpace α} {_x' : MeasurableSpace α'} {T : (α → ε) → (α' → E')}
-    {p p' : ℝ≥0∞} {μ : Measure α} {ν : Measure α'} {c : ℝ≥0} (h : HasStrongType T p p' μ ν c)
-    [NormedRing 𝕜] [MulActionWithZero 𝕜 E'] [IsBoundedSMul 𝕜 E'] (k : 𝕜) :
+variable {𝕜 E' : Type*} [NormedRing 𝕜] [NormedAddCommGroup E'] [MulActionWithZero 𝕜 E'] [IsBoundedSMul 𝕜 E'] in
+lemma HasStrongType.const_smul {α α' : Type*} {_x : MeasurableSpace α} {_x' : MeasurableSpace α'}
+    {T : (α → ε) → (α' → E')} {p p' : ℝ≥0∞} {μ : Measure α} {ν : Measure α'} {c : ℝ≥0}
+    (h : HasStrongType T p p' μ ν c) (k : 𝕜) :
     HasStrongType (k • T) p p' μ ν (‖k‖₊ * c) := by
   refine fun f hf ↦ ⟨AEStronglyMeasurable.const_smul (h f hf).1 k, eLpNorm_const_smul_le.trans ?_⟩
   simp only [ENNReal.smul_def, smul_eq_mul, coe_mul, mul_assoc]
@@ -640,10 +646,9 @@ lemma wnorm_const_smul_le {α : Type*} {_ : MeasurableSpace α} {p : ℝ≥0∞}
   apply le_of_eq
   congr <;> exact (coe_div knorm_ne_zero).symm
 
-lemma HasWeakType.const_smul {𝕜 E' α α' : Type*} [NormedAddCommGroup E']
-    {_x : MeasurableSpace α} {_x' : MeasurableSpace α'} {T : (α → ε) → (α' → E')}
-    {p p' : ℝ≥0∞} (hp' : p' ≠ 0) {μ : Measure α} {ν : Measure α'} {c : ℝ≥0}
-    (h : HasWeakType T p p' μ ν c) [NontriviallyNormedField 𝕜] [NormedSpace 𝕜 E'] (k : 𝕜) :
+lemma HasWeakType.const_smul {α α' : Type*} {_x : MeasurableSpace α} {_x' : MeasurableSpace α'}
+    {T : (α → ε) → (α' → E')} {p p' : ℝ≥0∞} (hp' : p' ≠ 0) {μ : Measure α} {ν : Measure α'}
+    {c : ℝ≥0} (h : HasWeakType T p p' μ ν c) (k : 𝕜) :
     HasWeakType (k • T) p p' μ ν (‖k‖₊ * c) := by
   intro f hf
   refine ⟨aestronglyMeasurable_const.smul (h f hf).1, ?_⟩

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -564,7 +564,7 @@ lemma distribution_add_le' {A : ℝ≥0∞} {g₁ g₂ : α → ε}
   apply distribution_add_le_of_enorm
   simp (discharger := positivity) [← ofReal_mul, ← ofReal_add, h]
 
-lemma distribution_add_le [TopologicalSpace ε] [ENormedAddMonoid ε] :
+lemma distribution_add_le {ε} [TopologicalSpace ε] [ENormedAddMonoid ε] {f g : α → ε} :
     distribution (f + g) (t + s) μ ≤ distribution f t μ + distribution g s μ :=
   calc
     _ ≤ μ ({x | t < ↑‖f x‖ₑ} ∪ {x | s < ↑‖g x‖ₑ}) := by

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -659,20 +659,15 @@ lemma HasWeakType.const_smul {α α' : Type*} {_x : MeasurableSpace α} {_x' : M
       apply (h f hf).2
     _ = (‖k‖ₑ * c) * eLpNorm f p μ := by simp [coe_mul, mul_assoc]
 
-
-lemma HasWeakType.const_mul {E' α α' : Type*} [NontriviallyNormedField E']
-    {_x : MeasurableSpace α} {_x' : MeasurableSpace α'} {T : (α → ε) → (α' → E')} {p p' : ℝ≥0∞}
-    (hp' : p' ≠ 0) {μ : Measure α} {ν : Measure α'} {c : ℝ≥0} (h : HasWeakType T p p' μ ν c) (e : E') :
+lemma HasWeakType.const_mul {α α' : Type*}
+    {_x : MeasurableSpace α} {_x' : MeasurableSpace α'} {T : (α → ε) → (α' → 𝕜)} {p p' : ℝ≥0∞}
+    (hp' : p' ≠ 0) {μ : Measure α} {ν : Measure α'} {c : ℝ≥0} (h : HasWeakType T p p' μ ν c) (e : 𝕜) :
     HasWeakType (fun f x ↦ e * T f x) p p' μ ν (‖e‖₊ * c) :=
   h.const_smul hp' e
 
 end
 
-
-
-variable (L : E₁ →L[𝕜] E₂ →L[𝕜] E₃)
-
-lemma _root_.ContinuousLinearMap.distribution_le {f : α → E₁} {g : α → E₂} :
+lemma _root_.ContinuousLinearMap.distribution_le {f : α → E₁} {g : α → E₂} (L : E₁ →L[𝕜] E₂ →L[𝕜] E₃) :
     distribution (fun x ↦ L (f x) (g x)) (‖L‖ₑ * t * s) μ ≤
     distribution f t μ + distribution g s μ := by
   unfold distribution
@@ -681,8 +676,7 @@ lemma _root_.ContinuousLinearMap.distribution_le {f : α → E₁} {g : α → E
     simp only [mem_union, mem_setOf_eq, Pi.add_apply] at hz ⊢
     contrapose! hz
     calc
-      ‖(L (f z)) (g z)‖ₑ ≤ ‖L‖ₑ * ‖f z‖ₑ * ‖g z‖ₑ := by
-        calc
+      ‖(L (f z)) (g z)‖ₑ ≤ ‖L‖ₑ * ‖f z‖ₑ * ‖g z‖ₑ := by calc
           _ ≤ ‖L (f z)‖ₑ * ‖g z‖ₑ := ContinuousLinearMap.le_opENorm (L (f z)) (g z)
           _ ≤ ‖L‖ₑ * ‖f z‖ₑ * ‖g z‖ₑ :=
             mul_le_mul' (ContinuousLinearMap.le_opENorm L (f z)) (by rfl)


### PR DESCRIPTION
Clean-ups on top of #275: remove unintentional changes, align style more with mathlib and clean up the variable blocks. Now, each theorem only asks for the minimal necessary typeclass assumptions, and it is clear which theorems require normed spaces and which ones don't.

All in all, #275 and this PR together
- correct the statement of HasWeakType.const_mul (which only holds for `p' ≠ 0`)
- completes the proof of `HasWeakType.const_mul`
- weaken the hypotheses in this file: many lemmas only require `[MulActionWithZero 𝕜 E] [IsBoundedSMul 𝕜 E]` and not `[NormedSpace 𝕜 E]`