### PR TITLE
chore(lakefile.toml): remove moreLeanArgs

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -24,4 +24,3 @@ rev = "master"
 
 [[lean_lib]]
 name = "Carleson"
-moreLeanArgs = ["-Dpp.unicode.fun=true", "-DautoImplicit=false", "-DrelaxedAutoImplicit=false"]


### PR DESCRIPTION
This is cargo-culted by matching [mathlib4/#23667](https://github.com/leanprover-community/mathlib4/pull/23667).