### PR TITLE
chore(RealInterpolation): small golfs

### DIFF
--- a/Carleson/ToMathlib/RealInterpolation.lean
+++ b/Carleson/ToMathlib/RealInterpolation.lean
@@ -1401,9 +1401,8 @@ protected lemma StronglyMeasurable.truncCompl
   exact hf.ite (measurableSet_lt stronglyMeasurable_const hf.norm) stronglyMeasurable_const
 
 -- @[measurability, fun_prop]
--- lemma aemeasurable_trunc [MeasurableSpace E₁] [NormedAddCommGroup E₁] [BorelSpace E₁]
---     (hf : AEMeasurable f μ) :
---     AEMeasurable (trunc f t) μ := by
+-- lemma AEMeasurable.trunc [MeasurableSpace E₁] [NormedAddCommGroup E₁] [BorelSpace E₁]
+--     (hf : AEMeasurable f μ) : AEMeasurable (trunc f t) μ := by
 --   rcases hf with ⟨g, ⟨wg1, wg2⟩⟩
 --   exists (trunc g t)
 --   constructor
@@ -1418,9 +1417,8 @@ protected lemma StronglyMeasurable.truncCompl
 --   rfl
 
 -- @[measurability, fun_prop]
--- lemma aeMeasurable_truncCompl [MeasurableSpace E₁] [NormedAddCommGroup E₁] [BorelSpace E₁]
---     (hf : AEMeasurable f μ) :
---     AEMeasurable (truncCompl f t) μ := by
+-- lemma AEMeasurable.truncCompl [MeasurableSpace E₁] [NormedAddCommGroup E₁] [BorelSpace E₁]
+--     (hf : AEMeasurable f μ) : AEMeasurable (truncCompl f t) μ := by
 --   rcases hf with ⟨g, ⟨wg1, wg2⟩⟩
 --   exists (truncCompl g t)
 --   constructor
@@ -2315,7 +2313,7 @@ lemma indicator_ton_measurable_lt {g : α → E₁} [MeasurableSpace E₁] [Norm
   nullMeasurableSet_lt (ton_aeMeasurable tc).fst hg.snd.norm
 
 @[measurability]
-lemma truncation_ton_measurable {f : α → E₁}
+lemma AEMeasurable.trunc_ton {f : α → E₁}
     [MeasurableSpace E₁] [NormedAddCommGroup E₁] [BorelSpace E₁]
     [SigmaFinite (μ.restrict (Function.support f))] -- TODO: TypeClass or implicit variable?
     (hf : AEMeasurable f μ) (tc : ToneCouple) :
@@ -2330,7 +2328,7 @@ lemma truncation_ton_measurable {f : α → E₁}
     hf.restrict.snd.restrict
 
 @[measurability]
-lemma aeMeasurable_truncCompl_ton {f : α → E₁}
+lemma AEMeasurable.truncCompl_ton {f : α → E₁}
     [MeasurableSpace E₁] [NormedAddCommGroup E₁] [BorelSpace E₁]
     [SigmaFinite (μ.restrict (Function.support f))] -- TODO: TypeClass or implicit variable?
     (hf : AEMeasurable f μ) (tc : ToneCouple) :
@@ -2380,14 +2378,12 @@ lemma restrict_to_support_trnc {p : ℝ} {j : Bool} [NormedAddCommGroup E₁] (h
   · simp_rw [f_zero]; simp [hp]
 
 @[fun_prop]
-theorem aeMeasurable_trunc_restrict
+theorem AEMeasurable.trunc_restrict
     [MeasurableSpace E₁] [NormedAddCommGroup E₁] [BorelSpace E₁] {j : Bool}
     {hμ : SigmaFinite (μ.restrict (Function.support f))} (hf : AEMeasurable f μ) (tc : ToneCouple) :
     AEMeasurable (fun a ↦ trnc j f (tc.ton a.1) a.2)
-      ((volume.restrict (Ioi 0)).prod (μ.restrict (Function.support f))) := by
-  rcases j
-  · exact aeMeasurable_truncCompl_ton hf _
-  · exact truncation_ton_measurable hf _
+      ((volume.restrict (Ioi 0)).prod (μ.restrict (Function.support f))) :=
+  j.rec (hf.truncCompl_ton _) (hf.trunc_ton _)
 
 lemma lintegral_lintegral_pow_swap_truncCompl {q q₀ p₀ : ℝ} [MeasurableSpace E₁]
     [NormedAddCommGroup E₁]

--- a/Carleson/ToMathlib/RealInterpolation.lean
+++ b/Carleson/ToMathlib/RealInterpolation.lean
@@ -1434,9 +1434,8 @@ protected lemma StronglyMeasurable.truncCompl
 --     intro f_eq_g; unfold truncCompl; unfold trunc; dsimp only [Pi.sub_apply]; rw [f_eq_g]
 
 @[measurability]
-lemma aestronglyMeasurable_trunc
-    (hf : AEStronglyMeasurable f μ) :
-    AEStronglyMeasurable (trunc f t) μ := by
+nonrec lemma AEStronglyMeasurable.trunc
+    (hf : AEStronglyMeasurable f μ) : AEStronglyMeasurable (trunc f t) μ := by
   rcases hf with ⟨g, ⟨wg1, wg2⟩⟩
   exists (trunc g t)
   constructor
@@ -1449,30 +1448,15 @@ lemma aestronglyMeasurable_trunc
     rw [h₂]
 
 @[measurability]
-lemma aestronglyMeasurable_truncCompl
-    (hf : AEStronglyMeasurable f μ) :
-    AEStronglyMeasurable (truncCompl f t) μ := by
-  rcases hf with ⟨g, ⟨wg1, wg2⟩⟩
-  use truncCompl g t
-  constructor
-  · rw [truncCompl_eq]
-    exact wg1.indicator (s := {x | t < ‖g x‖}) (stronglyMeasurable_const.measurableSet_lt wg1.norm)
-  · apply measure_mono_null ?_ wg2
-    intro x
-    contrapose
-    simp only [mem_compl_iff, mem_setOf_eq, not_not]
-    intro h₂
-    rw [truncCompl_eq, truncCompl_eq]
-    simp only
-    rw [h₂]
+nonrec lemma AEStronglyMeasurable.truncCompl
+    (hf : AEStronglyMeasurable f μ) : AEStronglyMeasurable (truncCompl f t) μ := by
+  simp_rw [truncCompl]; exact hf.sub hf.trunc
 
 @[measurability]
 lemma aestronglyMeasurable_trnc {j : Bool}
     (hf : AEStronglyMeasurable f μ) :
-    AEStronglyMeasurable (trnc j f t) μ := by
-  rcases j
-  · exact aestronglyMeasurable_truncCompl hf
-  · exact aestronglyMeasurable_trunc hf
+    AEStronglyMeasurable (trnc j f t) μ :=
+  j.rec (.truncCompl hf) (.trunc hf)
 
 lemma trunc_le {f : α → E₁} {a : ℝ} (x : α) :
     ‖trunc f a x‖ ≤ max 0 a := by
@@ -1553,7 +1537,7 @@ lemma trnc_le_func {j : Bool} {f : α → E₁} {a : ℝ} {x : α} :
 
 -- /-- The `t`-truncation of `f : α →ₘ[μ] E`. -/
 -- def AEEqFun.trunc (f : α →ₘ[μ] E) (t : ℝ) : α →ₘ[μ] E :=
---   AEEqFun.mk (trunc f t) (aestronglyMeasurable_trunc f.aestronglyMeasurable)
+--   AEEqFun.mk (trunc f t) (.trunc f.aestronglyMeasurable)
 
 -- /-- A set of measurable functions is closed under truncation. -/
 -- class IsClosedUnderTruncation (U : Set (α →ₘ[μ] E)) : Prop where
@@ -1609,7 +1593,7 @@ lemma rpow_le_rpow_of_exponent_le_base_ge {a b t γ : ℝ} (hγ : γ > 0) (htγ 
     exact ofReal_le_ofReal (Real.rpow_le_rpow_of_exponent_le ((one_le_div hγ).mpr htγ) hab)
 
 lemma trunc_preserves_Lp {p : ℝ≥0∞} (hf : MemLp f p μ) : MemLp (trunc f t) p μ := by
-  refine ⟨aestronglyMeasurable_trunc hf.1, lt_of_le_of_lt (eLpNorm_mono_ae (ae_of_all _ ?_)) hf.2⟩
+  refine ⟨hf.1.trunc, lt_of_le_of_lt (eLpNorm_mono_ae (ae_of_all _ ?_)) hf.2⟩
   intro x
   unfold trunc
   split_ifs with is_fx_le_a <;> simp
@@ -2852,8 +2836,7 @@ lemma weaktype_estimate_truncCompl_top {C₀ : ℝ≥0} (hC₀ : C₀ > 0) {p p�
       rw [← snorm_zero]
       exact eLpNorm_trnc_est (p := ⊤)
     have obs : eLpNorm (T (trnc ⊥ f a)) ⊤ ν = 0 :=
-      weaktype_aux₀ hp₀ (hq₀ ▸ zero_lt_top) zero_lt_top zero_lt_top h₀T
-        (aestronglyMeasurable_truncCompl hf.1) this
+      weaktype_aux₀ hp₀ (hq₀ ▸ zero_lt_top) zero_lt_top zero_lt_top h₀T hf.1.truncCompl this
     exact nonpos_iff_eq_zero.mp (Trans.trans (distribution_mono_right (Trans.trans obs
       (zero_le (ENNReal.ofReal t)))) meas_eLpNormEssSup_lt)
   · have p_pos : p > 0 := lt_trans hp₀ hp₀p


### PR DESCRIPTION
- Rename aestronglyMeasurable_trunc{Compl} to AEStronglyMeasurable.trunc{Compl}.
This enables dot notation (and matches their content). Do the same for three more lemmas not in #209.
- Golf the proof of .truncCompl.

Extracted from/inspired by #209; reducing the diff in MR-cleanup-realinterpolation2.