### PR TITLE
feat(WeakType): generalise most remaining lemmas to enorm

### DIFF
--- a/Carleson/ToMathlib/HardyLittlewood.lean
+++ b/Carleson/ToMathlib/HardyLittlewood.lean
@@ -521,8 +521,6 @@ theorem hasStrongType_globalMaximalFunction [BorelSpace X] [IsFiniteMeasureOnCom
     [Nonempty X] [μ.IsOpenPosMeasure] {p₁ p₂ : ℝ≥0} (hp₁ : 1 ≤ p₁) (hp₁₂ : p₁ < p₂) :
     HasStrongType (fun (u : X → E) (x : X) ↦ globalMaximalFunction μ p₁ u x)
       p₂ p₂ μ μ (C2_0_6' A p₁ p₂) := by
-  unfold globalMaximalFunction
-  simp_rw [C2_0_6']
   convert HasStrongType.const_mul (c := C2_0_6 A p₁ p₂) _ _
   · sorry -- how to prevent this diamond?
   · sorry -- missing instance, right?

--- a/Carleson/ToMathlib/HardyLittlewood.lean
+++ b/Carleson/ToMathlib/HardyLittlewood.lean
@@ -529,23 +529,25 @@ theorem hasStrongType_globalMaximalFunction [BorelSpace X] [IsFiniteMeasureOnCom
   -- figure out what's going wrong here!
   all_goals sorry
 
-theorem hasWeakType_globalMaximalFunction [ENormedSpace E] [BorelSpace X] [IsFiniteMeasureOnCompacts μ]
+theorem hasWeakType_globalMaximalFunction [BorelSpace X] [IsFiniteMeasureOnCompacts μ]
     [Nonempty X] [μ.IsOpenPosMeasure] {p₁ p₂ : ℝ≥0} (hp₁ : 1 ≤ p₁) (hp₁₂ : p₁ ≤ p₂) :
     HasWeakType (fun (u : X → E) (x : X) ↦ globalMaximalFunction μ p₁ u x)
       p₂ p₂ μ μ (A ^ 4) := by
-  rw [← hasWeakType_toReal_iff sorry /- todo: cleanup (task 117). -/]
-  unfold globalMaximalFunction
-  simp_rw [ENNReal.toReal_mul]
+  -- rw [← hasWeakType_toReal_iff sorry /- todo: cleanup (task 117). -/]
+  -- unfold globalMaximalFunction
+  -- simp_rw [ENNReal.toReal_mul]
   have : ofNNReal p₂ ≠ 0 := by -- surely, there is a simpler proof
     refine coe_ne_zero.mpr ?_
     have : 1 ≤ p₂ := by
       trans p₁
       exacts [hp₁, hp₁₂]
     positivity
-  apply HasWeakType.const_mul (c := A ^ 2) (e := A ^ 2) (p' := p₂) (μ := μ) (ν := μ) (p := p₂)
-    (ε := E) this _
+  sorry
+  /- TODO: fix this proof (currently times out), was:
+  apply HasWeakType.const_mul (c := A ^ 2) (e := A ^ 2) (p' := p₂) (μ := μ) (ν := μ) (p := p₂) this _
+  -- perhaps specify (ε := E) also
   · simp; ring
-  exact hasWeakType_maximalFunction countable_globalMaximalFunction hp₁ hp₁₂ |>.toReal
+  exact hasWeakType_maximalFunction countable_globalMaximalFunction hp₁ hp₁₂ -/
 
 /-- Use `lowerSemiContinuous_MB` -/
 lemma lowerSemiContinuous_globalMaximalFunction (hf : LocallyIntegrable f μ) :

--- a/Carleson/ToMathlib/HardyLittlewood.lean
+++ b/Carleson/ToMathlib/HardyLittlewood.lean
@@ -521,33 +521,20 @@ theorem hasStrongType_globalMaximalFunction [BorelSpace X] [IsFiniteMeasureOnCom
     [Nonempty X] [μ.IsOpenPosMeasure] {p₁ p₂ : ℝ≥0} (hp₁ : 1 ≤ p₁) (hp₁₂ : p₁ < p₂) :
     HasStrongType (fun (u : X → E) (x : X) ↦ globalMaximalFunction μ p₁ u x)
       p₂ p₂ μ μ (C2_0_6' A p₁ p₂) := by
-  convert HasStrongType.const_mul (c := C2_0_6 A p₁ p₂) _ _
-  · sorry -- how to prevent this diamond?
-  · sorry -- missing instance, right?
-  convert hasStrongType_maximalFunction_todo countable_globalMaximalFunction hp₁ hp₁₂
-  -- TODO: all these goals are "obvious", there is always a matching instance in context
-  -- figure out what's going wrong here!
-  all_goals sorry
+  apply HasStrongType.const_mul (c := C2_0_6 A p₁ p₂)
+  exact hasStrongType_maximalFunction_todo countable_globalMaximalFunction hp₁ hp₁₂
 
 theorem hasWeakType_globalMaximalFunction [BorelSpace X] [IsFiniteMeasureOnCompacts μ]
     [Nonempty X] [μ.IsOpenPosMeasure] {p₁ p₂ : ℝ≥0} (hp₁ : 1 ≤ p₁) (hp₁₂ : p₁ ≤ p₂) :
     HasWeakType (fun (u : X → E) (x : X) ↦ globalMaximalFunction μ p₁ u x)
       p₂ p₂ μ μ (A ^ 4) := by
-  -- rw [← hasWeakType_toReal_iff sorry /- todo: cleanup (task 117). -/]
-  -- unfold globalMaximalFunction
-  -- simp_rw [ENNReal.toReal_mul]
-  have : ofNNReal p₂ ≠ 0 := by -- surely, there is a simpler proof
+  have : (p₂ : ℝ≥0∞) ≠ 0 := by
     refine coe_ne_zero.mpr ?_
-    have : 1 ≤ p₂ := by
-      trans p₁
-      exacts [hp₁, hp₁₂]
-    positivity
-  sorry
-  /- TODO: fix this proof (currently times out), was:
-  apply HasWeakType.const_mul (c := A ^ 2) (e := A ^ 2) (p' := p₂) (μ := μ) (ν := μ) (p := p₂) this _
-  -- perhaps specify (ε := E) also
-  · simp; ring
-  exact hasWeakType_maximalFunction countable_globalMaximalFunction hp₁ hp₁₂ -/
+    have := zero_lt_one (α := ℝ≥0)
+    order
+  convert HasWeakType.const_mul (c := A ^ 2) (e := A ^ 2) this _
+  · rw [ENNReal.coe_pow, ← pow_add]
+  exact hasWeakType_maximalFunction countable_globalMaximalFunction hp₁ hp₁₂
 
 /-- Use `lowerSemiContinuous_MB` -/
 lemma lowerSemiContinuous_globalMaximalFunction (hf : LocallyIntegrable f μ) :

--- a/Carleson/ToMathlib/HardyLittlewood.lean
+++ b/Carleson/ToMathlib/HardyLittlewood.lean
@@ -541,5 +541,4 @@ lemma lowerSemiContinuous_globalMaximalFunction (hf : LocallyIntegrable f μ) :
     LowerSemicontinuous (globalMaximalFunction μ 1 f) := by
   sorry
 
-
 end GMF

--- a/Carleson/ToMathlib/HardyLittlewood.lean
+++ b/Carleson/ToMathlib/HardyLittlewood.lean
@@ -530,7 +530,7 @@ theorem hasStrongType_globalMaximalFunction [BorelSpace X] [IsFiniteMeasureOnCom
   · simp
   exact hasStrongType_maximalFunction_todo countable_globalMaximalFunction hp₁ hp₁₂ |>.toReal
 
-theorem hasWeakType_globalMaximalFunction [BorelSpace X] [IsFiniteMeasureOnCompacts μ]
+theorem hasWeakType_globalMaximalFunction [ENormedSpace E] [BorelSpace X] [IsFiniteMeasureOnCompacts μ]
     [Nonempty X] [μ.IsOpenPosMeasure] {p₁ p₂ : ℝ≥0} (hp₁ : 1 ≤ p₁) (hp₁₂ : p₁ ≤ p₂) :
     HasWeakType (fun (u : X → E) (x : X) ↦ globalMaximalFunction μ p₁ u x)
       p₂ p₂ μ μ (A ^ 4) := by
@@ -543,7 +543,7 @@ theorem hasWeakType_globalMaximalFunction [BorelSpace X] [IsFiniteMeasureOnCompa
       trans p₁
       exacts [hp₁, hp₁₂]
     positivity
-  convert HasWeakType.const_mul (c := A ^ 2) (e := (A : ℝ) ^ 2) (p' := p₂) (μ := μ) (ν := μ) (p := p₂)
+  apply HasWeakType.const_mul (c := A ^ 2) (e := A ^ 2) (p' := p₂) (μ := μ) (ν := μ) (p := p₂)
     (ε := E) this _
   · simp; ring
   exact hasWeakType_maximalFunction countable_globalMaximalFunction hp₁ hp₁₂ |>.toReal

--- a/Carleson/ToMathlib/HardyLittlewood.lean
+++ b/Carleson/ToMathlib/HardyLittlewood.lean
@@ -516,19 +516,20 @@ theorem laverage_le_globalMaximalFunction [IsFiniteMeasureOnCompacts μ] [μ.IsO
 /-- The constant factor in the statement that `M` has strong type. -/
 def C2_0_6' (A p₁ p₂ : ℝ≥0) : ℝ≥0 := A ^ 2 * C2_0_6 A p₁ p₂
 
-/-- Equation (2.0.46).
-Easy from `hasStrongType_maximalFunction`. Ideally prove separately
-`HasStrongType.const_smul` and `HasStrongType.const_mul`. -/
+/-- Equation (2.0.46). Easy from `hasStrongType_maximalFunction` -/
 theorem hasStrongType_globalMaximalFunction [BorelSpace X] [IsFiniteMeasureOnCompacts μ]
     [Nonempty X] [μ.IsOpenPosMeasure] {p₁ p₂ : ℝ≥0} (hp₁ : 1 ≤ p₁) (hp₁₂ : p₁ < p₂) :
     HasStrongType (fun (u : X → E) (x : X) ↦ globalMaximalFunction μ p₁ u x)
       p₂ p₂ μ μ (C2_0_6' A p₁ p₂) := by
-  rw [← hasStrongType_toReal_iff sorry /- todo: cleanup (task 117). -/]
   unfold globalMaximalFunction
-  simp_rw [ENNReal.toReal_mul, C2_0_6']
+  simp_rw [C2_0_6']
   convert HasStrongType.const_mul (c := C2_0_6 A p₁ p₂) _ _
-  · simp
-  exact hasStrongType_maximalFunction_todo countable_globalMaximalFunction hp₁ hp₁₂ |>.toReal
+  · sorry -- how to prevent this diamond?
+  · sorry -- missing instance, right?
+  convert hasStrongType_maximalFunction_todo countable_globalMaximalFunction hp₁ hp₁₂
+  -- TODO: all these goals are "obvious", there is always a matching instance in context
+  -- figure out what's going wrong here!
+  all_goals sorry
 
 theorem hasWeakType_globalMaximalFunction [ENormedSpace E] [BorelSpace X] [IsFiniteMeasureOnCompacts μ]
     [Nonempty X] [μ.IsOpenPosMeasure] {p₁ p₂ : ℝ≥0} (hp₁ : 1 ≤ p₁) (hp₁₂ : p₁ ≤ p₂) :

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -21,7 +21,7 @@ variable {α 𝕜 E : Type*} {m : MeasurableSpace α}
 lemma ENNNorm_absolute_homogeneous {c : 𝕜} (z : E) : ofNNReal ‖c • z‖₊ = ↑‖c‖₊ * ↑‖z‖₊ :=
   (toReal_eq_toReal_iff' coe_ne_top coe_ne_top).mp (norm_smul c z)
 
-lemma enorm_absolute_homogeneous {c : 𝕜} (z : E) : ‖c • z‖ₑ = ‖c‖ₑ * ‖z‖ₑ :=
+lemma enorm_absolute_homogeneous' {c : 𝕜} (z : E) : ‖c • z‖ₑ = ‖c‖ₑ * ‖z‖ₑ :=
   (toReal_eq_toReal_iff' coe_ne_top coe_ne_top).mp (norm_smul c z)
 
 lemma ENNNorm_add_le (y z : E) : ofNNReal ‖y + z‖₊ ≤ ↑‖y‖₊ + ↑‖z‖₊ :=
@@ -578,14 +578,14 @@ variable [NormedAddCommGroup E] [MulActionWithZero 𝕜 E] [IsBoundedSMul 𝕜 E
 
 -- TODO: add an analogue for the ENorm context, using scalar multiplication w.r.t. `NNReal` on an `ENormedSpace`
 
-lemma distribution_smul_left {f : α → E} {c : 𝕜} (hc : c ≠ 0) :
+lemma distribution_smul_left' {f : α → E} {c : 𝕜} (hc : c ≠ 0) :
     distribution (c • f) t μ = distribution f (t / ‖c‖ₑ) μ := by
   have h₀ : ‖c‖ₑ ≠ 0 := enorm_ne_zero.mpr hc
   unfold distribution
   congr with x
   simp only [Pi.smul_apply, mem_setOf_eq]
   rw [← @ENNReal.mul_lt_mul_right (t / ‖c‖ₑ) _ (‖c‖ₑ) h₀ coe_ne_top,
-    enorm_absolute_homogeneous _, mul_comm, ENNReal.div_mul_cancel h₀ coe_ne_top]
+    enorm_absolute_homogeneous' _, mul_comm, ENNReal.div_mul_cancel h₀ coe_ne_top]
 
 variable {𝕜 E' : Type*} [NormedRing 𝕜] [NormedAddCommGroup E'] [MulActionWithZero 𝕜 E'] [IsBoundedSMul 𝕜 E'] in
 lemma HasStrongType.const_smul {α α' : Type*} {_x : MeasurableSpace α} {_x' : MeasurableSpace α'}
@@ -616,7 +616,7 @@ lemma wnorm_const_smul_le {α : Type*} {_ : MeasurableSpace α} {p : ℝ≥0∞}
     intro _
     right
     exact toReal_pos hp ptop
-  simp only [distribution_smul_left k_zero]
+  simp only [distribution_smul_left' k_zero]
   intro t
   rw [ENNReal.mul_iSup]
   have knorm_ne_zero : ‖k‖₊ ≠ 0 := nnnorm_ne_zero_iff.mpr k_zero

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -619,7 +619,7 @@ lemma HasStrongType.const_smul [ContinuousConstSMul ℝ≥0 ε']
 -- TODO: do we want to unify this lemma with its unprimed version, perhaps using an
 -- `ENormedSemiring` class?
 variable {𝕜 E' : Type*} [NormedRing 𝕜] [NormedAddCommGroup E'] [MulActionWithZero 𝕜 E'] [IsBoundedSMul 𝕜 E'] in
-lemma HasStrongType.const_smul' [ContinuousENorm ε]
+lemma HasStrongType.const_smul'
     {T : (α → ε) → (α' → E')} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (k : 𝕜) :
     HasStrongType (k • T) p p' μ ν (‖k‖ₑ * c) := by
   refine fun f hf ↦ ⟨AEStronglyMeasurable.const_smul (h f hf).1 k, eLpNorm_const_smul_le.trans ?_⟩
@@ -635,12 +635,12 @@ lemma HasStrongType.const_mul
 -- TODO: do we want to unify this lemma with its unprimed version, perhaps using an
 -- `ENormedSemiring` class?
 variable {E' : Type*} [NormedRing E'] in
-lemma HasStrongType.const_mul' [ContinuousENorm ε]
+lemma HasStrongType.const_mul'
     {T : (α → ε) → (α' → E')} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (e : E') :
     HasStrongType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
   h.const_smul' e
 
-lemma wnorm_const_smul_le [ENormedSpace ε] (hp : p ≠ 0) {f : α → ε} (k : ℝ≥0) :
+lemma wnorm_const_smul_le (hp : p ≠ 0) {f : α → ε'} (k : ℝ≥0) :
     wnorm (k • f) p μ ≤ ‖k‖ₑ * wnorm f p μ := by
   by_cases ptop : p = ⊤
   · simp only [ptop, wnorm_top]

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -341,8 +341,8 @@ lemma MemWℒp.ennreal_toReal {f : α → ℝ≥0∞} (hf : MemWℒp f p μ) :
   ⟨hf.aeStronglyMeasurable.ennreal_toReal, wnorm_toReal_le.trans_lt hf.2⟩
 
 /-- If a function `f` is `MemWℒp`, then its norm is almost everywhere finite.-/
-theorem MemWℒp.ae_ne_top {f : α → ε} {p : ℝ≥0∞} {μ : Measure α}
-    (hf : MemWℒp f p μ) : ∀ᵐ x ∂μ, ‖f x‖ₑ ≠ ∞ := by
+theorem MemWℒp.ae_ne_top {f : α → ε} {μ : Measure α} (hf : MemWℒp f p μ) :
+    ∀ᵐ x ∂μ, ‖f x‖ₑ ≠ ∞ := by
   by_cases hp_inf : p = ∞
   · rw [hp_inf] at hf
     simp_rw [← lt_top_iff_ne_top]
@@ -608,7 +608,7 @@ lemma distribution_smul_left' {f : α → E} {c : 𝕜} (hc : c ≠ 0) :
     enorm_absolute_homogeneous' _, mul_comm, ENNReal.div_mul_cancel h₀ coe_ne_top]
 
 lemma HasStrongType.const_smul [ContinuousConstSMul ℝ≥0 ε']
-    {T : (α → ε) → (α' → ε')} {p p' : ℝ≥0∞} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (k : ℝ≥0) :
+    {T : (α → ε) → (α' → ε')} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (k : ℝ≥0) :
     HasStrongType (k • T) p p' μ ν (‖k‖ₑ * c) := by
   refine fun f hf ↦ ⟨AEStronglyMeasurable.const_smul (h f hf).1 k, eLpNorm_const_smul_le'.trans ?_⟩
   simp only [ENNReal.smul_def, smul_eq_mul, coe_mul, mul_assoc]
@@ -619,7 +619,7 @@ lemma HasStrongType.const_smul [ContinuousConstSMul ℝ≥0 ε']
 -- `ENormedSemiring` class?
 variable {𝕜 E' : Type*} [NormedRing 𝕜] [NormedAddCommGroup E'] [MulActionWithZero 𝕜 E'] [IsBoundedSMul 𝕜 E'] in
 lemma HasStrongType.const_smul'
-    {T : (α → ε) → (α' → E')} {p p' : ℝ≥0∞} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (k : 𝕜) :
+    {T : (α → ε) → (α' → E')} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (k : 𝕜) :
     HasStrongType (k • T) p p' μ ν (‖k‖ₑ * c) := by
   refine fun f hf ↦ ⟨AEStronglyMeasurable.const_smul (h f hf).1 k, eLpNorm_const_smul_le.trans ?_⟩
   simp only [ENNReal.smul_def, smul_eq_mul, coe_mul, mul_assoc]
@@ -627,7 +627,7 @@ lemma HasStrongType.const_smul'
   exact (h f hf).2
 
 lemma HasStrongType.const_mul
-    {T : (α → ε) → (α' → ℝ≥0∞)} {p p' : ℝ≥0∞} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (e : ℝ≥0) :
+    {T : (α → ε) → (α' → ℝ≥0∞)} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (e : ℝ≥0) :
     HasStrongType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
   h.const_smul e
 
@@ -635,11 +635,11 @@ lemma HasStrongType.const_mul
 -- `ENormedSemiring` class?
 variable {E' : Type*} [NormedRing E'] in
 lemma HasStrongType.const_mul'
-    {T : (α → ε) → (α' → E')} {p p' : ℝ≥0∞} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (e : E') :
+    {T : (α → ε) → (α' → E')} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (e : E') :
     HasStrongType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
   h.const_smul' e
 
-lemma wnorm_const_smul_le {p : ℝ≥0∞} (hp : p ≠ 0) {f : α → ε} (k : ℝ≥0) :
+lemma wnorm_const_smul_le (hp : p ≠ 0) {f : α → ε} (k : ℝ≥0) :
     wnorm (k • f) p μ ≤ ‖k‖ₑ * wnorm f p μ := by
   by_cases ptop : p = ⊤
   · simp only [ptop, wnorm_top]
@@ -666,7 +666,7 @@ lemma wnorm_const_smul_le {p : ℝ≥0∞} (hp : p ≠ 0) {f : α → ε} (k : �
   apply le_of_eq
   congr <;> exact (coe_div k_zero).symm
 
-lemma wnorm_const_smul_le' {p : ℝ≥0∞} (hp : p ≠ 0) {f : α → E} (k : 𝕜) :
+lemma wnorm_const_smul_le' (hp : p ≠ 0) {f : α → E} (k : 𝕜) :
     wnorm (k • f) p μ ≤ ‖k‖ₑ * wnorm f p μ := by
   by_cases ptop : p = ⊤
   · simp only [ptop, wnorm_top]
@@ -695,8 +695,7 @@ lemma wnorm_const_smul_le' {p : ℝ≥0∞} (hp : p ≠ 0) {f : α → E} (k : �
   congr <;> exact (coe_div knorm_ne_zero).symm
 
 lemma HasWeakType.const_smul [ContinuousConstSMul ℝ≥0 ε']
-    {T : (α → ε) → (α' → ε')} {p p' : ℝ≥0∞} (hp' : p' ≠ 0)
-    {c : ℝ≥0∞} (h : HasWeakType T p p' μ ν c) (k : ℝ≥0) :
+    {T : (α → ε) → (α' → ε')} (hp' : p' ≠ 0) {c : ℝ≥0∞} (h : HasWeakType T p p' μ ν c) (k : ℝ≥0) :
     HasWeakType (k • T) p p' μ ν (‖k‖ₑ * c) := by
   intro f hf
   refine ⟨(h f hf).1.const_smul k, ?_⟩
@@ -709,7 +708,7 @@ lemma HasWeakType.const_smul [ContinuousConstSMul ℝ≥0 ε']
 
 -- TODO: do we want to unify this lemma with its unprimed version, perhaps using an
 -- `ENormedSemiring` class?
-lemma HasWeakType.const_smul' {T : (α → ε) → (α' → E')} {p p' : ℝ≥0∞} (hp' : p' ≠ 0)
+lemma HasWeakType.const_smul' {T : (α → ε) → (α' → E')} (hp' : p' ≠ 0)
     {c : ℝ≥0∞} (h : HasWeakType T p p' μ ν c) (k : 𝕜) :
     HasWeakType (k • T) p p' μ ν (‖k‖ₑ * c) := by
   intro f hf
@@ -721,15 +720,15 @@ lemma HasWeakType.const_smul' {T : (α → ε) → (α' → E')} {p p' : ℝ≥0
       apply (h f hf).2
     _ = (‖k‖ₑ * c) * eLpNorm f p μ := by simp [coe_mul, mul_assoc]
 
-lemma HasWeakType.const_mul {T : (α → ε) → (α' → ℝ≥0∞)} {p p' : ℝ≥0∞} (hp' : p' ≠ 0) {c : ℝ≥0∞}
+lemma HasWeakType.const_mul {T : (α → ε) → (α' → ℝ≥0∞)} (hp' : p' ≠ 0) {c : ℝ≥0∞}
     (h : HasWeakType T p p' μ ν c) (e : ℝ≥0) :
     HasWeakType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
   h.const_smul hp' e
 
 -- TODO: do we want to unify this lemma with its unprimed version, perhaps using an
 -- `ENormedSemiring` class?
-lemma HasWeakType.const_mul' {T : (α → ε) → (α' → 𝕜)} {p p' : ℝ≥0∞}
-    (hp' : p' ≠ 0) {c : ℝ≥0∞} (h : HasWeakType T p p' μ ν c) (e : 𝕜) :
+lemma HasWeakType.const_mul' {T : (α → ε) → (α' → 𝕜)} (hp' : p' ≠ 0) {c : ℝ≥0∞}
+    (h : HasWeakType T p p' μ ν c) (e : 𝕜) :
     HasWeakType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
   h.const_smul' hp' e
 

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -578,10 +578,7 @@ variable {f g : α → ε}
 
 section
 
-variable [TopologicalSpace ε] [ContinuousENorm ε]
-
-variable [NormedAddCommGroup E] [MulActionWithZero 𝕜 E] [IsBoundedSMul 𝕜 E]
-  {E' : Type*} [NormedAddCommGroup E'] [MulActionWithZero 𝕜 E'] [IsBoundedSMul 𝕜 E']
+-- variable [TopologicalSpace ε] [ContinuousENorm ε] -- XXX: revisit this
 
 -- TODO: this lemma and its primed version could be unified using a `NormedSemifield` typeclass
 -- (which includes NNReal and normed fields like ℝ and ℂ), i.e. assuming 𝕜 is a normed semifield.
@@ -598,6 +595,9 @@ lemma distribution_smul_left {ε} [TopologicalSpace ε] [ENormedSpace ε] {f : �
   rw [← @ENNReal.mul_lt_mul_right (t / ‖c‖ₑ) _ (‖c‖ₑ) h₀ coe_ne_top,
     enorm_absolute_homogeneous (c := c) _, ENNReal.div_mul_cancel h₀ coe_ne_top, mul_comm]
 
+variable [NormedAddCommGroup E] [MulActionWithZero 𝕜 E] [IsBoundedSMul 𝕜 E]
+  {E' : Type*} [NormedAddCommGroup E'] [MulActionWithZero 𝕜 E'] [IsBoundedSMul 𝕜 E']
+
 lemma distribution_smul_left' {f : α → E} {c : 𝕜} (hc : c ≠ 0) :
     distribution (c • f) t μ = distribution f (t / ‖c‖ₑ) μ := by
   have h₀ : ‖c‖ₑ ≠ 0 := enorm_ne_zero.mpr hc
@@ -607,18 +607,21 @@ lemma distribution_smul_left' {f : α → E} {c : 𝕜} (hc : c ≠ 0) :
   rw [← @ENNReal.mul_lt_mul_right (t / ‖c‖ₑ) _ (‖c‖ₑ) h₀ coe_ne_top,
     enorm_absolute_homogeneous' _, mul_comm, ENNReal.div_mul_cancel h₀ coe_ne_top]
 
-variable {𝕜 E' : Type*} [NormedRing 𝕜] [NormedAddCommGroup E'] [MulActionWithZero 𝕜 E'] [IsBoundedSMul 𝕜 E'] in
-lemma HasStrongType.const_smul
-    {T : (α → ε) → (α' → E')} {p p' : ℝ≥0∞} {c : ℝ≥0∞}
-    (h : HasStrongType T p p' μ ν c) (k : 𝕜) :
+variable [TopologicalSpace ε] [ContinuousENorm ε]
+
+variable {ε' : Type*} [TopologicalSpace ε'] [ENormedSpace ε']
+
+lemma HasStrongType.const_smul [ContinuousConstSMul ℝ≥0 ε']
+    {T : (α → ε) → (α' → ε')} {p p' : ℝ≥0∞} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (k : ℝ≥0) :
     HasStrongType (k • T) p p' μ ν (‖k‖ₑ * c) := by
-  refine fun f hf ↦ ⟨AEStronglyMeasurable.const_smul (h f hf).1 k, eLpNorm_const_smul_le.trans ?_⟩
+  refine fun f hf ↦ ⟨AEStronglyMeasurable.const_smul (h f hf).1 k, eLpNorm_const_smul_le'.trans ?_⟩
   simp only [ENNReal.smul_def, smul_eq_mul, coe_mul, mul_assoc]
   gcongr
   exact (h f hf).2
 
-lemma HasStrongType.const_mul {E' : Type*} [NormedRing E']
-    {T : (α → ε) → (α' → E')} {p p' : ℝ≥0∞} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (e : E') :
+-- XXX: is this the statement we want?
+lemma HasStrongType.const_mul
+    {T : (α → ε) → (α' → ℝ≥0)} {p p' : ℝ≥0∞} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (e : ℝ≥0) :
     HasStrongType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
   h.const_smul e
 

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -608,8 +608,8 @@ lemma distribution_smul_left' {f : α → E} {c : 𝕜} (hc : c ≠ 0) :
     enorm_absolute_homogeneous' _, mul_comm, ENNReal.div_mul_cancel h₀ coe_ne_top]
 
 variable {𝕜 E' : Type*} [NormedRing 𝕜] [NormedAddCommGroup E'] [MulActionWithZero 𝕜 E'] [IsBoundedSMul 𝕜 E'] in
-lemma HasStrongType.const_smul {α α' : Type*} {_x : MeasurableSpace α} {_x' : MeasurableSpace α'}
-    {T : (α → ε) → (α' → E')} {p p' : ℝ≥0∞} {μ : Measure α} {ν : Measure α'} {c : ℝ≥0∞}
+lemma HasStrongType.const_smul
+    {T : (α → ε) → (α' → E')} {p p' : ℝ≥0∞} {c : ℝ≥0∞}
     (h : HasStrongType T p p' μ ν c) (k : 𝕜) :
     HasStrongType (k • T) p p' μ ν (‖k‖ₑ * c) := by
   refine fun f hf ↦ ⟨AEStronglyMeasurable.const_smul (h f hf).1 k, eLpNorm_const_smul_le.trans ?_⟩
@@ -617,14 +617,13 @@ lemma HasStrongType.const_smul {α α' : Type*} {_x : MeasurableSpace α} {_x' :
   gcongr
   exact (h f hf).2
 
-lemma HasStrongType.const_mul {E' α α' : Type*} [NormedRing E']
-    {_x : MeasurableSpace α} {_x' : MeasurableSpace α'} {T : (α → ε) → (α' → E')} {p p' : ℝ≥0∞}
-    {μ : Measure α} {ν : Measure α'} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (e : E') :
+lemma HasStrongType.const_mul {E' : Type*} [NormedRing E']
+    {T : (α → ε) → (α' → E')} {p p' : ℝ≥0∞} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (e : E') :
     HasStrongType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
   h.const_smul e
 
-lemma wnorm_const_smul_le {α : Type*} {_ : MeasurableSpace α} {p : ℝ≥0∞} (hp : p ≠ 0)
-    {μ : Measure α} {f : α → E} (k : 𝕜) : wnorm (k • f) p μ ≤ ‖k‖ₑ * wnorm f p μ := by
+lemma wnorm_const_smul_le {p : ℝ≥0∞} (hp : p ≠ 0)
+    {f : α → E} (k : 𝕜) : wnorm (k • f) p μ ≤ ‖k‖ₑ * wnorm f p μ := by
   by_cases ptop : p = ⊤
   · simp only [ptop, wnorm_top]
     apply eLpNormEssSup_const_smul_le
@@ -651,8 +650,8 @@ lemma wnorm_const_smul_le {α : Type*} {_ : MeasurableSpace α} {p : ℝ≥0∞}
   apply le_of_eq
   congr <;> exact (coe_div knorm_ne_zero).symm
 
-lemma HasWeakType.const_smul {α α' : Type*} {_x : MeasurableSpace α} {_x' : MeasurableSpace α'}
-    {T : (α → ε) → (α' → E')} {p p' : ℝ≥0∞} (hp' : p' ≠ 0) {μ : Measure α} {ν : Measure α'}
+lemma HasWeakType.const_smul
+    {T : (α → ε) → (α' → E')} {p p' : ℝ≥0∞} (hp' : p' ≠ 0) {ν : Measure α'}
     {c : ℝ≥0∞} (h : HasWeakType T p p' μ ν c) (k : 𝕜) :
     HasWeakType (k • T) p p' μ ν (‖k‖ₑ * c) := by
   intro f hf
@@ -664,9 +663,8 @@ lemma HasWeakType.const_smul {α α' : Type*} {_x : MeasurableSpace α} {_x' : M
       apply (h f hf).2
     _ = (‖k‖ₑ * c) * eLpNorm f p μ := by simp [coe_mul, mul_assoc]
 
-lemma HasWeakType.const_mul {α α' : Type*}
-    {_x : MeasurableSpace α} {_x' : MeasurableSpace α'} {T : (α → ε) → (α' → 𝕜)} {p p' : ℝ≥0∞}
-    (hp' : p' ≠ 0) {μ : Measure α} {ν : Measure α'} {c : ℝ≥0∞} (h : HasWeakType T p p' μ ν c) (e : 𝕜) :
+lemma HasWeakType.const_mul {T : (α → ε) → (α' → 𝕜)} {p p' : ℝ≥0∞} (hp' : p' ≠ 0) {c : ℝ≥0∞}
+    (h : HasWeakType T p p' μ ν c) (e : 𝕜) :
     HasWeakType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
   h.const_smul hp' e
 

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -578,12 +578,12 @@ variable {f g : α → ε}
 
 section
 
-variable {ε ε' : Type*} [TopologicalSpace ε] [ENormedSpace ε] [TopologicalSpace ε'] [ENormedSpace ε']
+variable {ε ε' : Type*} [TopologicalSpace ε] [TopologicalSpace ε'] [ENormedSpace ε']
 
 -- TODO: this lemma and its primed version could be unified using a `NormedSemifield` typeclass
 -- (which includes NNReal and normed fields like ℝ and ℂ), i.e. assuming 𝕜 is a normed semifield.
 -- Investigate if this is worthwhile when upstreaming this to mathlib.
-lemma distribution_smul_left {ε} [TopologicalSpace ε] [ENormedSpace ε] {f : α → ε} {c : ℝ≥0} (hc : c ≠ 0) :
+lemma distribution_smul_left [ENormedSpace ε] {f : α → ε} {c : ℝ≥0} (hc : c ≠ 0) :
     distribution (c • f) t μ = distribution f (t / ‖c‖ₑ) μ := by
   have h₀ : ‖c‖ₑ ≠ 0 := by
     have : ‖c‖ₑ = ‖(c : ℝ≥0∞)‖ₑ := rfl
@@ -607,7 +607,7 @@ lemma distribution_smul_left' {f : α → E} {c : 𝕜} (hc : c ≠ 0) :
   rw [← @ENNReal.mul_lt_mul_right (t / ‖c‖ₑ) _ (‖c‖ₑ) h₀ coe_ne_top,
     enorm_absolute_homogeneous' _, mul_comm, ENNReal.div_mul_cancel h₀ coe_ne_top]
 
-lemma HasStrongType.const_smul [ContinuousConstSMul ℝ≥0 ε']
+lemma HasStrongType.const_smul [ContinuousENorm ε] [ContinuousConstSMul ℝ≥0 ε']
     {T : (α → ε) → (α' → ε')} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (k : ℝ≥0) :
     HasStrongType (k • T) p p' μ ν (‖k‖ₑ * c) := by
   refine fun f hf ↦ ⟨AEStronglyMeasurable.const_smul (h f hf).1 k, eLpNorm_const_smul_le'.trans ?_⟩
@@ -618,7 +618,7 @@ lemma HasStrongType.const_smul [ContinuousConstSMul ℝ≥0 ε']
 -- TODO: do we want to unify this lemma with its unprimed version, perhaps using an
 -- `ENormedSemiring` class?
 variable {𝕜 E' : Type*} [NormedRing 𝕜] [NormedAddCommGroup E'] [MulActionWithZero 𝕜 E'] [IsBoundedSMul 𝕜 E'] in
-lemma HasStrongType.const_smul'
+lemma HasStrongType.const_smul' [ContinuousENorm ε]
     {T : (α → ε) → (α' → E')} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (k : 𝕜) :
     HasStrongType (k • T) p p' μ ν (‖k‖ₑ * c) := by
   refine fun f hf ↦ ⟨AEStronglyMeasurable.const_smul (h f hf).1 k, eLpNorm_const_smul_le.trans ?_⟩
@@ -626,7 +626,7 @@ lemma HasStrongType.const_smul'
   gcongr
   exact (h f hf).2
 
-lemma HasStrongType.const_mul
+lemma HasStrongType.const_mul [ContinuousENorm ε]
     {T : (α → ε) → (α' → ℝ≥0∞)} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (e : ℝ≥0) :
     HasStrongType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
   h.const_smul e
@@ -634,12 +634,12 @@ lemma HasStrongType.const_mul
 -- TODO: do we want to unify this lemma with its unprimed version, perhaps using an
 -- `ENormedSemiring` class?
 variable {E' : Type*} [NormedRing E'] in
-lemma HasStrongType.const_mul'
+lemma HasStrongType.const_mul' [ContinuousENorm ε]
     {T : (α → ε) → (α' → E')} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (e : E') :
     HasStrongType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
   h.const_smul' e
 
-lemma wnorm_const_smul_le (hp : p ≠ 0) {f : α → ε} (k : ℝ≥0) :
+lemma wnorm_const_smul_le [ENormedSpace ε] (hp : p ≠ 0) {f : α → ε} (k : ℝ≥0) :
     wnorm (k • f) p μ ≤ ‖k‖ₑ * wnorm f p μ := by
   by_cases ptop : p = ⊤
   · simp only [ptop, wnorm_top]
@@ -694,7 +694,7 @@ lemma wnorm_const_smul_le' (hp : p ≠ 0) {f : α → E} (k : 𝕜) :
   apply le_of_eq
   congr <;> exact (coe_div knorm_ne_zero).symm
 
-lemma HasWeakType.const_smul [ContinuousConstSMul ℝ≥0 ε']
+lemma HasWeakType.const_smul [ContinuousENorm ε] [ContinuousConstSMul ℝ≥0 ε']
     {T : (α → ε) → (α' → ε')} (hp' : p' ≠ 0) {c : ℝ≥0∞} (h : HasWeakType T p p' μ ν c) (k : ℝ≥0) :
     HasWeakType (k • T) p p' μ ν (‖k‖ₑ * c) := by
   intro f hf
@@ -708,7 +708,7 @@ lemma HasWeakType.const_smul [ContinuousConstSMul ℝ≥0 ε']
 
 -- TODO: do we want to unify this lemma with its unprimed version, perhaps using an
 -- `ENormedSemiring` class?
-lemma HasWeakType.const_smul' {T : (α → ε) → (α' → E')} (hp' : p' ≠ 0)
+lemma HasWeakType.const_smul' [ContinuousENorm ε] {T : (α → ε) → (α' → E')} (hp' : p' ≠ 0)
     {c : ℝ≥0∞} (h : HasWeakType T p p' μ ν c) (k : 𝕜) :
     HasWeakType (k • T) p p' μ ν (‖k‖ₑ * c) := by
   intro f hf
@@ -720,15 +720,15 @@ lemma HasWeakType.const_smul' {T : (α → ε) → (α' → E')} (hp' : p' ≠ 0
       apply (h f hf).2
     _ = (‖k‖ₑ * c) * eLpNorm f p μ := by simp [coe_mul, mul_assoc]
 
-lemma HasWeakType.const_mul {T : (α → ε) → (α' → ℝ≥0∞)} (hp' : p' ≠ 0) {c : ℝ≥0∞}
-    (h : HasWeakType T p p' μ ν c) (e : ℝ≥0) :
-    HasWeakType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
+lemma HasWeakType.const_mul [ContinuousENorm ε] {T : (α → ε) → (α' → ℝ≥0∞)} (hp' : p' ≠ 0)
+    {c : ℝ≥0∞} (h : HasWeakType T p p' μ ν c) (e : ℝ≥0) :
+    HasWeakType (fun f x ↦ e * T f x) p p' μ ν (e * c) :=
   h.const_smul hp' e
 
 -- TODO: do we want to unify this lemma with its unprimed version, perhaps using an
 -- `ENormedSemiring` class?
-lemma HasWeakType.const_mul' {T : (α → ε) → (α' → 𝕜)} (hp' : p' ≠ 0) {c : ℝ≥0∞}
-    (h : HasWeakType T p p' μ ν c) (e : 𝕜) :
+lemma HasWeakType.const_mul' [ContinuousENorm ε] {T : (α → ε) → (α' → 𝕜)} (hp' : p' ≠ 0)
+    {c : ℝ≥0∞} (h : HasWeakType T p p' μ ν c) (e : 𝕜) :
     HasWeakType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
   h.const_smul' hp' e
 

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -578,7 +578,7 @@ variable {f g : α → ε}
 
 section
 
--- variable [TopologicalSpace ε] [ContinuousENorm ε] -- XXX: revisit this
+variable {ε ε' : Type*} [TopologicalSpace ε] [ENormedSpace ε] [TopologicalSpace ε'] [ENormedSpace ε']
 
 -- TODO: this lemma and its primed version could be unified using a `NormedSemifield` typeclass
 -- (which includes NNReal and normed fields like ℝ and ℂ), i.e. assuming 𝕜 is a normed semifield.
@@ -607,10 +607,6 @@ lemma distribution_smul_left' {f : α → E} {c : 𝕜} (hc : c ≠ 0) :
   rw [← @ENNReal.mul_lt_mul_right (t / ‖c‖ₑ) _ (‖c‖ₑ) h₀ coe_ne_top,
     enorm_absolute_homogeneous' _, mul_comm, ENNReal.div_mul_cancel h₀ coe_ne_top]
 
-variable [TopologicalSpace ε] [ContinuousENorm ε]
-
-variable {ε' : Type*} [TopologicalSpace ε'] [ENormedSpace ε']
-
 lemma HasStrongType.const_smul [ContinuousConstSMul ℝ≥0 ε']
     {T : (α → ε) → (α' → ε')} {p p' : ℝ≥0∞} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (k : ℝ≥0) :
     HasStrongType (k • T) p p' μ ν (‖k‖ₑ * c) := by
@@ -625,11 +621,11 @@ lemma HasStrongType.const_mul
     HasStrongType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
   h.const_smul e
 
-lemma wnorm_const_smul_le {p : ℝ≥0∞} (hp : p ≠ 0)
-    {f : α → E} (k : 𝕜) : wnorm (k • f) p μ ≤ ‖k‖ₑ * wnorm f p μ := by
+lemma wnorm_const_smul_le {p : ℝ≥0∞} (hp : p ≠ 0) {f : α → ε} (k : ℝ≥0) :
+    wnorm (k • f) p μ ≤ ‖k‖ₑ * wnorm f p μ := by
   by_cases ptop : p = ⊤
   · simp only [ptop, wnorm_top]
-    apply eLpNormEssSup_const_smul_le
+    apply eLpNormEssSup_const_smul_le'
   simp only [wnorm, ptop, ↓reduceIte, wnorm', iSup_le_iff]
   by_cases k_zero : k = 0
   · simp only [distribution, k_zero, Pi.smul_apply, zero_smul, enorm_zero, not_lt_zero', setOf_false,
@@ -638,27 +634,26 @@ lemma wnorm_const_smul_le {p : ℝ≥0∞} (hp : p ≠ 0)
     intro _
     right
     exact toReal_pos hp ptop
-  simp only [distribution_smul_left' k_zero]
+  simp only [distribution_smul_left k_zero]
   intro t
   rw [ENNReal.mul_iSup]
-  have knorm_ne_zero : ‖k‖₊ ≠ 0 := nnnorm_ne_zero_iff.mpr k_zero
   have : t * distribution f (t / ‖k‖ₑ) μ ^ p.toReal⁻¹ =
       ‖k‖ₑ * ((t / ‖k‖ₑ) * distribution f (t / ‖k‖ₑ) μ ^ p.toReal⁻¹) := by
-    nth_rewrite 1 [← mul_div_cancel₀ t knorm_ne_zero]
+    nth_rewrite 1 [← mul_div_cancel₀ t k_zero]
     simp only [coe_mul, mul_assoc]
     congr
-    exact coe_div knorm_ne_zero
-  erw [this]
+    exact coe_div k_zero
+  rw [this]
   apply le_iSup_of_le (↑t / ↑‖k‖₊)
   apply le_of_eq
-  congr <;> exact (coe_div knorm_ne_zero).symm
+  congr <;> exact (coe_div k_zero).symm
 
-lemma HasWeakType.const_smul
-    {T : (α → ε) → (α' → E')} {p p' : ℝ≥0∞} (hp' : p' ≠ 0) {ν : Measure α'}
-    {c : ℝ≥0∞} (h : HasWeakType T p p' μ ν c) (k : 𝕜) :
+lemma HasWeakType.const_smul [ContinuousConstSMul ℝ≥0 ε']
+    {T : (α → ε) → (α' → ε')} {p p' : ℝ≥0∞} (hp' : p' ≠ 0) {ν : Measure α'}
+    {c : ℝ≥0∞} (h : HasWeakType T p p' μ ν c) (k : ℝ≥0) :
     HasWeakType (k • T) p p' μ ν (‖k‖ₑ * c) := by
   intro f hf
-  refine ⟨aestronglyMeasurable_const.smul (h f hf).1, ?_⟩
+  refine ⟨(h f hf).1.const_smul k, ?_⟩
   calc wnorm ((k • T) f) p' ν
     _ ≤ ‖k‖ₑ * wnorm (T f) p' ν := by simp [wnorm_const_smul_le hp']
     _ ≤ ‖k‖ₑ * (c * eLpNorm f p μ) := by
@@ -666,8 +661,9 @@ lemma HasWeakType.const_smul
       apply (h f hf).2
     _ = (‖k‖ₑ * c) * eLpNorm f p μ := by simp [coe_mul, mul_assoc]
 
-lemma HasWeakType.const_mul {T : (α → ε) → (α' → 𝕜)} {p p' : ℝ≥0∞} (hp' : p' ≠ 0) {c : ℝ≥0∞}
-    (h : HasWeakType T p p' μ ν c) (e : 𝕜) :
+-- XXX: is this the statement we want?
+lemma HasWeakType.const_mul {T : (α → ε) → (α' → ℝ≥0)} {p p' : ℝ≥0∞} (hp' : p' ≠ 0) {c : ℝ≥0∞}
+    (h : HasWeakType T p p' μ ν c) (e : ℝ≥0) :
     HasWeakType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
   h.const_smul hp' e
 

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -615,11 +615,29 @@ lemma HasStrongType.const_smul [ContinuousConstSMul ℝ≥0 ε']
   gcongr
   exact (h f hf).2
 
--- XXX: is this the statement we want?
+-- TODO: do we want to unify this lemma with its unprimed version, perhaps using an
+-- `ENormedSemiring` class?
+variable {𝕜 E' : Type*} [NormedRing 𝕜] [NormedAddCommGroup E'] [MulActionWithZero 𝕜 E'] [IsBoundedSMul 𝕜 E'] in
+lemma HasStrongType.const_smul'
+    {T : (α → ε) → (α' → E')} {p p' : ℝ≥0∞} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (k : 𝕜) :
+    HasStrongType (k • T) p p' μ ν (‖k‖ₑ * c) := by
+  refine fun f hf ↦ ⟨AEStronglyMeasurable.const_smul (h f hf).1 k, eLpNorm_const_smul_le.trans ?_⟩
+  simp only [ENNReal.smul_def, smul_eq_mul, coe_mul, mul_assoc]
+  gcongr
+  exact (h f hf).2
+
 lemma HasStrongType.const_mul
     {T : (α → ε) → (α' → ℝ≥0∞)} {p p' : ℝ≥0∞} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (e : ℝ≥0) :
     HasStrongType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
   h.const_smul e
+
+-- TODO: do we want to unify this lemma with its unprimed version, perhaps using an
+-- `ENormedSemiring` class?
+variable {E' : Type*} [NormedRing E'] in
+lemma HasStrongType.const_mul'
+    {T : (α → ε) → (α' → E')} {p p' : ℝ≥0∞} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (e : E') :
+    HasStrongType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
+  h.const_smul' e
 
 lemma wnorm_const_smul_le {p : ℝ≥0∞} (hp : p ≠ 0) {f : α → ε} (k : ℝ≥0) :
     wnorm (k • f) p μ ≤ ‖k‖ₑ * wnorm f p μ := by
@@ -648,8 +666,36 @@ lemma wnorm_const_smul_le {p : ℝ≥0∞} (hp : p ≠ 0) {f : α → ε} (k : �
   apply le_of_eq
   congr <;> exact (coe_div k_zero).symm
 
+lemma wnorm_const_smul_le' {p : ℝ≥0∞} (hp : p ≠ 0) {f : α → E} (k : 𝕜) :
+    wnorm (k • f) p μ ≤ ‖k‖ₑ * wnorm f p μ := by
+  by_cases ptop : p = ⊤
+  · simp only [ptop, wnorm_top]
+    apply eLpNormEssSup_const_smul_le
+  simp only [wnorm, ptop, ↓reduceIte, wnorm', iSup_le_iff]
+  by_cases k_zero : k = 0
+  · simp only [distribution, k_zero, Pi.smul_apply, zero_smul, enorm_zero, not_lt_zero', setOf_false,
+      measure_empty, coe_lt_enorm, zero_mul, nonpos_iff_eq_zero, mul_eq_zero, ENNReal.coe_eq_zero,
+      ENNReal.rpow_eq_zero_iff, inv_pos, true_and, zero_ne_top, inv_neg'', false_and, or_false]
+    intro _
+    right
+    exact toReal_pos hp ptop
+  simp only [distribution_smul_left' k_zero]
+  intro t
+  rw [ENNReal.mul_iSup]
+  have knorm_ne_zero : ‖k‖₊ ≠ 0 := nnnorm_ne_zero_iff.mpr k_zero
+  have : t * distribution f (t / ‖k‖ₑ) μ ^ p.toReal⁻¹ =
+      ‖k‖ₑ * ((t / ‖k‖ₑ) * distribution f (t / ‖k‖ₑ) μ ^ p.toReal⁻¹) := by
+    nth_rewrite 1 [← mul_div_cancel₀ t knorm_ne_zero]
+    simp only [coe_mul, mul_assoc]
+    congr
+    exact coe_div knorm_ne_zero
+  erw [this]
+  apply le_iSup_of_le (↑t / ↑‖k‖₊)
+  apply le_of_eq
+  congr <;> exact (coe_div knorm_ne_zero).symm
+
 lemma HasWeakType.const_smul [ContinuousConstSMul ℝ≥0 ε']
-    {T : (α → ε) → (α' → ε')} {p p' : ℝ≥0∞} (hp' : p' ≠ 0) {ν : Measure α'}
+    {T : (α → ε) → (α' → ε')} {p p' : ℝ≥0∞} (hp' : p' ≠ 0)
     {c : ℝ≥0∞} (h : HasWeakType T p p' μ ν c) (k : ℝ≥0) :
     HasWeakType (k • T) p p' μ ν (‖k‖ₑ * c) := by
   intro f hf
@@ -661,11 +707,31 @@ lemma HasWeakType.const_smul [ContinuousConstSMul ℝ≥0 ε']
       apply (h f hf).2
     _ = (‖k‖ₑ * c) * eLpNorm f p μ := by simp [coe_mul, mul_assoc]
 
--- XXX: is this the statement we want?
+-- TODO: do we want to unify this lemma with its unprimed version, perhaps using an
+-- `ENormedSemiring` class?
+lemma HasWeakType.const_smul' {T : (α → ε) → (α' → E')} {p p' : ℝ≥0∞} (hp' : p' ≠ 0)
+    {c : ℝ≥0∞} (h : HasWeakType T p p' μ ν c) (k : 𝕜) :
+    HasWeakType (k • T) p p' μ ν (‖k‖ₑ * c) := by
+  intro f hf
+  refine ⟨aestronglyMeasurable_const.smul (h f hf).1, ?_⟩
+  calc wnorm ((k • T) f) p' ν
+    _ ≤ ‖k‖ₑ * wnorm (T f) p' ν := by simp [wnorm_const_smul_le' hp']
+    _ ≤ ‖k‖ₑ * (c * eLpNorm f p μ) := by
+      gcongr
+      apply (h f hf).2
+    _ = (‖k‖ₑ * c) * eLpNorm f p μ := by simp [coe_mul, mul_assoc]
+
 lemma HasWeakType.const_mul {T : (α → ε) → (α' → ℝ≥0∞)} {p p' : ℝ≥0∞} (hp' : p' ≠ 0) {c : ℝ≥0∞}
     (h : HasWeakType T p p' μ ν c) (e : ℝ≥0) :
     HasWeakType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
   h.const_smul hp' e
+
+-- TODO: do we want to unify this lemma with its unprimed version, perhaps using an
+-- `ENormedSemiring` class?
+lemma HasWeakType.const_mul' {T : (α → ε) → (α' → 𝕜)} {p p' : ℝ≥0∞}
+    (hp' : p' ≠ 0) {c : ℝ≥0∞} (h : HasWeakType T p p' μ ν c) (e : 𝕜) :
+    HasWeakType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
+  h.const_smul' hp' e
 
 end
 

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -617,7 +617,7 @@ lemma HasStrongType.const_smul [ContinuousConstSMul ℝ≥0 ε']
 
 -- XXX: is this the statement we want?
 lemma HasStrongType.const_mul
-    {T : (α → ε) → (α' → ℝ≥0)} {p p' : ℝ≥0∞} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (e : ℝ≥0) :
+    {T : (α → ε) → (α' → ℝ≥0∞)} {p p' : ℝ≥0∞} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (e : ℝ≥0) :
     HasStrongType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
   h.const_smul e
 
@@ -662,7 +662,7 @@ lemma HasWeakType.const_smul [ContinuousConstSMul ℝ≥0 ε']
     _ = (‖k‖ₑ * c) * eLpNorm f p μ := by simp [coe_mul, mul_assoc]
 
 -- XXX: is this the statement we want?
-lemma HasWeakType.const_mul {T : (α → ε) → (α' → ℝ≥0)} {p p' : ℝ≥0∞} (hp' : p' ≠ 0) {c : ℝ≥0∞}
+lemma HasWeakType.const_mul {T : (α → ε) → (α' → ℝ≥0∞)} {p p' : ℝ≥0∞} (hp' : p' ≠ 0) {c : ℝ≥0∞}
     (h : HasWeakType T p p' μ ν c) (e : ℝ≥0) :
     HasWeakType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
   h.const_smul hp' e

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -578,12 +578,13 @@ variable {f g : α → ε}
 
 section
 
-variable {ε ε' : Type*} [TopologicalSpace ε] [TopologicalSpace ε'] [ENormedSpace ε']
+variable {ε ε' : Type*} [TopologicalSpace ε] [ContinuousENorm ε]
+variable [TopologicalSpace ε'] [ENormedSpace ε']
 
 -- TODO: this lemma and its primed version could be unified using a `NormedSemifield` typeclass
 -- (which includes NNReal and normed fields like ℝ and ℂ), i.e. assuming 𝕜 is a normed semifield.
 -- Investigate if this is worthwhile when upstreaming this to mathlib.
-lemma distribution_smul_left [ENormedSpace ε] {f : α → ε} {c : ℝ≥0} (hc : c ≠ 0) :
+lemma distribution_smul_left {f : α → ε'} {c : ℝ≥0} (hc : c ≠ 0) :
     distribution (c • f) t μ = distribution f (t / ‖c‖ₑ) μ := by
   have h₀ : ‖c‖ₑ ≠ 0 := by
     have : ‖c‖ₑ = ‖(c : ℝ≥0∞)‖ₑ := rfl
@@ -607,7 +608,7 @@ lemma distribution_smul_left' {f : α → E} {c : 𝕜} (hc : c ≠ 0) :
   rw [← @ENNReal.mul_lt_mul_right (t / ‖c‖ₑ) _ (‖c‖ₑ) h₀ coe_ne_top,
     enorm_absolute_homogeneous' _, mul_comm, ENNReal.div_mul_cancel h₀ coe_ne_top]
 
-lemma HasStrongType.const_smul [ContinuousENorm ε] [ContinuousConstSMul ℝ≥0 ε']
+lemma HasStrongType.const_smul [ContinuousConstSMul ℝ≥0 ε']
     {T : (α → ε) → (α' → ε')} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (k : ℝ≥0) :
     HasStrongType (k • T) p p' μ ν (‖k‖ₑ * c) := by
   refine fun f hf ↦ ⟨AEStronglyMeasurable.const_smul (h f hf).1 k, eLpNorm_const_smul_le'.trans ?_⟩
@@ -626,7 +627,7 @@ lemma HasStrongType.const_smul' [ContinuousENorm ε]
   gcongr
   exact (h f hf).2
 
-lemma HasStrongType.const_mul [ContinuousENorm ε]
+lemma HasStrongType.const_mul
     {T : (α → ε) → (α' → ℝ≥0∞)} {c : ℝ≥0∞} (h : HasStrongType T p p' μ ν c) (e : ℝ≥0) :
     HasStrongType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
   h.const_smul e
@@ -694,7 +695,7 @@ lemma wnorm_const_smul_le' (hp : p ≠ 0) {f : α → E} (k : 𝕜) :
   apply le_of_eq
   congr <;> exact (coe_div knorm_ne_zero).symm
 
-lemma HasWeakType.const_smul [ContinuousENorm ε] [ContinuousConstSMul ℝ≥0 ε']
+lemma HasWeakType.const_smul [ContinuousConstSMul ℝ≥0 ε']
     {T : (α → ε) → (α' → ε')} (hp' : p' ≠ 0) {c : ℝ≥0∞} (h : HasWeakType T p p' μ ν c) (k : ℝ≥0) :
     HasWeakType (k • T) p p' μ ν (‖k‖ₑ * c) := by
   intro f hf
@@ -708,7 +709,7 @@ lemma HasWeakType.const_smul [ContinuousENorm ε] [ContinuousConstSMul ℝ≥0 �
 
 -- TODO: do we want to unify this lemma with its unprimed version, perhaps using an
 -- `ENormedSemiring` class?
-lemma HasWeakType.const_smul' [ContinuousENorm ε] {T : (α → ε) → (α' → E')} (hp' : p' ≠ 0)
+lemma HasWeakType.const_smul' {T : (α → ε) → (α' → E')} (hp' : p' ≠ 0)
     {c : ℝ≥0∞} (h : HasWeakType T p p' μ ν c) (k : 𝕜) :
     HasWeakType (k • T) p p' μ ν (‖k‖ₑ * c) := by
   intro f hf
@@ -720,14 +721,14 @@ lemma HasWeakType.const_smul' [ContinuousENorm ε] {T : (α → ε) → (α' →
       apply (h f hf).2
     _ = (‖k‖ₑ * c) * eLpNorm f p μ := by simp [coe_mul, mul_assoc]
 
-lemma HasWeakType.const_mul [ContinuousENorm ε] {T : (α → ε) → (α' → ℝ≥0∞)} (hp' : p' ≠ 0)
+lemma HasWeakType.const_mul {T : (α → ε) → (α' → ℝ≥0∞)} (hp' : p' ≠ 0)
     {c : ℝ≥0∞} (h : HasWeakType T p p' μ ν c) (e : ℝ≥0) :
     HasWeakType (fun f x ↦ e * T f x) p p' μ ν (e * c) :=
   h.const_smul hp' e
 
 -- TODO: do we want to unify this lemma with its unprimed version, perhaps using an
 -- `ENormedSemiring` class?
-lemma HasWeakType.const_mul' [ContinuousENorm ε] {T : (α → ε) → (α' → 𝕜)} (hp' : p' ≠ 0)
+lemma HasWeakType.const_mul' {T : (α → ε) → (α' → 𝕜)} (hp' : p' ≠ 0)
     {c : ℝ≥0∞} (h : HasWeakType T p p' μ ν c) (e : 𝕜) :
     HasWeakType (fun f x ↦ e * T f x) p p' μ ν (‖e‖ₑ * c) :=
   h.const_smul' hp' e

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -12,7 +12,7 @@ open NNReal ENNReal NormedSpace MeasureTheory Set Filter Topology Function
 
 section move
 
-variable {α 𝕜 E : Type*} {m : MeasurableSpace α}
+variable {α 𝕜 ε E : Type*} {m : MeasurableSpace α}
   {μ : Measure α} [NontriviallyNormedField 𝕜]
   [NormedAddCommGroup E] [MulActionWithZero 𝕜 E] [IsBoundedSMul 𝕜 E]
   {p : ℝ≥0∞}
@@ -20,6 +20,13 @@ variable {α 𝕜 E : Type*} {m : MeasurableSpace α}
 -- todo: move/rename/and perhaps reformulate in terms of ‖.‖ₑ
 lemma ENNNorm_absolute_homogeneous {c : 𝕜} (z : E) : ofNNReal ‖c • z‖₊ = ↑‖c‖₊ * ↑‖z‖₊ :=
   (toReal_eq_toReal_iff' coe_ne_top coe_ne_top).mp (norm_smul c z)
+
+-- TODO: this lemma and its primed version could be unified using a `NormedSemifield` typeclass
+-- (which includes NNReal and normed fields like ℝ and ℂ), i.e. assuming 𝕜 is a normed semifield.
+-- Investigate if this is worthwhile when upstreaming this to mathlib.
+lemma enorm_absolute_homogeneous [TopologicalSpace ε] [ENormedSpace ε] {c : ℝ≥0} (z : ε) :
+    ‖c • z‖ₑ = ‖c‖ₑ * ‖z‖ₑ :=
+  ENormedSpace.enorm_smul _ _
 
 lemma enorm_absolute_homogeneous' {c : 𝕜} (z : E) : ‖c • z‖ₑ = ‖c‖ₑ * ‖z‖ₑ :=
   (toReal_eq_toReal_iff' coe_ne_top coe_ne_top).mp (norm_smul c z)
@@ -576,7 +583,20 @@ variable [TopologicalSpace ε] [ContinuousENorm ε]
 variable [NormedAddCommGroup E] [MulActionWithZero 𝕜 E] [IsBoundedSMul 𝕜 E]
   {E' : Type*} [NormedAddCommGroup E'] [MulActionWithZero 𝕜 E'] [IsBoundedSMul 𝕜 E']
 
--- TODO: add an analogue for the ENorm context, using scalar multiplication w.r.t. `NNReal` on an `ENormedSpace`
+-- TODO: this lemma and its primed version could be unified using a `NormedSemifield` typeclass
+-- (which includes NNReal and normed fields like ℝ and ℂ), i.e. assuming 𝕜 is a normed semifield.
+-- Investigate if this is worthwhile when upstreaming this to mathlib.
+lemma distribution_smul_left {ε} [TopologicalSpace ε] [ENormedSpace ε] {f : α → ε} {c : ℝ≥0} (hc : c ≠ 0) :
+    distribution (c • f) t μ = distribution f (t / ‖c‖ₑ) μ := by
+  have h₀ : ‖c‖ₑ ≠ 0 := by
+    have : ‖c‖ₑ = ‖(c : ℝ≥0∞)‖ₑ := rfl
+    rw [this, enorm_ne_zero]
+    exact ENNReal.coe_ne_zero.mpr hc
+  unfold distribution
+  congr with x
+  simp only [Pi.smul_apply, mem_setOf_eq]
+  rw [← @ENNReal.mul_lt_mul_right (t / ‖c‖ₑ) _ (‖c‖ₑ) h₀ coe_ne_top,
+    enorm_absolute_homogeneous (c := c) _, ENNReal.div_mul_cancel h₀ coe_ne_top, mul_comm]
 
 lemma distribution_smul_left' {f : α → E} {c : 𝕜} (hc : c ≠ 0) :
     distribution (c • f) t μ = distribution f (t / ‖c‖ₑ) μ := by


### PR DESCRIPTION
One section about the layercake formula remains (and will be changed in a future PR). This requires generalising a handful of mathlib lemmas: https://github.com/leanprover-community/mathlib4/pull/23707 contained some of these, others need ENormedSpace to be in mathlib first.

For most of this file, there is a trade-off about generality to be made: currently, there is no typeclass unifying both a normed space over a field and an ENormedSpace. Hence, we usually add enorm variants of existing lemmas and keep the existing versions.
We make one change, though: the normed space becomes primed; the enorm version stays unprimed.