### PR TITLE
Lemma 10.1.4 (both parts)

### DIFF
--- a/Carleson/ToMathlib/HardyLittlewood.lean
+++ b/Carleson/ToMathlib/HardyLittlewood.lean
@@ -677,6 +677,13 @@ theorem hasWeakType_maximalFunction_equal_exponents
 def C_weakType_maximalFunction (A p₁ p₂ : ℝ≥0) :=
   if p₁ = p₂ then (ofNNReal A) ^ (2 / p₁ : ℝ) else C2_0_6 A p₁ p₂
 
+lemma C_weakType_maximalFunction_lt_top {A p₁ p₂ : ℝ≥0} :
+    C_weakType_maximalFunction A p₁ p₂ < ∞ := by
+  unfold C_weakType_maximalFunction
+  split_ifs with hps
+  · apply rpow_lt_top_of_nonneg (by positivity) (by simp)
+  · simp
+
 /-- `hasStrongType_maximalFunction` minus the assumption `hR`, but where `p₁ = p₂` is possible and
 we only conclude a weak-type estimate. -/
 theorem hasWeakType_maximalFunction
@@ -772,6 +779,10 @@ theorem hasStrongType_globalMaximalFunction [BorelSpace X] [IsFiniteMeasureOnCom
 def C_weakType_globalMaximalFunction (A p₁ p₂ : ℝ≥0) :=
   A ^ 2 * C_weakType_maximalFunction A p₁ p₂
 
+lemma C_weakType_globalMaximalFunction_lt_top {A p₁ p₂ : ℝ≥0} :
+    C_weakType_globalMaximalFunction A p₁ p₂ < ∞ :=
+  mul_lt_top (by simp) C_weakType_maximalFunction_lt_top
+
 -- the constant here `A ^ 4` can be improved
 theorem hasWeakType_globalMaximalFunction [BorelSpace X] [IsFiniteMeasureOnCompacts μ]
     [Nonempty X] [μ.IsOpenPosMeasure] {p₁ p₂ : ℝ≥0} (hp₁ : 1 ≤ p₁) (hp₁₂ : p₁ ≤ p₂) :
@@ -788,5 +799,14 @@ theorem hasWeakType_globalMaximalFunction [BorelSpace X] [IsFiniteMeasureOnCompa
 lemma lowerSemiContinuous_globalMaximalFunction (hf : LocallyIntegrable f μ) :
     LowerSemicontinuous (globalMaximalFunction μ 1 f) := by
   sorry
+
+theorem globalMaximalFunction_ae_lt_top [BorelSpace X] [IsFiniteMeasureOnCompacts μ]
+    [Nonempty X] [μ.IsOpenPosMeasure] {p₁ p₂ : ℝ≥0} (hp₁ : 1 ≤ p₁) (hp₁₂ : p₁ < p₂)
+    {u : X → E} (hu : MemLp u p₂ μ):
+    ∀ᵐ x ∂μ, globalMaximalFunction μ p₁ u x < ∞ := by
+  simp_rw [lt_top_iff_ne_top]
+  conv => arg 1; intro x; rw [← enorm_eq_self (x := globalMaximalFunction μ p₁ u x)]
+  exact MemWℒp.ae_ne_top (HasWeakType.memWℒp (hasWeakType_globalMaximalFunction hp₁ hp₁₂.le) hu
+    C_weakType_globalMaximalFunction_lt_top)
 
 end GMF

--- a/Carleson/ToMathlib/HardyLittlewood.lean
+++ b/Carleson/ToMathlib/HardyLittlewood.lean
@@ -806,7 +806,7 @@ theorem globalMaximalFunction_ae_lt_top [BorelSpace X] [IsFiniteMeasureOnCompact
     ∀ᵐ x ∂μ, globalMaximalFunction μ p₁ u x < ∞ := by
   simp_rw [lt_top_iff_ne_top]
   conv => arg 1; intro x; rw [← enorm_eq_self (x := globalMaximalFunction μ p₁ u x)]
-  exact MemWℒp.ae_ne_top (HasWeakType.memWℒp (hasWeakType_globalMaximalFunction hp₁ hp₁₂.le) hu
+  exact MemWLp.ae_ne_top (HasWeakType.memWLp (hasWeakType_globalMaximalFunction hp₁ hp₁₂.le) hu
     C_weakType_globalMaximalFunction_lt_top)
 
 end GMF

--- a/Carleson/ToMathlib/HardyLittlewood.lean
+++ b/Carleson/ToMathlib/HardyLittlewood.lean
@@ -704,10 +704,18 @@ def globalMaximalFunction [μ.IsDoubling A] (p : ℝ) (u : X → E) (x : X) : �
     (·.1) (fun x ↦ 2 ^ (x.2)) p u x
 
 -- prove only if needed. Use `MB_le_eLpNormEssSup`
--- theorem globalMaximalFunction_lt_top {p : ℝ≥0} (hp₁ : 1 ≤ p)
---     {u : X → E} (hu : AEStronglyMeasurable u μ) (hu : IsBounded (range u)) {x : X} :
---     globalMaximalFunction μ p u x < ∞ := by
---   sorry
+theorem globalMaximalFunction_lt_top {p : ℝ≥0} (hp₁ : 1 ≤ p)
+    {u : X → E} (hu : MemLp u ⊤ μ) {x : X} :
+    globalMaximalFunction μ p u x < ∞ := by
+  unfold globalMaximalFunction
+  rw [maximalFunction_eq_MB (by simp)]
+  apply mul_lt_top (by simp) (rpow_lt_top_of_nonneg (by simp) (lt_top_iff_ne_top.mp _))
+  have : MemLp (fun x ↦ ‖u x‖ ^ p.toReal) ⊤ μ := by
+    have rw1 : p.toReal = (p : ℝ≥0∞).toReal := by simp
+    have rw2 : (⊤ : ℝ≥0∞) = ⊤ / p := by simp
+    rw [rw1, rw2, memLp_norm_rpow_iff hu.aestronglyMeasurable (by positivity) (by simp)]
+    exact hu
+  exact lt_of_le_of_lt MB_le_eLpNormEssSup (this.eLpNormEssSup_lt_top)
 
 protected theorem MeasureTheory.AEStronglyMeasurable.globalMaximalFunction
     [BorelSpace X] {p : ℝ} {u : X → E} : AEStronglyMeasurable (globalMaximalFunction μ p u) μ :=

--- a/Carleson/ToMathlib/Misc.lean
+++ b/Carleson/ToMathlib/Misc.lean
@@ -214,6 +214,7 @@ variable {α : Type*} {m : MeasurableSpace α} {μ : Measure α} {s : Set α}
 
 attribute [fun_prop] Continuous.comp_aestronglyMeasurable
   AEStronglyMeasurable.mul AEStronglyMeasurable.prodMk
+  AEMeasurable.restrict AEStronglyMeasurable.restrict
 attribute [gcongr] Measure.AbsolutelyContinuous.prod -- todo: also add one-sided versions for gcongr
 attribute [fun_prop] AEStronglyMeasurable.comp_measurable
 

--- a/Carleson/TwoSidedCarleson/Basic.lean
+++ b/Carleson/TwoSidedCarleson/Basic.lean
@@ -41,33 +41,6 @@ lemma czOperator_aestronglyMeasurable {g : X → ℂ} (hg : BoundedFiniteSupport
     simp_rw [mem_compl_iff, mem_ball, not_lt]
     apply measurableSet_le <;> fun_prop
 
-lemma memLp_top_czOperator {g : X → ℂ} (hg : BoundedFiniteSupport g) (hr : 0 < r) :
-    MemLp (czOperator K r g) ⊤ volume := by
-  constructor
-  · exact czOperator_aestronglyMeasurable hg
-  rw [eLpNorm_exponent_top]
-  let C := (C_K a * eLpNorm g ⊤ volume).toNNReal
-  apply eLpNormEssSup_lt_top_of_ae_enorm_bound (C := C)
-  unfold C czOperator
-  rw [ENNReal.coe_toNNReal (mul_lt_top (by simp) (hg.eLpNorm_lt_top)).ne]
-  apply Filter.Eventually.mono _ (fun x ↦ (enorm_integral_le_lintegral_enorm _).trans)
-  apply Filter.Eventually.mono _ (fun x ↦ (lintegral_mono_ae ?ae).trans)
-  case ae =>
-    change ∀ᵐ y ∂volume.restrict (ball x r)ᶜ, ‖K x y * g y‖ₑ
-        ≤ (fun a ↦ ‖K x a‖ₑ * eLpNorm g ⊤ volume) y
-    filter_upwards [enorm_ae_le_eLpNormEssSup g (volume.restrict (ball x r)ᶜ)]
-    intro y hy
-    simp_rw [enorm_mul]
-    rw [← eLpNorm_exponent_top] at hy
-    gcongr
-    apply hy.trans
-    apply eLpNorm_restrict_le
-  simp_rw [lintegral_mul_const' _ _ hg.eLpNorm_lt_top.ne]
-  filter_upwards
-  intro x
-  gcongr
-  sorry
-
 lemma czoperator_welldefined {g : X → ℂ} (hg : BoundedFiniteSupport g) (hr : 0 < r) (x : X):
     IntegrableOn (fun y => K x y * g y) (ball x r)ᶜ volume := by
   let Kxg := fun y ↦ K x y * g y

--- a/Carleson/TwoSidedCarleson/Basic.lean
+++ b/Carleson/TwoSidedCarleson/Basic.lean
@@ -26,6 +26,48 @@ lemma memLp_top_K_on_ball_complement (hr : 0 < r) {x : X}:
       · intro y hy
         apply enorm_K_le_ball_complement' hr hy
 
+@[fun_prop]
+lemma czOperator_aestronglyMeasurable {g : X → ℂ} (hg : BoundedFiniteSupport g) :
+    AEStronglyMeasurable (fun x ↦ czOperator K r g x) := by
+  unfold czOperator
+  conv => arg 1; intro x; rw [← integral_indicator (by measurability)]
+  let f := fun (x,z) ↦ (ball x r)ᶜ.indicator (fun y ↦ K x y * g y) z
+  apply AEStronglyMeasurable.integral_prod_right' (f := f)
+  unfold f
+  apply AEStronglyMeasurable.indicator
+  · apply Continuous.comp_aestronglyMeasurable₂ (by fun_prop) aestronglyMeasurable_K
+    exact AEStronglyMeasurable.snd (hg.aestronglyMeasurable)
+  · conv => arg 1; change {x : (X × X) | x.2 ∈ (ball x.1 r)ᶜ}
+    simp_rw [mem_compl_iff, mem_ball, not_lt]
+    apply measurableSet_le <;> fun_prop
+
+lemma memLp_top_czOperator {g : X → ℂ} (hg : BoundedFiniteSupport g) (hr : 0 < r) :
+    MemLp (czOperator K r g) ⊤ volume := by
+  constructor
+  · exact czOperator_aestronglyMeasurable hg
+  rw [eLpNorm_exponent_top]
+  let C := (C_K a * eLpNorm g ⊤ volume).toNNReal
+  apply eLpNormEssSup_lt_top_of_ae_enorm_bound (C := C)
+  unfold C czOperator
+  rw [ENNReal.coe_toNNReal (mul_lt_top (by simp) (hg.eLpNorm_lt_top)).ne]
+  apply Filter.Eventually.mono _ (fun x ↦ (enorm_integral_le_lintegral_enorm _).trans)
+  apply Filter.Eventually.mono _ (fun x ↦ (lintegral_mono_ae ?ae).trans)
+  case ae =>
+    change ∀ᵐ y ∂volume.restrict (ball x r)ᶜ, ‖K x y * g y‖ₑ
+        ≤ (fun a ↦ ‖K x a‖ₑ * eLpNorm g ⊤ volume) y
+    filter_upwards [enorm_ae_le_eLpNormEssSup g (volume.restrict (ball x r)ᶜ)]
+    intro y hy
+    simp_rw [enorm_mul]
+    rw [← eLpNorm_exponent_top] at hy
+    gcongr
+    apply hy.trans
+    apply eLpNorm_restrict_le
+  simp_rw [lintegral_mul_const' _ _ hg.eLpNorm_lt_top.ne]
+  filter_upwards
+  intro x
+  gcongr
+  sorry
+
 lemma czoperator_welldefined {g : X → ℂ} (hg : BoundedFiniteSupport g) (hr : 0 < r) (x : X):
     IntegrableOn (fun y => K x y * g y) (ball x r)ᶜ volume := by
   let Kxg := fun y ↦ K x y * g y

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -669,7 +669,7 @@ irreducible_def C10_1_4 (a : ℕ) : ℝ≥0 := 2 ^ (a ^ 3 + 20 * a + 2)
 
 @[fun_prop]
 lemma czOperator_aemeasurable {g : X → ℂ} (hg : BoundedFiniteSupport g) :
-    AEMeasurable (fun x ↦ czOperator K r g x) (μ := (volume.restrict (ball x (R/4)))) := by
+    AEMeasurable (fun x ↦ czOperator K r g x) := by
   sorry
 
 lemma globalMaximalFunction_zero_enorm_czoperator_ae_zero (hR : 0 < R) {g : X → ℂ} (hg : BoundedFiniteSupport g)
@@ -677,9 +677,7 @@ lemma globalMaximalFunction_zero_enorm_czoperator_ae_zero (hR : 0 < R) {g : X �
     ∀ᵐ x' ∂(volume.restrict (ball x (R / 4))), ‖czOperator K r g x'‖ₑ = 0 := by
   change (fun x' ↦ ‖czOperator K r g x'‖ₑ) =ᶠ[ae (volume.restrict (ball x (R / 4)))] 0
   rw [← lintegral_eq_zero_iff' ?hf]
-  case hf =>
-    have : AEMeasurable (fun x ↦ czOperator K r g x) (μ := (volume.restrict (ball x (R/4)))) := by sorry
-    fun_prop
+  case hf => exact AEMeasurable.restrict (by fun_prop) -- TODO tag with `fun_prop`?
   rw [← bot_eq_zero, ← le_bot_iff, bot_eq_zero]
   apply le_of_le_of_eq (lintegral_ball_le_volume_globalMaximalFunction _)
   · rw [hMzero]
@@ -702,13 +700,14 @@ theorem cotlar_set_F₁ (ha : 4 ≤ a) (hr : 0 < r) (hR : r ≤ R)
     filter_upwards [czzero]
     intro x' hx'
     simp [hx']
-  · rw [← lintegral_indicator_one ?hs]
-    case hs => sorry
-    rw [← ENNReal.mul_le_mul_right ?ne_z ?ne_t (c := 4 * MTrgx)]
-    case ne_z => sorry
-    case ne_t => sorry
-    rw [← lintegral_mul_const]
-    case neg.hf => sorry
+  · rw [← lintegral_indicator_one₀ ?hs]
+    case hs =>
+      apply nullMeasurableSet_lt (by fun_prop)
+      exact AEMeasurable.restrict (by fun_prop) -- TODO tag with `fun_prop`?
+    rw [← ENNReal.mul_le_mul_right (by simp [hMzero]) ?ne_t (c := 4 * MTrgx)]
+    case ne_t => apply mul_ne_top (by simp); sorry --globalMaximalFunction_lt_top
+    rw [← lintegral_mul_const']
+    case neg.hr => apply mul_ne_top (by simp); sorry --globalMaximalFunction_lt_top
     simp_rw [← indicator_mul_const, Pi.one_apply, one_mul]
     trans ∫⁻ (y : X) in ball x (R / 4),
     {x' | 4 * globalMaximalFunction volume 1 (czOperator K r g) x < ‖czOperator K r g x'‖ₑ}.indicator

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -668,10 +668,10 @@ theorem cotlar_control (ha : 4 ≤ a)
 irreducible_def C10_1_4 (a : ℕ) : ℝ≥0 := 2 ^ (a ^ 3 + 20 * a + 2)
 
 omit [CompatibleFunctions ℝ X (defaultA a)] [IsCancellative X (defaultτ a)] in
-lemma globalMaximalFunction_zero_enorm_czoperator_ae_zero (hR : 0 < R) {g : X → ℂ} (hg : BoundedFiniteSupport g)
-    (hMzero : globalMaximalFunction volume 1 (czOperator K r g) x = 0) :
-    ∀ᵐ x' ∂(volume.restrict (ball x (R / 4))), ‖czOperator K r g x'‖ₑ = 0 := by
-  change (fun x' ↦ ‖czOperator K r g x'‖ₑ) =ᶠ[ae (volume.restrict (ball x (R / 4)))] 0
+lemma globalMaximalFunction_zero_enorm_ae_zero (hR : 0 < R) {f : X → ℂ} (hf : AEStronglyMeasurable f)
+    (hMzero : globalMaximalFunction volume 1 f x = 0) :
+    ∀ᵐ x' ∂(volume.restrict (ball x (R / 4))), ‖f x'‖ₑ = 0 := by
+  change (fun x' ↦ ‖f x'‖ₑ) =ᶠ[ae (volume.restrict (ball x (R / 4)))] 0
   rw [← lintegral_eq_zero_iff' ?hf]
   case hf => exact AEMeasurable.restrict (by fun_prop) -- TODO tag with `fun_prop`?
   rw [← bot_eq_zero, ← le_bot_iff, bot_eq_zero]
@@ -690,7 +690,7 @@ theorem cotlar_set_F₁ (hr : 0 < r) (hR : r ≤ R) {g : X → ℂ} (hg : Bounde
   by_cases hMzero : MTrgx = 0
   · apply le_of_eq_of_le _ (zero_le _)
     rw [measure_zero_iff_ae_nmem]
-    have czzero := globalMaximalFunction_zero_enorm_czoperator_ae_zero (lt_of_lt_of_le hr hR) hg hMzero
+    have czzero := globalMaximalFunction_zero_enorm_ae_zero (lt_of_lt_of_le hr hR) (by fun_prop) hMzero
     filter_upwards [czzero]
     intro x' hx'
     simp [hx']
@@ -722,13 +722,23 @@ theorem cotlar_set_F₁ (hr : 0 < r) (hR : r ≤ R) {g : X → ℂ} (hg : Bounde
   simp [(lt_of_lt_of_le hr hR)]
 
 /-- Part 2 of Lemma 10.1.4 about `F₂`. -/
-theorem cotlar_set_F₂ (ha : 4 ≤ a)
+theorem cotlar_set_F₂ (ha : 4 ≤ a) (hr : 0 < r) (hR : r ≤ R)
     (hT : ∀ r > 0, HasBoundedStrongType (czOperator K r) 2 2 volume volume (C_Ts a))
     {g : X → ℂ} (hg : BoundedFiniteSupport g) :
-    volume {x' ∈ ball x (R / 4) |
-      C10_1_4 a * globalMaximalFunction volume 1 g x <
+    volume.restrict (ball x (R / 4))
+      {x' | C10_1_4 a * globalMaximalFunction volume 1 g x <
       ‖czOperator K r ((ball x (R / 2)).indicator g) x'‖ₑ } ≤
     volume (ball x (R / 4)) / 4 := by
+  let Trgi := czOperator K r ((ball x (R / 2)).indicator g)
+  by_cases hMzero : globalMaximalFunction volume 1 g x = 0
+  · apply le_of_eq_of_le _ (zero_le _)
+    rw [measure_zero_iff_ae_nmem]
+    have gzero := globalMaximalFunction_zero_enorm_ae_zero (lt_of_lt_of_le hr hR) (by fun_prop) hMzero
+    have czzero : ∀ᵐ x' ∂(volume.restrict (ball x (R / 4))), ‖czOperator K r ((ball x (R / 2)).indicator g) x'‖ₑ = 0 := by
+      sorry
+    filter_upwards [czzero]
+    intro x' hx'
+    simp [hx']
   sorry
 
 /-- The constant used in `cotlar_estimate`. -/

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -698,7 +698,7 @@ theorem cotlar_set_F₁ (ha : 4 ≤ a) (hr : 0 < r) (hR : r ≤ R)
   by_cases hMzero : MTrgx = 0
   · apply le_of_eq_of_le _ (zero_le _)
     rw [measure_zero_iff_ae_nmem]
-    have czzero := globalMaximalFunction_zero_enorm_czoperator_ae_zero (r := r) (lt_of_lt_of_le hr hR) hg hMzero
+    have czzero := globalMaximalFunction_zero_enorm_czoperator_ae_zero (lt_of_lt_of_le hr hR) hg hMzero
     filter_upwards [czzero]
     intro x' hx'
     simp [hx']
@@ -720,6 +720,7 @@ theorem cotlar_set_F₁ (ha : 4 ≤ a) (hr : 0 < r) (hR : r ≤ R)
       exact le_of_lt
     trans ∫⁻ (y : X) in ball x (R / 4), ‖czOperator K r g y‖ₑ
     · apply lintegral_mono_fn
+      intro y -- otherwise runs into deterministic timeout, don't ask me why
       apply indicator_le_self
     rw [mul_assoc]
     nth_rw 2 [← mul_assoc]

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -3,7 +3,7 @@ import Carleson.ToMathlib.Annulus
 import Carleson.ToMathlib.HardyLittlewood
 import Carleson.ToMathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
 import Carleson.ToMathlib.MeasureTheory.Integral.Lebesgue
-import Carleson.TwoSidedCarleson.Basic
+import Carleson.TwoSidedCarleson.WeakCalderonZygmund
 
 open MeasureTheory Set Bornology Function ENNReal Metric
 open scoped NNReal
@@ -731,16 +731,17 @@ theorem cotlar_set_F₂ (ha : 4 ≤ a) (hr : 0 < r) (hR : r ≤ R) [IsOneSidedKe
   by_cases hMzero : globalMaximalFunction volume 1 g x = 0
   · apply le_of_eq_of_le _ (zero_le _)
     rw [measure_zero_iff_ae_nmem]
-    have gzero := globalMaximalFunction_zero_enorm_ae_zero (R := R / 2) (by simp [lt_of_lt_of_le hr hR]) (by fun_prop) hMzero
+    have gzero := globalMaximalFunction_zero_enorm_ae_zero (R := R / 2)
+        (by simp [lt_of_lt_of_le hr hR]) hg.aestronglyMeasurable hMzero
     have czzero : ∀ᵐ x' ∂(volume.restrict (ball x (R / 4))), ‖czOperator K r ((ball x (R / 2)).indicator g) x'‖ₑ = 0 := by
       simp_rw [← bot_eq_zero, ← le_bot_iff]
       apply Filter.Eventually.mono (.of_forall _) (fun x ↦ (enorm_integral_le_lintegral_enorm _).trans)
       intro x'
-      rw [le_bot_iff, bot_eq_zero, lintegral_eq_zero_iff' ?hf.aemeasurable]
-      case hf =>
+      rw [le_bot_iff, bot_eq_zero, lintegral_eq_zero_iff' ?hf_ae]
+      case hf_ae =>
         apply (AEMeasurable.enorm _).restrict
         apply AEMeasurable.mul (measurable_K_right x').aemeasurable
-        exact AEMeasurable.indicator (hg.aemeasurable) (by measurability)
+        exact AEMeasurable.indicator (hg.aemeasurable) measurableSet_ball
       simp_rw [← indicator_mul_right, enorm_indicator_eq_indicator_enorm]
       rw [indicator_ae_eq_zero, inter_comm, ← Measure.restrict_apply' measurableSet_ball,
         Measure.restrict_restrict measurableSet_ball, ← bot_eq_zero, ← le_bot_iff]
@@ -749,11 +750,52 @@ theorem cotlar_set_F₂ (ha : 4 ≤ a) (hr : 0 < r) (hR : r ≤ R) [IsOneSidedKe
       filter_upwards [gzero]
       intro y hy
       change ‖K x' y * g y‖ₑ = 0
-      simp [enorm_eq_zero.mp hy]
+      simp [hy]
     filter_upwards [czzero]
     intro x' hx'
     simp [hx']
-  sorry
+  by_cases hMinfty : globalMaximalFunction volume 1 g x = ∞
+  · simp_rw [hMinfty, C10_1_4_def]
+    simp
+  apply (Measure.restrict_le_self _).trans
+  let g1 := (ball x (R / 2)).indicator g
+  have bfs_g1 : BoundedFiniteSupport g1 := hg.indicator measurableSet_ball
+  have czw11 := czoperator_weak_1_1 ha hr (hT r hr)
+  unfold HasBoundedWeakType at czw11
+  have := (czw11 (f := g1) (bfs_g1.memLp _) bfs_g1.eLpNorm_lt_top bfs_g1.measure_support_lt).2
+  unfold wnorm wnorm' distribution at this
+  simp_rw [one_ne_top, reduceIte, toReal_one, inv_one, rpow_one,
+    iSup_le_iff] at this
+  have := this (C10_1_4 a * (globalMaximalFunction volume 1 g x).toNNReal)
+  have constants : C10_1_4 a = C10_0_3 a * (2 ^ (a + 2)) := by rw [C10_1_4_def, C10_0_3_def]; ring
+  nth_rw 1 [constants] at this
+  rw [coe_mul, coe_mul, coe_mul] at this --push_cast unfolds defaultA which is cumbersome
+  rw [mul_assoc, mul_assoc, ENNReal.mul_le_mul_left (by rw [C10_0_3_def]; positivity) coe_ne_top,
+    ← mul_assoc, mul_comm, ENNReal.coe_toNNReal hMinfty,
+    ← ENNReal.le_div_iff_mul_le ?ne_z ?ne_t] at this
+  case ne_z => left; exact mul_ne_zero (by simp) hMzero --again due to defaultA behaviour
+  case ne_t => left; exact mul_ne_top coe_ne_top hMinfty
+  apply this.trans
+  rw [ENNReal.div_le_iff_le_mul ?ne_z ?ne_t]
+  case ne_z => left; exact mul_ne_zero (by simp) hMzero --defaultA behaviour
+  case ne_t => left; exact mul_ne_top coe_ne_top hMinfty
+  unfold g1
+  simp_rw [eLpNorm_one_eq_lintegral_enorm, enorm_indicator_eq_indicator_enorm,
+    lintegral_indicator measurableSet_ball]
+  apply (lintegral_ball_le_volume_globalMaximalFunction (z := x) (x := x) (by simp [lt_of_lt_of_le hr hR])).trans
+  rw [← mul_assoc]
+  gcongr
+  have : volume (ball x (R / 2)) ≤ defaultA a * volume (ball x (R / 4)) := by
+    let tmp : R / 2 = 2 * (R / 4) := by ring
+    rw [tmp]
+    apply measure_ball_two_le_same
+  apply this.trans (le_of_eq _)
+  push_cast
+  nth_rw 2 [div_eq_mul_inv]
+  rw [mul_assoc, mul_comm]
+  congr
+  ring_nf
+  rw [mul_comm, ← mul_assoc, ENNReal.mul_inv_cancel (by simp) (by simp), one_mul]
 
 /-- The constant used in `cotlar_estimate`. -/
 irreducible_def C10_1_5 (a : ℕ) : ℝ≥0 := 2 ^ (a ^ 3 + 20 * a + 2)

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -667,14 +667,66 @@ theorem cotlar_control (ha : 4 ≤ a)
 /-- The constant used in `cotlar_set_F₂`. -/
 irreducible_def C10_1_4 (a : ℕ) : ℝ≥0 := 2 ^ (a ^ 3 + 20 * a + 2)
 
+@[fun_prop]
+lemma czOperator_aemeasurable {g : X → ℂ} (hg : BoundedFiniteSupport g) :
+    AEMeasurable (fun x ↦ czOperator K r g x) (μ := (volume.restrict (ball x (R/4)))) := by
+  sorry
+
+lemma globalMaximalFunction_zero_enorm_czoperator_ae_zero (hR : 0 < R) {g : X → ℂ} (hg : BoundedFiniteSupport g)
+    (hMzero : globalMaximalFunction volume 1 (czOperator K r g) x = 0) :
+    ∀ᵐ x' ∂(volume.restrict (ball x (R / 4))), ‖czOperator K r g x'‖ₑ = 0 := by
+  change (fun x' ↦ ‖czOperator K r g x'‖ₑ) =ᶠ[ae (volume.restrict (ball x (R / 4)))] 0
+  rw [← lintegral_eq_zero_iff' ?hf]
+  case hf =>
+    have : AEMeasurable (fun x ↦ czOperator K r g x) (μ := (volume.restrict (ball x (R/4)))) := by sorry
+    fun_prop
+  rw [← bot_eq_zero, ← le_bot_iff, bot_eq_zero]
+  apply le_of_le_of_eq (lintegral_ball_le_volume_globalMaximalFunction _)
+  · rw [hMzero]
+    simp
+  · simp [hR]
+
 /-- Part 1 of Lemma 10.1.4 about `F₁`. -/
-theorem cotlar_set_F₁ (ha : 4 ≤ a)
+theorem cotlar_set_F₁ (ha : 4 ≤ a) (hr : 0 < r) (hR : r ≤ R)
     (hT : ∀ r > 0, HasBoundedStrongType (czOperator K r) 2 2 volume volume (C_Ts a))
     {g : X → ℂ} (hg : BoundedFiniteSupport g) :
-    volume {x' ∈ ball x (R / 4) |
-      4 * globalMaximalFunction volume 1 (czOperator K r g) x < ‖czOperator K r g x'‖ₑ } ≤
+    volume.restrict (ball x (R / 4))
+      {x' | 4 * globalMaximalFunction volume 1 (czOperator K r g) x < ‖czOperator K r g x'‖ₑ } ≤
     volume (ball x (R / 4)) / 4 := by
-  sorry
+  let MTrgx := globalMaximalFunction volume 1 (czOperator K r g) x
+  nth_rw 2 [div_eq_mul_inv]
+  by_cases hMzero : MTrgx = 0
+  · apply le_of_eq_of_le _ (zero_le _)
+    rw [measure_zero_iff_ae_nmem]
+    have czzero := globalMaximalFunction_zero_enorm_czoperator_ae_zero (r := r) (lt_of_lt_of_le hr hR) hg hMzero
+    filter_upwards [czzero]
+    intro x' hx'
+    simp [hx']
+  · rw [← lintegral_indicator_one ?hs]
+    case hs => sorry
+    rw [← ENNReal.mul_le_mul_right ?ne_z ?ne_t (c := 4 * MTrgx)]
+    case ne_z => sorry
+    case ne_t => sorry
+    rw [← lintegral_mul_const]
+    case neg.hf => sorry
+    simp_rw [← indicator_mul_const, Pi.one_apply, one_mul]
+    trans ∫⁻ (y : X) in ball x (R / 4),
+    {x' | 4 * globalMaximalFunction volume 1 (czOperator K r g) x < ‖czOperator K r g x'‖ₑ}.indicator
+      (fun x_1 ↦ ‖czOperator K r g y‖ₑ ) y
+    · apply lintegral_mono_fn
+      intro y
+      apply indicator_le_indicator'
+      rw [mem_setOf_eq]
+      exact le_of_lt
+    trans ∫⁻ (y : X) in ball x (R / 4), ‖czOperator K r g y‖ₑ
+    · apply lintegral_mono_fn
+      apply indicator_le_self
+    rw [mul_assoc]
+    nth_rw 2 [← mul_assoc]
+    rw [ENNReal.inv_mul_cancel (by simp) (by simp)]
+    simp only [one_mul, MTrgx]
+    apply lintegral_ball_le_volume_globalMaximalFunction
+    simp [(lt_of_lt_of_le hr hR)]
 
 /-- Part 2 of Lemma 10.1.4 about `F₂`. -/
 theorem cotlar_set_F₂ (ha : 4 ≤ a)

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -682,9 +682,7 @@ lemma globalMaximalFunction_zero_enorm_czoperator_ae_zero (hR : 0 < R) {g : X �
 
 omit [CompatibleFunctions ℝ X (defaultA a)] [IsCancellative X (defaultτ a)] in
 /-- Part 1 of Lemma 10.1.4 about `F₁`. -/
-theorem cotlar_set_F₁ (ha : 4 ≤ a) (hr : 0 < r) (hR : r ≤ R)
-    (hT : ∀ r > 0, HasBoundedStrongType (czOperator K r) 2 2 volume volume (C_Ts a))
-    {g : X → ℂ} (hg : BoundedFiniteSupport g) :
+theorem cotlar_set_F₁ (hr : 0 < r) (hR : r ≤ R) {g : X → ℂ} (hg : BoundedFiniteSupport g) :
     volume.restrict (ball x (R / 4))
       {x' | 4 * globalMaximalFunction volume 1 (czOperator K r g) x < ‖czOperator K r g x'‖ₑ } ≤
     volume (ball x (R / 4)) / 4 := by
@@ -697,16 +695,12 @@ theorem cotlar_set_F₁ (ha : 4 ≤ a) (hr : 0 < r) (hR : r ≤ R)
     intro x' hx'
     simp [hx']
   rw [← lintegral_indicator_one₀ (nullMeasurableSet_lt (by fun_prop) (by fun_prop))]
-  rw [← ENNReal.mul_le_mul_right (by simp [hMzero]) ?ne_t (c := 4 * MTrgx)]
-  case ne_t =>
-    apply mul_ne_top (by simp)
-    unfold MTrgx
-    exact (globalMaximalFunction_lt_top (p := 1) (by simp) (memLp_top_czOperator hg hr)).ne
-  rw [← lintegral_mul_const' _ _ ?hr]
-  case hr =>
-    apply mul_ne_top (by simp)
-    unfold MTrgx
-    exact (globalMaximalFunction_lt_top (p := 1) (by simp) (memLp_top_czOperator hg hr)).ne
+  by_cases hMinfty : MTrgx = ∞
+  · unfold MTrgx at hMinfty
+    simp_rw [hMinfty]
+    simp
+  rw [← ENNReal.mul_le_mul_right (by simp [hMzero]) (by finiteness) (c := 4 * MTrgx)]
+  rw [← lintegral_mul_const' _ _ (by finiteness)]
   simp_rw [← indicator_mul_const, Pi.one_apply, one_mul]
   trans ∫⁻ (y : X) in ball x (R / 4),
       {x' | 4 * MTrgx < ‖czOperator K r g x'‖ₑ}.indicator (fun x_1 ↦ ‖czOperator K r g y‖ₑ ) y
@@ -717,7 +711,7 @@ theorem cotlar_set_F₁ (ha : 4 ≤ a) (hr : 0 < r) (hR : r ≤ R)
     exact le_of_lt
   trans ∫⁻ (y : X) in ball x (R / 4), ‖czOperator K r g y‖ₑ
   · apply lintegral_mono_fn
-    intro y -- otherwise runs into deterministic timeout, don't ask me why
+    intro y
     apply indicator_le_self
   nth_rw 2 [div_eq_mul_inv]
   rw [mul_assoc]

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -692,7 +692,6 @@ theorem cotlar_set_F₁ (ha : 4 ≤ a) (hr : 0 < r) (hR : r ≤ R)
       {x' | 4 * globalMaximalFunction volume 1 (czOperator K r g) x < ‖czOperator K r g x'‖ₑ } ≤
     volume (ball x (R / 4)) / 4 := by
   let MTrgx := globalMaximalFunction volume 1 (czOperator K r g) x
-  nth_rw 2 [div_eq_mul_inv]
   by_cases hMzero : MTrgx = 0
   · apply le_of_eq_of_le _ (zero_le _)
     rw [measure_zero_iff_ae_nmem]
@@ -700,33 +699,33 @@ theorem cotlar_set_F₁ (ha : 4 ≤ a) (hr : 0 < r) (hR : r ≤ R)
     filter_upwards [czzero]
     intro x' hx'
     simp [hx']
-  · rw [← lintegral_indicator_one₀ ?hs]
-    case hs =>
-      apply nullMeasurableSet_lt (by fun_prop)
-      exact AEMeasurable.restrict (by fun_prop) -- TODO tag with `fun_prop`?
-    rw [← ENNReal.mul_le_mul_right (by simp [hMzero]) ?ne_t (c := 4 * MTrgx)]
-    case ne_t => apply mul_ne_top (by simp); sorry --globalMaximalFunction_lt_top
-    rw [← lintegral_mul_const']
-    case neg.hr => apply mul_ne_top (by simp); sorry --globalMaximalFunction_lt_top
-    simp_rw [← indicator_mul_const, Pi.one_apply, one_mul]
-    trans ∫⁻ (y : X) in ball x (R / 4),
-    {x' | 4 * globalMaximalFunction volume 1 (czOperator K r g) x < ‖czOperator K r g x'‖ₑ}.indicator
-      (fun x_1 ↦ ‖czOperator K r g y‖ₑ ) y
-    · apply lintegral_mono_fn
-      intro y
-      apply indicator_le_indicator'
-      rw [mem_setOf_eq]
-      exact le_of_lt
-    trans ∫⁻ (y : X) in ball x (R / 4), ‖czOperator K r g y‖ₑ
-    · apply lintegral_mono_fn
-      intro y -- otherwise runs into deterministic timeout, don't ask me why
-      apply indicator_le_self
-    rw [mul_assoc]
-    nth_rw 2 [← mul_assoc]
-    rw [ENNReal.inv_mul_cancel (by simp) (by simp)]
-    simp only [one_mul, MTrgx]
-    apply lintegral_ball_le_volume_globalMaximalFunction
-    simp [(lt_of_lt_of_le hr hR)]
+  rw [← lintegral_indicator_one₀ ?hs]
+  case hs =>
+    apply nullMeasurableSet_lt (by fun_prop)
+    exact AEMeasurable.restrict (by fun_prop) -- TODO tag with `fun_prop`?
+  rw [← ENNReal.mul_le_mul_right (by simp [hMzero]) ?ne_t (c := 4 * MTrgx)]
+  case ne_t => apply mul_ne_top (by simp); sorry --globalMaximalFunction_lt_top
+  rw [← lintegral_mul_const' _ _ ?hr]
+  case hr => apply mul_ne_top (by simp); sorry --globalMaximalFunction_lt_top
+  simp_rw [← indicator_mul_const, Pi.one_apply, one_mul]
+  trans ∫⁻ (y : X) in ball x (R / 4),
+      {x' | 4 * MTrgx < ‖czOperator K r g x'‖ₑ}.indicator (fun x_1 ↦ ‖czOperator K r g y‖ₑ ) y
+  · apply lintegral_mono_fn
+    intro y
+    apply indicator_le_indicator'
+    rw [mem_setOf_eq]
+    exact le_of_lt
+  trans ∫⁻ (y : X) in ball x (R / 4), ‖czOperator K r g y‖ₑ
+  · apply lintegral_mono_fn
+    intro y -- otherwise runs into deterministic timeout, don't ask me why
+    apply indicator_le_self
+  nth_rw 2 [div_eq_mul_inv]
+  rw [mul_assoc]
+  nth_rw 2 [← mul_assoc]
+  rw [ENNReal.inv_mul_cancel (by simp) (by simp)]
+  simp only [one_mul, MTrgx]
+  apply lintegral_ball_le_volume_globalMaximalFunction
+  simp [(lt_of_lt_of_le hr hR)]
 
 /-- Part 2 of Lemma 10.1.4 about `F₂`. -/
 theorem cotlar_set_F₂ (ha : 4 ≤ a)

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -667,43 +667,7 @@ theorem cotlar_control (ha : 4 ≤ a)
 /-- The constant used in `cotlar_set_F₂`. -/
 irreducible_def C10_1_4 (a : ℕ) : ℝ≥0 := 2 ^ (a ^ 3 + 20 * a + 2)
 
-@[fun_prop]
-lemma czOperator_aestronglyMeasurable {g : X → ℂ} (hg : BoundedFiniteSupport g) :
-    AEStronglyMeasurable (fun x ↦ czOperator K r g x) := by
-  unfold czOperator
-  conv => arg 1; intro x; rw [← integral_indicator (by measurability)]
-  let f := fun (x,z) ↦ (ball x r)ᶜ.indicator (fun y ↦ K x y * g y) z
-  apply AEStronglyMeasurable.integral_prod_right' (f := f)
-  unfold f
-  apply AEStronglyMeasurable.indicator
-  · apply Continuous.comp_aestronglyMeasurable₂ (by fun_prop) aestronglyMeasurable_K
-    exact AEStronglyMeasurable.snd (hg.aestronglyMeasurable)
-  · conv => arg 1; change {x : (X × X) | x.2 ∈ (ball x.1 r)ᶜ}
-    simp_rw [mem_compl_iff, mem_ball, not_lt]
-    apply measurableSet_le <;> fun_prop
-
-lemma memLp_top_czOperator {g : X → ℂ} (hg : BoundedFiniteSupport g) :
-    MemLp (czOperator K r g) ⊤ volume := by
-  -- constructor
-  -- · exact czOperator_aestronglyMeasurable hg
-  -- · rw [eLpNorm_exponent_top]
-  --   apply eLpNormEssSup_lt_top_of_ae_enorm_bound
-  --     (C := 0) --fix for build while proof is sorry'd
-  --   unfold czOperator
-  --   apply Filter.Eventually.mono _ (fun x ↦ (enorm_integral_le_lintegral_enorm _).trans)
-  --   -- rotate_left
-  --   apply Filter.Eventually.mono _ (fun x ↦ (lintegral_mono_ae ?ae).trans)
-  --   case ae =>
-  --     change ∀ᵐ y ∂volume.restrict (ball x r)ᶜ, ‖K x y * g y‖ₑ
-  --         ≤ eLpNormEssSup (K x) (volume.restrict (ball x r)ᶜ) * ‖g y‖ₑ
-  --     simp_rw [enorm_mul]
-  --     filter_upwards [enorm_ae_le_eLpNormEssSup (K x) (volume.restrict (ball x r)ᶜ)]
-  --     intro y hy
-  --     gcongr
-  --   sorry
-  sorry
-
-
+omit [CompatibleFunctions ℝ X (defaultA a)] [IsCancellative X (defaultτ a)] in
 lemma globalMaximalFunction_zero_enorm_czoperator_ae_zero (hR : 0 < R) {g : X → ℂ} (hg : BoundedFiniteSupport g)
     (hMzero : globalMaximalFunction volume 1 (czOperator K r g) x = 0) :
     ∀ᵐ x' ∂(volume.restrict (ball x (R / 4))), ‖czOperator K r g x'‖ₑ = 0 := by
@@ -716,6 +680,7 @@ lemma globalMaximalFunction_zero_enorm_czoperator_ae_zero (hR : 0 < R) {g : X �
     simp
   · simp [hR]
 
+omit [CompatibleFunctions ℝ X (defaultA a)] [IsCancellative X (defaultτ a)] in
 /-- Part 1 of Lemma 10.1.4 about `F₁`. -/
 theorem cotlar_set_F₁ (ha : 4 ≤ a) (hr : 0 < r) (hR : r ≤ R)
     (hT : ∀ r > 0, HasBoundedStrongType (czOperator K r) 2 2 volume volume (C_Ts a))
@@ -736,12 +701,12 @@ theorem cotlar_set_F₁ (ha : 4 ≤ a) (hr : 0 < r) (hR : r ≤ R)
   case ne_t =>
     apply mul_ne_top (by simp)
     unfold MTrgx
-    exact (globalMaximalFunction_lt_top (p := 1) (by simp) (memLp_top_czOperator hg)).ne
+    exact (globalMaximalFunction_lt_top (p := 1) (by simp) (memLp_top_czOperator hg hr)).ne
   rw [← lintegral_mul_const' _ _ ?hr]
   case hr =>
     apply mul_ne_top (by simp)
     unfold MTrgx
-    exact (globalMaximalFunction_lt_top (p := 1) (by simp) (memLp_top_czOperator hg)).ne
+    exact (globalMaximalFunction_lt_top (p := 1) (by simp) (memLp_top_czOperator hg hr)).ne
   simp_rw [← indicator_mul_const, Pi.one_apply, one_mul]
   trans ∫⁻ (y : X) in ball x (R / 4),
       {x' | 4 * MTrgx < ‖czOperator K r g x'‖ₑ}.indicator (fun x_1 ↦ ‖czOperator K r g y‖ₑ ) y

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -668,9 +668,41 @@ theorem cotlar_control (ha : 4 ≤ a)
 irreducible_def C10_1_4 (a : ℕ) : ℝ≥0 := 2 ^ (a ^ 3 + 20 * a + 2)
 
 @[fun_prop]
-lemma czOperator_aemeasurable {g : X → ℂ} (hg : BoundedFiniteSupport g) :
-    AEMeasurable (fun x ↦ czOperator K r g x) := by
+lemma czOperator_aestronglyMeasurable {g : X → ℂ} (hg : BoundedFiniteSupport g) :
+    AEStronglyMeasurable (fun x ↦ czOperator K r g x) := by
+  unfold czOperator
+  conv => arg 1; intro x; rw [← integral_indicator (by measurability)]
+  let f := fun (x,z) ↦ (ball x r)ᶜ.indicator (fun y ↦ K x y * g y) z
+  apply AEStronglyMeasurable.integral_prod_right' (f := f)
+  unfold f
+  apply AEStronglyMeasurable.indicator
+  · apply Continuous.comp_aestronglyMeasurable₂ (by fun_prop) aestronglyMeasurable_K
+    exact AEStronglyMeasurable.snd (hg.aestronglyMeasurable)
+  · conv => arg 1; change {x : (X × X) | x.2 ∈ (ball x.1 r)ᶜ}
+    simp_rw [mem_compl_iff, mem_ball, not_lt]
+    apply measurableSet_le <;> fun_prop
+
+lemma memLp_top_czOperator {g : X → ℂ} (hg : BoundedFiniteSupport g) :
+    MemLp (czOperator K r g) ⊤ volume := by
+  -- constructor
+  -- · exact czOperator_aestronglyMeasurable hg
+  -- · rw [eLpNorm_exponent_top]
+  --   apply eLpNormEssSup_lt_top_of_ae_enorm_bound
+  --     (C := 0) --fix for build while proof is sorry'd
+  --   unfold czOperator
+  --   apply Filter.Eventually.mono _ (fun x ↦ (enorm_integral_le_lintegral_enorm _).trans)
+  --   -- rotate_left
+  --   apply Filter.Eventually.mono _ (fun x ↦ (lintegral_mono_ae ?ae).trans)
+  --   case ae =>
+  --     change ∀ᵐ y ∂volume.restrict (ball x r)ᶜ, ‖K x y * g y‖ₑ
+  --         ≤ eLpNormEssSup (K x) (volume.restrict (ball x r)ᶜ) * ‖g y‖ₑ
+  --     simp_rw [enorm_mul]
+  --     filter_upwards [enorm_ae_le_eLpNormEssSup (K x) (volume.restrict (ball x r)ᶜ)]
+  --     intro y hy
+  --     gcongr
+  --   sorry
   sorry
+
 
 lemma globalMaximalFunction_zero_enorm_czoperator_ae_zero (hR : 0 < R) {g : X → ℂ} (hg : BoundedFiniteSupport g)
     (hMzero : globalMaximalFunction volume 1 (czOperator K r g) x = 0) :
@@ -701,9 +733,15 @@ theorem cotlar_set_F₁ (ha : 4 ≤ a) (hr : 0 < r) (hR : r ≤ R)
     simp [hx']
   rw [← lintegral_indicator_one₀ (nullMeasurableSet_lt (by fun_prop) (by fun_prop))]
   rw [← ENNReal.mul_le_mul_right (by simp [hMzero]) ?ne_t (c := 4 * MTrgx)]
-  case ne_t => apply mul_ne_top (by simp); sorry --globalMaximalFunction_lt_top
+  case ne_t =>
+    apply mul_ne_top (by simp)
+    unfold MTrgx
+    exact (globalMaximalFunction_lt_top (p := 1) (by simp) (memLp_top_czOperator hg)).ne
   rw [← lintegral_mul_const' _ _ ?hr]
-  case hr => apply mul_ne_top (by simp); sorry --globalMaximalFunction_lt_top
+  case hr =>
+    apply mul_ne_top (by simp)
+    unfold MTrgx
+    exact (globalMaximalFunction_lt_top (p := 1) (by simp) (memLp_top_czOperator hg)).ne
   simp_rw [← indicator_mul_const, Pi.one_apply, one_mul]
   trans ∫⁻ (y : X) in ball x (R / 4),
       {x' | 4 * MTrgx < ‖czOperator K r g x'‖ₑ}.indicator (fun x_1 ↦ ‖czOperator K r g y‖ₑ ) y

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -699,10 +699,7 @@ theorem cotlar_set_F₁ (ha : 4 ≤ a) (hr : 0 < r) (hR : r ≤ R)
     filter_upwards [czzero]
     intro x' hx'
     simp [hx']
-  rw [← lintegral_indicator_one₀ ?hs]
-  case hs =>
-    apply nullMeasurableSet_lt (by fun_prop)
-    exact AEMeasurable.restrict (by fun_prop) -- TODO tag with `fun_prop`?
+  rw [← lintegral_indicator_one₀ (nullMeasurableSet_lt (by fun_prop) (by fun_prop))]
   rw [← ENNReal.mul_le_mul_right (by simp [hMzero]) ?ne_t (c := 4 * MTrgx)]
   case ne_t => apply mul_ne_top (by simp); sorry --globalMaximalFunction_lt_top
   rw [← lintegral_mul_const' _ _ ?hr]

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -6932,6 +6932,7 @@ The proof of \Cref{nontangential-from-simple} relies on the following auxiliary 
     \end{equation}
 \end{lemma}
 Throughout \Cref{subsec-CZD} and \Cref{subsec-cotlar}, for any measurable bounded function $w: X \to \C$, let $Mw: X \to [0, \infty)$ denote the corresponding Hardy--Littlewood maximal function defined in \Cref{Hardy-Littlewood}.
+Note: In some cases, a stronger formalization of \Cref{Hardy-Littlewood} is used, where $w$ is not necessarily bounded. In particular it is applied to $T_rg(x)$.
 Apart from \Cref{Hardy-Littlewood}, \Cref{subsec-CZD} and \Cref{subsec-cotlar} have no dependencies in the previous chapters.
 
 

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -6932,7 +6932,7 @@ The proof of \Cref{nontangential-from-simple} relies on the following auxiliary 
     \end{equation}
 \end{lemma}
 Throughout \Cref{subsec-CZD} and \Cref{subsec-cotlar}, for any measurable bounded function $w: X \to \C$, let $Mw: X \to [0, \infty)$ denote the corresponding Hardy--Littlewood maximal function defined in \Cref{Hardy-Littlewood}.
-Note: In some cases, a stronger formalization of \Cref{Hardy-Littlewood} is used, where $w$ is not necessarily bounded. In particular it is applied to $T_rg(x)$.
+Note: In some cases, a stronger formalization of \Cref{Hardy-Littlewood} is used, where $w$ is not necessarily bounded. In particular it is applied to $T_rg$.
 Apart from \Cref{Hardy-Littlewood}, \Cref{subsec-CZD} and \Cref{subsec-cotlar} have no dependencies in the previous chapters.
 
 


### PR DESCRIPTION
Update:

* Now also includes the F2 estimate
* I think `HasBoundedWeakType` should be refactored to use `BoundedFiniteSupport` instead of three separate conditions. If desired I can make a separate PR for that after this lands.

The below has already been addressed.

<strike>Some points of attention:

* This lemma will need `globalMaximalFunction_lt_top` from `HardyLittlewood.lean : 710` but don't know how to do that. Marked with two sorries at `L707`, `L710`
* To prove `czOperator_aemeasurable` (or similar) at `L671` I was stuck with dealing with functions defined as integrals. Probably a matter of me not knowing the right Mathlib results. Or is this where `hT` is actually put to use?
* In applying some `indicator` results (`L720`), I encountered "deterministic timeout" errors, with Lean slowing down and eating significant memory/CPU. Was fixed by an extra `intro y`.
* Should the result `AEMeasurable.restrict` be tagged with `fun_prop`?</strike>