### PR TITLE
Lorentz spaces and interpolation

### DIFF
--- a/Carleson/Classical/ClassicalCarleson.lean
+++ b/Carleson/Classical/ClassicalCarleson.lean
@@ -214,3 +214,7 @@ theorem classical_carleson {f : ℝ → ℂ} (cont_f : Continuous f) (periodic_f
 
   -- Show a.e. convergence on [0,2π]
   exact carleson_interval cont_f periodic_f
+
+/- Carleson's theorem asserting a.e. convergence of the partial Fourier sums for L^p functions for p>1. -/
+theorem classical_carleson' {T : ℝ} [hT : Fact (0 < T)] {f : AddCircle T → ℂ} {p : ENNReal} (hp : 1 < p) (hf : MemLp f p AddCircle.haarAddCircle) :
+    ∀ᵐ x, Filter.Tendsto (partialFourierSum' · f x) Filter.atTop (nhds (f x)) := sorry

--- a/Carleson/ToMathlib/Lorentz.lean
+++ b/Carleson/ToMathlib/Lorentz.lean
@@ -84,13 +84,14 @@ def HasLorentzType (T : (α → ε₁) → (α' → ε₂))
 --TODO: define the standard enorm on EReal
 instance : ContinuousENorm EReal := sorry
 
---TODO: define this more generally (not only for EReal) ?
-def HasRestrictedWeakType (T : (α → EReal) → (α' → EReal)) (p p' : ℝ≥0∞) (μ : Measure α) (ν : Measure α')
+--TODO: what exactly should be the requirements on 𝕂? Actually, we only need a 1 here.
+variable {𝕂 : Type*} [TopologicalSpace 𝕂] [ContinuousENorm 𝕂] [NormedField 𝕂]
+def HasRestrictedWeakType (T : (α → 𝕂) → (α' → ε₂)) (p p' : ℝ≥0∞) (μ : Measure α) (ν : Measure α')
     (c : ℝ≥0∞) : Prop :=
   ∀ (F : Set α) (G : Set α'), (MeasurableSet F) → (μ F < ∞) → (MeasurableSet G) → (ν G < ∞) →
     AEStronglyMeasurable (T (F.indicator (fun _ ↦ 1))) ν ∧ eLpNorm (T (F.indicator (fun _ ↦ 1))) 1 (ν.restrict G) ≤ c * (μ F) ^ p⁻¹.toReal * (ν G) ^ p'⁻¹.toReal
 
-lemma HasRestrictedWeakType.HasLorentzType {T : (α → EReal) → (α' → EReal)} {p p' : ℝ≥0∞} {μ : Measure α} {ν : Measure α'}
+lemma HasRestrictedWeakType.HasLorentzType {T : (α → 𝕂) → (α' → ε₂)} {p p' : ℝ≥0∞} {μ : Measure α} {ν : Measure α'}
   {c : ℝ≥0∞} (hT : HasRestrictedWeakType T p p' μ ν c) (hpp' : p.HolderConjugate p') :
     --TODO: might have to adjust the constant
     HasLorentzType T p 1 p ∞ μ ν c := sorry

--- a/Carleson/ToMathlib/Lorentz.lean
+++ b/Carleson/ToMathlib/Lorentz.lean
@@ -1,0 +1,96 @@
+import Mathlib.MeasureTheory.Integral.MeanInequalities
+import Mathlib.MeasureTheory.Integral.Layercake
+import Mathlib.MeasureTheory.Integral.Lebesgue.Basic
+import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
+import Mathlib.Analysis.SpecialFunctions.Pow.Integral
+import Carleson.ToMathlib.ENorm
+import Carleson.ToMathlib.Misc
+import Carleson.ToMathlib.WeakType
+
+--open NNReal ENNReal NormedSpace MeasureTheory Set Filter Topology Function
+
+
+noncomputable section
+
+open scoped NNReal ENNReal
+
+variable {α ε ε' E F G : Type*} {m m0 : MeasurableSpace α} {p : ℝ≥0∞} {q : ℝ}
+  [NormedAddCommGroup E] [NormedAddCommGroup F] [NormedAddCommGroup G] [ENorm ε] [ENorm ε']
+
+
+namespace MeasureTheory
+
+def decreasing_rearrangement (f : α → ε) (μ : Measure α) (t : ℝ≥0) : ℝ≥0 :=
+  sInf {σ | distribution f σ μ ≤ t}
+
+lemma decreasing_rearrangement_antitone {f : α → ε} {μ : Measure α} :
+    Antitone (decreasing_rearrangement f μ) := sorry
+
+#check NNReal.measurableSpace
+
+
+lemma distribution_decreasing_rearrangement (f : α → ε) (μ : Measure α) (t : ℝ≥0):
+  distribution f t μ = distribution (decreasing_rearrangement f μ) t Measure.Subtype.measureSpace.volume := sorry
+
+section Lorentz
+
+/-- The Lorentz norm of a function, for `r < ∞` -/
+def eLorentzNorm' (f : α → ε) (p : ℝ≥0∞) (r : ℝ≥0) (μ : Measure α) : ℝ≥0∞ :=
+  (∫⁻ (t : ℝ≥0), t ^ (p⁻¹ - 1).toReal * decreasing_rearrangement f μ t ^ r.toReal ∂Measure.Subtype.measureSpace.volume) ^ r⁻¹.toReal
+
+/-- The Lorentz norm of a function, for `r = ∞` -/
+def eLorentzNormSup (f : α → ε) (p : ℝ≥0∞) (μ : Measure α) :=
+  ⨆ t : ℝ≥0, t ^ p⁻¹.toReal * decreasing_rearrangement f μ t
+
+/-- The Lorentz norm of a function -/
+def eLorentzNorm (f : α → ε) (p : ℝ≥0∞) (r : ℝ≥0∞) (μ : Measure α) : ℝ≥0∞ :=
+  if r = 0 then 0 else if r = ∞ then eLorentzNormSup f p μ else eLorentzNorm' f p r.toNNReal μ
+
+--attribute [local instance] Measure.Subtype.measureSpace in
+/- Alternative definitions, TODO: check which should be the correct definition -/
+lemma eLorentzNorm_eq {f : α → ε} {p : ℝ≥0∞} {r : ℝ≥0∞} {μ : Measure α} :
+    eLorentzNorm f p r μ
+      = p ^ r⁻¹.toReal * eLpNorm (fun (t : ℝ≥0) ↦ t * distribution f t μ) r
+        (Measure.Subtype.measureSpace.volume.withDensity (fun (t : ℝ≥0) ↦ t⁻¹)) := sorry
+
+lemma eLorentzNorm_eq_Lp {f : α → ε} {p : ℝ≥0∞} {μ : Measure α} :
+  eLorentzNorm f p p μ = eLpNorm f p μ := sorry
+
+lemma eLorentzNorm_eq_wnorm {f : α → ε} {p : ℝ≥0∞} {μ : Measure α} :
+  eLorentzNorm f p ∞ μ = wnorm f p μ := sorry
+
+
+
+variable [TopologicalSpace ε] [ContinuousENorm ε]
+/-- A function is in the Lorentz space L_{pr} if it is (strongly a.e.)-measurable and has finite Lorentz norm. -/
+def MemLorentz (f : α → ε) (p r : ℝ≥0∞) (μ : Measure α) : Prop :=
+  AEStronglyMeasurable f μ ∧ eLorentzNorm f p r μ < ∞
+
+-- TODO: could maybe be strengthened to ↔
+lemma MemLorentz_nested {f : α → ε} {p r₁ r₂ : ℝ≥0∞} {μ : Measure α}
+  (h : r₁ ≤ r₂) (hf : MemLorentz f p r₁ μ) :
+    MemLorentz f p r₂ μ := sorry
+
+
+variable {α' ε₁ ε₂ : Type*} {m : MeasurableSpace α'} [TopologicalSpace ε₁] [ContinuousENorm ε₁]
+    [TopologicalSpace ε₂] [ContinuousENorm ε₂] --[TopologicalSpace ε₃] [ContinuousENorm ε₃]
+    {f : α → ε} {f₁ : α → ε₁}
+
+
+def HasLorentzType (T : (α → ε₁) → (α' → ε₂))
+    (p r q s : ℝ≥0∞) (μ : Measure α) (ν : Measure α') (c : ℝ≥0∞) : Prop :=
+  ∀ f : α → ε₁, MemLorentz f p r μ → AEStronglyMeasurable (T f) ν ∧ eLorentzNorm (T f) q s ν ≤ c * eLorentzNorm f p r μ
+
+--TODO: define the standard enorm on EReal
+instance : ContinuousENorm EReal := sorry
+
+--TODO: define this more generally (not only for EReal) ?
+def HasRestrictedWeakType (T : (α → EReal) → (α' → EReal)) (p p' : ℝ≥0∞) (μ : Measure α) (ν : Measure α')
+    (c : ℝ≥0∞) : Prop :=
+  ∀ (F : Set α) (G : Set α'), (MeasurableSet F) → (μ F < ∞) → (MeasurableSet G) → (ν G < ∞) →
+    AEStronglyMeasurable (T (F.indicator (fun _ ↦ 1))) ν ∧ eLpNorm (T (F.indicator (fun _ ↦ 1))) 1 (ν.restrict G) ≤ c * (μ F) ^ p⁻¹.toReal * (ν G) ^ p'⁻¹.toReal
+
+lemma HasRestrictedWeakType.HasLorentzType {T : (α → EReal) → (α' → EReal)} {p p' : ℝ≥0∞} {μ : Measure α} {ν : Measure α'}
+  {c : ℝ≥0∞} (hT : HasRestrictedWeakType T p p' μ ν c) (hpp' : p.HolderConjugate p') :
+    --TODO: might have to adjust the constant
+    HasLorentzType T p 1 p ∞ μ ν c := sorry

--- a/Carleson/ToMathlib/RealInterpolation/Main.lean
+++ b/Carleson/ToMathlib/RealInterpolation/Main.lean
@@ -1,4 +1,5 @@
 import Carleson.ToMathlib.RealInterpolation.Minkowski
+import Carleson.ToMathlib.Lorentz
 
 /-!
 # The Marcinkiewisz real interpolation theorem
@@ -1370,6 +1371,21 @@ theorem exists_hasStrongType_real_interpolation {p₀ p₁ q₀ q₁ p q : ℝ�
     Subadditive_trunc_from_SubadditiveOn_Lp₀p₁ hp₀.1 hp₁.1 ht hp' hT hf
   rw [coe_C_realInterpolation hp₀ hp₁ hq₀q₁] <;> try assumption
   apply exists_hasStrongType_real_interpolation_aux₄ <;> assumption
+
+
+/-- General Marcinkiewicz real interpolation theorem. -/
+theorem exists_hasLorentzType_real_interpolation {p₀ p₁ r₀ r₁ q₀ q₁ s₀ s₁ p q : ℝ≥0∞}
+    [MeasurableSpace E₁] [NormedAddCommGroup E₁] [BorelSpace E₁]
+    [MeasurableSpace E₂] [NormedAddCommGroup E₂] [BorelSpace E₂]
+    (hp₀ : 1 ≤ p₀) (hp₁ : 1 ≤ p₁) (hr₀ : 1 ≤ r₀) (hr₁ : 1 ≤ r₁) (hq₀ : 1 ≤ q₀) (hq₁ : 1 ≤ q₁) (hs₀ : 1 ≤ s₀) (hs₁ : 1 ≤ s₁) -- TODO: find out which of these are actually necessary
+    (hp₀p₁ : p₀ ≠ p₁) (hq₀q₁ : q₀ ≠ q₁)
+    {C₀ C₁ t A : ℝ≥0} (hA : 0 < A) (ht : t ∈ Ioo 0 1) (hC₀ : 0 < C₀) (hC₁ : 0 < C₁)
+    (hp : p⁻¹ = (1 - t) / p₀ + t / p₁) (hq : q⁻¹ = (1 - t) / q₀ + t / q₁)
+    (hmT : ∀ f, MemLorentz f p q μ → AEStronglyMeasurable (T f) ν)
+    (hT : AESubadditiveOn T (fun f ↦ MemLorentz f p₀ r₀ μ ∨ MemLorentz f p₁ r₁ μ) A ν)
+    (h₀T : HasLorentzType T p₀ r₀ q₀ s₀ μ ν C₀) (h₁T : HasLorentzType T p₁ r₁ q₁ s₁ μ ν C₁) :
+    --TODO: probably no longer the right constant
+      ∀ r, 0 < r → HasLorentzType T p r q r μ ν (C_realInterpolation p₀ p₁ q₀ q₁ q C₀ C₁ A t) := sorry
 
 /- State and prove Remark 1.2.7 -/
 

--- a/Carleson/TwoSidedCarleson/MainTheorem.lean
+++ b/Carleson/TwoSidedCarleson/MainTheorem.lean
@@ -33,6 +33,10 @@ theorem two_sided_metric_carleson (ha : 4 ≤ a) (hq : q ∈ Ioc 1 2) (hqq' : q.
   -- note: you might need to case on whether `volume F` is `∞` or not.
   sorry
 
-
+/- Theorem 10.0.1, reformulation -/
+theorem two_sided_metric_carleson_restricted_weak_type (ha : 4 ≤ a) (hq : q ∈ Ioc 1 2) (hqq' : q.HolderConjugate q')
+  (hT : ∀ r > 0, HasBoundedStrongType (czOperator K r) 2 2 volume volume (C_Ts a))
+    {f : X → ℂ} (hmf : Measurable f) (hf : ∀ x, ‖f x‖ ≤ F.indicator 1 x) :
+      HasRestrictedWeakType (carlesonOperator K) q q' volume volume (C10_0_1 a q) := sorry
 
 end

--- a/Carleson/TwoSidedCarleson/MainTheorem.lean
+++ b/Carleson/TwoSidedCarleson/MainTheorem.lean
@@ -39,4 +39,15 @@ theorem two_sided_metric_carleson_restricted_weak_type (ha : 4 ≤ a) (hq : q �
     {f : X → ℂ} (hmf : Measurable f) (hf : ∀ x, ‖f x‖ ≤ F.indicator 1 x) :
       HasRestrictedWeakType (carlesonOperator K) q q' volume volume (C10_0_1 a q) := sorry
 
+/- Theorem 10.0.1, reformulation -/
+theorem two_sided_metric_carleson_strong_type (ha : 4 ≤ a) (hq : q ∈ Ioo 1 2) (hqq' : q.HolderConjugate q')
+  (hT : ∀ r > 0, HasBoundedStrongType (czOperator K r) 2 2 volume volume (C_Ts a))
+    {f : X → ℂ} (hmf : Measurable f) (hf : ∀ x, ‖f x‖ ≤ F.indicator 1 x) :
+      HasStrongType (carlesonOperator K) q q' volume volume (C10_0_1 a q) := by
+  have := (two_sided_metric_carleson_restricted_weak_type ha (mem_Ioc_of_Ioo hq) hqq' hT hmf hf).HasLorentzType
+  /- Apply `exists_hasLorentzType_real_interpolation` and `MemLorentz_nested` here,
+  or just directly write another version of real interpolation that directly gives strong type.
+  -/
+  sorry
+
 end


### PR DESCRIPTION
Adds the definition of Lorentz spaces and states an interpolation theorem for them. 
We aim to apply this to get Carleson's classical  theorem for L^p functions on the torus for p>1 (and not just continuous ones). 