### PR TITLE
cleanup some sorry's

### DIFF
--- a/Carleson/Antichain/AntichainOperator.lean
+++ b/Carleson/Antichain/AntichainOperator.lean
@@ -376,7 +376,8 @@ lemma Dens2Antichain {𝔄 : Finset (𝔓 X)} (h𝔄 : IsAntichain (·≤·) (�
   -- I am not sure if this is correctly stated
   have hMB_le : MB volume (𝔄 : Set (𝔓 X)) 𝔠 (fun 𝔭 ↦ 8*D ^ 𝔰 𝔭) (fun x ↦ ‖f x‖) ≤
     ((maximalFunction volume (𝔄 : Set (𝔓 X)) 𝔠 (fun 𝔭 ↦ 8*D ^ 𝔰 𝔭) ((2*nnq')/(3*nnq' - 2))
-      (fun x ↦ ‖f x‖ * (dens₂ (𝔄 : Set (𝔓 X))).toReal ^ ((nnq' : ℝ)⁻¹ - 2⁻¹)))) := by sorry
+      (fun x ↦ ‖f x‖ * (dens₂ (𝔄 : Set (𝔓 X))).toReal ^ ((nnq' : ℝ)⁻¹ - 2⁻¹)))) := by
+    sorry
 
   -- 6.1.14' : it seems what is actually used is the following:
   have hMB_le' : (eLpNorm (fun x ↦ ((MB volume 𝔄 𝔠 (fun 𝔭 ↦ 8*D ^ 𝔰 𝔭) f x).toNNReal : ℂ))
@@ -496,7 +497,8 @@ theorem antichain_operator {𝔄 : Set (𝔓 X)} {f g : X → ℂ}
     (h𝔄 : IsAntichain (·≤·) 𝔄) :
     ‖∫ x, conj (g x) * carlesonSum 𝔄 f x‖ₑ ≤
     C_2_0_3 a nnq * (dens₁ 𝔄) ^ ((q - 1) / (8 * a ^ 4)) * (dens₂ 𝔄) ^ (q⁻¹ - 2⁻¹) *
-    (eLpNorm f 2 volume) * (eLpNorm g 2 volume) := sorry
+    (eLpNorm f 2 volume) * (eLpNorm g 2 volume) := by
+  sorry
 
 /-- Version of the forest operator theorem, but controlling the integral of the norm instead of
 the integral of the function multiplied by another function. -/

--- a/Carleson/Antichain/TileCorrelation.lean
+++ b/Carleson/Antichain/TileCorrelation.lean
@@ -365,7 +365,8 @@ lemma correlation_zero_of_ne_subset {p p' : 𝔓 X} (hle : 𝔰 p' ≤ 𝔰 p) {
     ‖∫ y, (adjointCarleson p' g y) * conj (adjointCarleson p g y)‖ₑ = 0 := by
   by_contra h0
   apply hpp'
-  have hy : ∃ y : X, (adjointCarleson p' g y) * conj (adjointCarleson p g y) ≠ 0 := sorry
+  have hy : ∃ y : X, (adjointCarleson p' g y) * conj (adjointCarleson p g y) ≠ 0 := by
+    sorry
   obtain ⟨y, hy⟩ := hy
   sorry
 

--- a/Carleson/Classical/CarlesonOperatorReal.lean
+++ b/Carleson/Classical/CarlesonOperatorReal.lean
@@ -230,10 +230,10 @@ variable {α β : Type*} [MeasurableSpace α]
   [TopologicalSpace β] [OrderTopology β] [SecondCountableTopology β]
   [BorelSpace β]
 
-lemma Measurable_iSup_gt {s : Set ι} [OrdConnected s]
-    (h1f : ∀ x i, ContinuousWithinAt (f · x) s i)
-    (h2f : ∀ i, Measurable (f i)) :
-    Measurable (⨆ i ∈ s, f i ·) := sorry
+-- lemma Measurable_iSup_gt {s : Set ι} [OrdConnected s]
+--     (h1f : ∀ x i, ContinuousWithinAt (f · x) s i)
+--     (h2f : ∀ i, Measurable (f i)) :
+--     Measurable (⨆ i ∈ s, f i ·) := sorry
   -- use SecondCountableTopology to rewrite the sup as a sup over the countable dense set (or similar)
   -- then use measurable_iSup
 -/

--- a/Carleson/MetricCarleson/Basic.lean
+++ b/Carleson/MetricCarleson/Basic.lean
@@ -37,7 +37,8 @@ lemma cdist_le_dist {f g : Θ X} {x : X} {r : ℝ≥0} :
   sorry
 
 -- why do we know this?
-instance : SecondCountableTopology (Θ X) := sorry
+instance : SecondCountableTopology (Θ X) :=
+  sorry
 
 end MetricΘ
 

--- a/Carleson/TileStructure.lean
+++ b/Carleson/TileStructure.lean
@@ -517,11 +517,11 @@ lemma dens₂_eq_biSup_dens₂ (𝔓' : Set (𝔓 X)) :
     dens₂ (𝔓') = ⨆ (p ∈ 𝔓'), dens₂ ({p}) := by
   simp [dens₂]
 
--- a small characterization that might be useful
-lemma isAntichain_iff_disjoint (𝔄 : Set (𝔓 X)) :
-    IsAntichain (·≤·) (toTileLike (X := X) '' 𝔄) ↔
-    ∀ p p', p ∈ 𝔄 → p' ∈ 𝔄 → p ≠ p' →
-    Disjoint (toTileLike (X := X) p).toTile (toTileLike p').toTile := sorry
+-- -- a small characterization that might be useful
+-- lemma isAntichain_iff_disjoint (𝔄 : Set (𝔓 X)) :
+--     IsAntichain (·≤·) (toTileLike (X := X) '' 𝔄) ↔
+--     ∀ p p', p ∈ 𝔄 → p' ∈ 𝔄 → p ≠ p' →
+--     Disjoint (toTileLike (X := X) p).toTile (toTileLike p').toTile := sorry
 
 lemma ENNReal.rpow_le_rpow_of_nonpos {x y : ℝ≥0∞} {z : ℝ} (hz : z ≤ 0) (h : x ≤ y) :
     y ^ z ≤ x ^ z := by

--- a/Carleson/ToMathlib/DoublingMeasure.lean
+++ b/Carleson/ToMathlib/DoublingMeasure.lean
@@ -266,46 +266,46 @@ variable {x x': X} {r r' s d : ℝ} (hs : 0 < s)
 
 end
 /-
-def Ai (A : ℝ≥0) (s : ℝ) : ℝ≥0 := As A s -- maybe wrong
+-- def Ai (A : ℝ≥0) (s : ℝ) : ℝ≥0 := As A s -- maybe wrong
 
-lemma measure_ball_le_of_subset {x' x : X} {r r' s : ℝ}
-    (hs : r' ≤ s * r) (hr : ball x' r ⊆ ball x r') :
-    μ.real (ball x (2 * r)) ≤ Ai A s * μ.real (ball x' r) := by sorry
+-- lemma measure_ball_le_of_subset {x' x : X} {r r' s : ℝ}
+--     (hs : r' ≤ s * r) (hr : ball x' r ⊆ ball x r') :
+--     μ.real (ball x (2 * r)) ≤ Ai A s * μ.real (ball x' r) := by sorry
 
-def Ai2 (A : ℝ≥0) : ℝ≥0 := Ai A 2
+-- def Ai2 (A : ℝ≥0) : ℝ≥0 := Ai A 2
 
-lemma measure_ball_two_le_of_subset {x' x : X} {r : ℝ} (hr : ball x' r ⊆ ball x (2 * r)) :
-    μ.real (ball x (2 * r)) ≤ Ai2 A * μ.real (ball x' r) :=
-  measure_ball_le_of_subset le_rfl hr
+-- lemma measure_ball_two_le_of_subset {x' x : X} {r : ℝ} (hr : ball x' r ⊆ ball x (2 * r)) :
+--     μ.real (ball x (2 * r)) ≤ Ai2 A * μ.real (ball x' r) :=
+--   measure_ball_le_of_subset le_rfl hr
 
-def Np (A : ℝ≥0) (s : ℝ) : ℕ := ⌊As A (s * A + 2⁻¹)⌋₊ -- probably wrong
+-- def Np (A : ℝ≥0) (s : ℝ) : ℕ := ⌊As A (s * A + 2⁻¹)⌋₊ -- probably wrong
 
-/- Proof sketch: take a ball of radius `r / (2 * A)` around each point in `s`.
-These are disjoint, and are subsets of `ball x (r * (2 * A + 2⁻¹))`. -/
-lemma card_le_of_le_dist (x : X) {r r' s : ℝ} (P : Set X) (hs : r' ≤ s * r) (hP : P ⊆ ball x r')
-  (h2P : ∀ x y, x ∈ P → y ∈ P → x ≠ y → r ≤ dist x y) : P.Finite ∧ Nat.card P ≤ Np A s := by sorry
+-- /- Proof sketch: take a ball of radius `r / (2 * A)` around each point in `s`.
+-- These are disjoint, and are subsets of `ball x (r * (2 * A + 2⁻¹))`. -/
+-- lemma card_le_of_le_dist (x : X) {r r' s : ℝ} (P : Set X) (hs : r' ≤ s * r) (hP : P ⊆ ball x r')
+--   (h2P : ∀ x y, x ∈ P → y ∈ P → x ≠ y → r ≤ dist x y) : P.Finite ∧ Nat.card P ≤ Np A s := by sorry
 
-/- Proof sketch: take any maximal set `s` of points that are at least distance `r` apart.
-By the previous lemma, you only need a bounded number of points.
--/
-lemma ballsCoverBalls {r r' s : ℝ} (hs : r' ≤ s * r) : BallsCoverBalls X r' r (Np A s) := by
-  sorry
+-- /- Proof sketch: take any maximal set `s` of points that are at least distance `r` apart.
+-- By the previous lemma, you only need a bounded number of points.
+-- -/
+-- lemma ballsCoverBalls {r r' s : ℝ} (hs : r' ≤ s * r) : BallsCoverBalls X r' r (Np A s) := by
+--   sorry
 
-/- [Stein, 1.1.3(iv)] -/
-lemma continuous_measure_ball_inter {U : Set X} (hU : IsOpen U) {δ} (hδ : 0 < δ) :
-  Continuous fun x ↦ μ.real (ball x δ ∩ U) := sorry
+-- /- [Stein, 1.1.3(iv)] -/
+-- lemma continuous_measure_ball_inter {U : Set X} (hU : IsOpen U) {δ} (hδ : 0 < δ) :
+--   Continuous fun x ↦ μ.real (ball x δ ∩ U) := sorry
 
-/- [Stein, 1.1.4] -/
-lemma continuous_average {E} [NormedAddCommGroup E] [NormedSpace ℝ E] {f : X → E}
-    (hf : LocallyIntegrable f μ) {δ : ℝ} (hδ : 0 < δ) :
-    Continuous (fun x ↦ ⨍ y in ball x δ, f y ∂μ) :=
-  sorry
+-- /- [Stein, 1.1.4] -/
+-- lemma continuous_average {E} [NormedAddCommGroup E] [NormedSpace ℝ E] {f : X → E}
+--     (hf : LocallyIntegrable f μ) {δ : ℝ} (hδ : 0 < δ) :
+--     Continuous (fun x ↦ ⨍ y in ball x δ, f y ∂μ) :=
+--   sorry
 
-/- [Stein, 1.3.1], cor -/
-lemma tendsto_average_zero {E} [NormedAddCommGroup E] [NormedSpace ℝ E] {f : X → E}
-    (hf : LocallyIntegrable f μ) {x : X} :
-    Tendsto (fun δ ↦ ⨍ y in ball x δ, f y ∂μ) (𝓝[>] 0) (𝓝 (f x)) :=
-  sorry
+-- /- [Stein, 1.3.1], cor -/
+-- lemma tendsto_average_zero {E} [NormedAddCommGroup E] [NormedSpace ℝ E] {f : X → E}
+--     (hf : LocallyIntegrable f μ) {x : X} :
+--     Tendsto (fun δ ↦ ⨍ y in ball x δ, f y ∂μ) (𝓝[>] 0) (𝓝 (f x)) :=
+--   sorry
 -/
 
 end PseudoMetric


### PR DESCRIPTION
This PR ensures that 
* all commented out sorry's have a preceding `--`
* comment out some unused sorry's

This PR ensures that the regexes `^(?:(?!--).)*sorry` and the simpler `^[^-]*sorry` both count the number uncommented sorry's (currently 92).