### PR TITLE
Lemma 7.5.10 and most of Lemma 7.5.4

### DIFF
--- a/Carleson/ForestOperator/AlmostOrthogonality.lean
+++ b/Carleson/ForestOperator/AlmostOrthogonality.lean
@@ -27,6 +27,18 @@ open scoped Classical in
 def adjointCarlesonSum (ℭ : Set (𝔓 X)) (f : X → ℂ) (x : X) : ℂ :=
   ∑ p ∈ {p | p ∈ ℭ}, adjointCarleson p f x
 
+/-- A helper lemma used in Lemma 7.5.10. -/
+lemma adjointCarlesonSum_inter {A B : Set (𝔓 X)} {f : X → ℂ} {x : X} :
+    adjointCarlesonSum (A ∩ B) f x = adjointCarlesonSum A f x - adjointCarlesonSum (A \ B) f x := by
+  unfold adjointCarlesonSum; symm
+  classical rw [sub_eq_iff_eq_add, ← Finset.sum_union]; swap
+  · simp only [Finset.disjoint_filter, mem_diff, not_and, not_not]
+    exact fun x _ ⟨xA, xB⟩ _ ↦ xB
+  congr; ext x
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and, mem_inter_iff, mem_diff,
+    Finset.mem_union]
+  tauto
+
 variable (t) in
 /-- The operator `S_{2,𝔲} f(x)`, given above Lemma 7.4.3. -/
 def adjointBoundaryOperator (u : 𝔓 X) (f : X → ℂ) (x : X) : ℝ≥0∞ :=

--- a/Carleson/ForestOperator/LargeSeparation.lean
+++ b/Carleson/ForestOperator/LargeSeparation.lean
@@ -1396,6 +1396,10 @@ lemma global_tree_control1_edist_right (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t)
 /-- The constant used in `global_tree_control1_supbound`. -/
 irreducible_def C7_5_9s (a : ℕ) : ℝ≥0 := C7_5_5 a * 2 ^ (4 * a + 2)
 
+lemma one_le_C7_5_9s : 1 ≤ C7_5_9s a := by
+  simp only [C7_5_9s, C7_5_5]; norm_cast
+  rw [← pow_add]; exact Nat.one_le_two_pow
+
 /-- Equation (7.5.17) of Lemma 7.5.9. -/
 lemma global_tree_control1_supbound (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂)
     (h2u : 𝓘 u₁ ≤ 𝓘 u₂) (ℭ : Set (𝔓 X)) (hℭ : ℭ = t u₁ ∨ ℭ = t u₂ ∩ 𝔖₀ t u₁ u₂)
@@ -1464,6 +1468,9 @@ lemma global_tree_control1_supbound (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (h
 /-- The constant used in `global_tree_control2`. -/
 irreducible_def C7_5_10 (a : ℕ) : ℝ≥0 := C7_5_7 a + C7_5_9s a
 
+lemma one_le_C7_5_10 : 1 ≤ C7_5_10 a := by
+  rw [C7_5_10, ← zero_add 1]; exact add_le_add (by positivity) one_le_C7_5_9s
+
 /-- Lemma 7.5.10 -/
 lemma global_tree_control2 (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂)
     (h2u : 𝓘 u₁ ≤ 𝓘 u₂) (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf : BoundedCompactSupport f) :
@@ -1484,24 +1491,205 @@ lemma global_tree_control2 (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ 
       rw [C7_5_10, ENNReal.coe_add, add_mul, add_assoc]
       gcongr; exact local_tree_control hu₁ hu₂ hu h2u hJ hf
 
+/-- The product on the right-hand side of Lemma 7.5.4. -/
+def P7_5_4 (t : Forest X n) (u₁ u₂ : 𝔓 X) (f₁ f₂ : X → ℂ) (J : Grid X) : ℝ≥0∞ :=
+  ((⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₁) f₁ x‖ₑ) +
+    ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f₁ x) *
+  ((⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₂) f₂ x‖ₑ) +
+    ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f₂ x)
+
+/-- The support of `holderFunction` is in `𝓘 u₁`. -/
+lemma support_holderFunction_subset (u₂ : 𝔓 X) (f₁ f₂ : X → ℂ) (J : Grid X) (hu₁ : u₁ ∈ t) :
+    support (holderFunction t u₁ u₂ f₁ f₂ J) ⊆ 𝓘 u₁ := by
+  rw [support_subset_iff']; intro x nx
+  have : adjointCarlesonSum (t u₁) f₁ x = 0 := by
+    refine Finset.sum_eq_zero fun p mp ↦ ?_
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at mp
+    rw [adjoint_tile_support2 hu₁ mp]
+    exact indicator_of_not_mem nx _
+  rw [holderFunction, this, mul_zero, mul_zero, zero_mul]
+
+lemma enorm_holderFunction_le (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂) (h2u : 𝓘 u₁ ≤ 𝓘 u₂)
+    (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf₁ : BoundedCompactSupport f₁) (hf₂ : BoundedCompactSupport f₂)
+    (mx : x ∈ ball (c J) (8 * D ^ s J)) :
+    ‖holderFunction t u₁ u₂ f₁ f₂ J x‖ₑ ≤ C7_5_9s a * C7_5_10 a * P7_5_4 t u₁ u₂ f₁ f₂ J := by
+  simp_rw [holderFunction, enorm_mul, RCLike.enorm_conj, enorm_mul, enorm_exp_I_mul_ofReal, one_mul,
+    Complex.enorm_real, NNReal.enorm_eq]
+  calc
+    _ ≤ 1 * (⨆ z ∈ ball (c J) (8 * D ^ s J), ‖adjointCarlesonSum (t u₁) f₁ z‖ₑ) *
+        ⨆ z ∈ ball (c J) (8 * D ^ s J), ‖adjointCarlesonSum (t u₂ ∩ 𝔖₀ t u₁ u₂) f₂ z‖ₑ := by
+      gcongr
+      · rw [ENNReal.coe_le_one_iff]
+        exact (χ_le_indicator hJ).trans ((indicator_le fun _ _ ↦ le_refl _) _)
+      · apply le_biSup _ mx
+      · apply le_biSup _ mx
+    _ ≤ ((⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₁) f₁ x‖ₑ) +
+          C7_5_9s a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f₁ x) *
+        ((⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₂) f₂ x‖ₑ) +
+          C7_5_10 a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f₂ x) := by
+      rw [one_mul]; gcongr
+      · exact global_tree_control1_supbound hu₁ hu₂ hu h2u _ (.inl rfl) hJ hf₁
+      · exact global_tree_control2 hu₁ hu₂ hu h2u hJ hf₂
+    _ ≤ _ := by
+      rw [P7_5_4, mul_mul_mul_comm]
+      conv_rhs => rw [mul_add, mul_add]
+      gcongr <;> (nth_rw 1 [← one_mul (⨅ x ∈ _, _)]; gcongr; rw [ENNReal.one_le_coe_iff])
+      · exact one_le_C7_5_9s
+      · exact one_le_C7_5_10
+
+lemma holder_correlation_tree_1 (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂) (h2u : 𝓘 u₁ ≤ 𝓘 u₂)
+    (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf₁ : BoundedCompactSupport f₁) (hf₂ : BoundedCompactSupport f₂)
+    (mx : x ∈ ball (c J) (8 * D ^ s J)) (mx' : x' ∈ 𝓘 u₁) :
+    edist (χ t u₁ u₂ J x) (χ t u₁ u₂ J x') *
+    ‖exp (.I * 𝒬 u₁ x) * adjointCarlesonSum (t u₁) f₁ x‖ₑ *
+    ‖exp (.I * 𝒬 u₂ x) * adjointCarlesonSum (t u₂ ∩ 𝔖₀ t u₁ u₂) f₂ x‖ₑ ≤
+    C7_5_2 a * C7_5_9s a * C7_5_10 a * P7_5_4 t u₁ u₂ f₁ f₂ J * (edist x x' / D ^ s J) := by
+  simp_rw [enorm_mul, enorm_exp_I_mul_ofReal, one_mul]
+  by_cases mu₁ : x ∉ 𝓘 u₁
+  · have : adjointCarlesonSum (t u₁) f₁ x = 0 := by
+      refine Finset.sum_eq_zero fun p mp ↦ ?_
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at mp
+      rw [adjoint_tile_support2 hu₁ mp]
+      exact indicator_of_not_mem mu₁ _
+    rw [this, enorm_zero, mul_zero, zero_mul]; exact zero_le _
+  rw [not_not] at mu₁; rw [edist_dist]
+  calc
+    _ ≤ ENNReal.ofReal (C7_5_2 a * dist x x' / D ^ s J) *
+        ((⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₁) f₁ x‖ₑ) +
+          C7_5_9s a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f₁ x) *
+        ((⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₂) f₂ x‖ₑ) +
+          C7_5_10 a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f₂ x) := by
+      gcongr
+      · exact dist_χ_le hu₁ hu₂ hu h2u hJ mu₁ mx'
+      · exact (le_biSup _ mx).trans <|
+          global_tree_control1_supbound hu₁ hu₂ hu h2u _ (.inl rfl) hJ hf₁
+      · exact (le_biSup _ mx).trans <| global_tree_control2 hu₁ hu₂ hu h2u hJ hf₂
+    _ ≤ ENNReal.ofReal (C7_5_2 a * dist x x' / D ^ s J) *
+        (C7_5_9s a * C7_5_10 a * P7_5_4 t u₁ u₂ f₁ f₂ J) := by
+      rw [mul_assoc (ENNReal.ofReal _)]; gcongr _ * ?_
+      rw [P7_5_4, mul_mul_mul_comm]
+      conv_rhs => rw [mul_add, mul_add]
+      gcongr <;> (nth_rw 1 [← one_mul (⨅ x ∈ _, _)]; gcongr; rw [ENNReal.one_le_coe_iff])
+      · exact one_le_C7_5_9s
+      · exact one_le_C7_5_10
+    _ = _ := by
+      rw [mul_div_assoc, ENNReal.ofReal_mul (by positivity), ENNReal.ofReal_coe_nnreal,
+        ENNReal.ofReal_div_of_pos (by unfold defaultD; positivity), ← edist_dist x x',
+        ← Real.rpow_intCast, ← ENNReal.ofReal_rpow_of_pos (defaultD_pos a), ENNReal.rpow_intCast,
+        ENNReal.ofReal_natCast]
+      ring
+
+lemma holder_correlation_tree_2 (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂) (h2u : 𝓘 u₁ ≤ 𝓘 u₂)
+    (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf₁ : BoundedCompactSupport f₁) (hf₂ : BoundedCompactSupport f₂)
+    (mx : x ∈ ball (c J) (8 * D ^ s J)) (mx' : x' ∈ ball (c J) (8 * D ^ s J)) :
+    χ t u₁ u₂ J x' * edist (exp (.I * 𝒬 u₁ x) * adjointCarlesonSum (t u₁) f₁ x)
+      (exp (.I * 𝒬 u₁ x') * adjointCarlesonSum (t u₁) f₁ x') *
+    ‖exp (.I * 𝒬 u₂ x) * adjointCarlesonSum (t u₂ ∩ 𝔖₀ t u₁ u₂) f₂ x‖ₑ ≤
+    C7_5_9d a * C7_5_10 a * P7_5_4 t u₁ u₂ f₁ f₂ J * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ :=
+  calc
+    _ ≤ 1 * (C7_5_9d a * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f₁ x) *
+        ((⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₂) f₂ x‖ₑ) +
+          C7_5_10 a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f₂ x) := by
+      gcongr
+      · rw [ENNReal.coe_le_one_iff]
+        exact (χ_le_indicator hJ).trans ((indicator_le fun _ _ ↦ le_refl _) _)
+      · exact global_tree_control1_edist_left hu₁ hu₂ hu h2u hJ hf₁ mx mx'
+      · rw [enorm_mul, enorm_exp_I_mul_ofReal, one_mul]
+        exact (le_biSup _ mx).trans <| global_tree_control2 hu₁ hu₂ hu h2u hJ hf₂
+    _ = (C7_5_9d a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f₁ x) *
+        ((⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₂) f₂ x‖ₑ) +
+          C7_5_10 a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f₂ x) * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ := by
+      ring
+    _ ≤ (C7_5_9d a * (⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₁) f₁ x‖ₑ) +
+          C7_5_9d a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f₁ x) *
+        (C7_5_10 a * (⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₂) f₂ x‖ₑ) +
+          C7_5_10 a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f₂ x) * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ := by
+      gcongr
+      · exact le_add_self
+      · nth_rw 1 [← one_mul (⨅ x ∈ _, _)]; gcongr; rw [ENNReal.one_le_coe_iff]
+        exact one_le_C7_5_10
+    _ = _ := by rw [← mul_add, ← mul_add, mul_mul_mul_comm, P7_5_4]
+
+lemma holder_correlation_tree_3 (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂) (h2u : 𝓘 u₁ ≤ 𝓘 u₂)
+    (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf₁ : BoundedCompactSupport f₁) (hf₂ : BoundedCompactSupport f₂)
+    (mx : x ∈ ball (c J) (8 * D ^ s J)) (mx' : x' ∈ ball (c J) (8 * D ^ s J)) :
+    χ t u₁ u₂ J x' * ‖exp (.I * 𝒬 u₁ x') * adjointCarlesonSum (t u₁) f₁ x'‖ₑ *
+    edist (exp (.I * 𝒬 u₂ x) * adjointCarlesonSum (t u₂ ∩ 𝔖₀ t u₁ u₂) f₂ x)
+      (exp (.I * 𝒬 u₂ x') * adjointCarlesonSum (t u₂ ∩ 𝔖₀ t u₁ u₂) f₂ x') ≤
+    C7_5_9s a * C7_5_9d a * P7_5_4 t u₁ u₂ f₁ f₂ J * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ :=
+  calc
+    _ ≤ 1 * ((⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₁) f₁ x‖ₑ) +
+          C7_5_9s a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f₁ x) *
+        (C7_5_9d a * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f₂ x) := by
+      gcongr
+      · rw [ENNReal.coe_le_one_iff]
+        exact (χ_le_indicator hJ).trans ((indicator_le fun _ _ ↦ le_refl _) _)
+      · rw [enorm_mul, enorm_exp_I_mul_ofReal, one_mul]
+        exact (le_biSup _ mx').trans <|
+          global_tree_control1_supbound hu₁ hu₂ hu h2u _ (.inl rfl) hJ hf₁
+      · exact global_tree_control1_edist_right hu₁ hu₂ hu h2u hJ hf₂ mx mx'
+    _ = ((⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₁) f₁ x‖ₑ) +
+          C7_5_9s a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f₁ x) *
+        (C7_5_9d a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f₂ x) * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ := by
+      ring
+    _ ≤ (C7_5_9s a * (⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₁) f₁ x‖ₑ) +
+          C7_5_9s a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f₁ x) *
+        (C7_5_9d a * (⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₂) f₂ x‖ₑ) +
+          C7_5_9d a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f₂ x) * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ := by
+      gcongr
+      · nth_rw 1 [← one_mul (⨅ x ∈ _, _)]; gcongr; rw [ENNReal.one_le_coe_iff]
+        exact one_le_C7_5_9s
+      · exact le_add_self
+    _ = _ := by rw [← mul_add, ← mul_add, mul_mul_mul_comm, P7_5_4]
+
 /-- The constant used in `holder_correlation_tree`.
 Has value `2 ^ (535 * a ^ 3)` in the blueprint. -/
 -- Todo: define this recursively in terms of previous constants
 irreducible_def C7_5_4 (a : ℕ) : ℝ≥0 := 2 ^ (535 * (a : ℝ) ^ 3)
 
-/-- Lemma 7.5.4. -/
-lemma holder_correlation_tree (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂)
-    (h2u : 𝓘 u₁ ≤ 𝓘 u₂) (hJ : J ∈ 𝓙₅ t u₁ u₂)
-    (hf₁ : IsBounded (range f₁)) (h2f₁ : HasCompactSupport f₁)
-    (hf₂ : IsBounded (range f₂)) (h2f₂ : HasCompactSupport f₂) :
-    HolderOnWith (C7_5_4 a *
-    ((⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₁) f₁ x‖₊) +
-    (⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 (‖f₁ ·‖) x).toNNReal) *
-    ((⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₂) f₂ x‖₊) +
-    (⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 (‖f₂ ·‖) x).toNNReal))
-    nnτ (holderFunction t u₁ u₂ f₁ f₂ J) (ball (c J) (8 * D ^ s J)) := by
+lemma inf_MB_lt_top_of_memLp (hf : MemLp f ⊤ volume) : ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f x < ⊤ :=
+  ((biInf_le _ Grid.c_mem_Grid).trans MB_le_eLpNormEssSup).trans_lt hf.eLpNormEssSup_lt_top
+
+lemma holder_correlation_tree_final (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂) (h2u : 𝓘 u₁ ≤ 𝓘 u₂)
+    (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf₁ : BoundedCompactSupport f₁) (hf₂ : BoundedCompactSupport f₂)
+    (mx : x ∈ ball (c J) (8 * D ^ s J)) (mx' : x' ∈ ball (c J) (8 * D ^ s J)) :
+    C7_5_2 a * C7_5_9s a * C7_5_10 a * P7_5_4 t u₁ u₂ f₁ f₂ J * (edist x x' / D ^ s J) +
+    C7_5_9d a * C7_5_10 a * P7_5_4 t u₁ u₂ f₁ f₂ J * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ +
+    C7_5_9s a * C7_5_9d a * P7_5_4 t u₁ u₂ f₁ f₂ J * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ ≤
+    (C7_5_4 a * (P7_5_4 t u₁ u₂ f₁ f₂ J).toNNReal : ℝ≥0) * edist x x' ^ (nnτ : ℝ) := by
   sorry
 
+/-- Lemma 7.5.4. -/
+lemma holder_correlation_tree (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂) (h2u : 𝓘 u₁ ≤ 𝓘 u₂)
+    (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf₁ : BoundedCompactSupport f₁) (hf₂ : BoundedCompactSupport f₂) :
+    HolderOnWith (C7_5_4 a * (P7_5_4 t u₁ u₂ f₁ f₂ J).toNNReal)
+      nnτ (holderFunction t u₁ u₂ f₁ f₂ J) (ball (c J) (8 * D ^ s J)) := fun x mx x' mx' ↦ by
+  by_cases mu₁ : x ∉ 𝓘 u₁ ∧ x' ∉ 𝓘 u₁
+  · have h0 := support_subset_iff'.mp (support_holderFunction_subset u₂ f₁ f₂ J hu₁)
+    rw [h0 _ mu₁.1, h0 _ mu₁.2, edist_self]; exact zero_le _
+  rw [not_and_or, not_not, not_not] at mu₁
+  wlog mu₁' : x' ∈ 𝓘 u₁ generalizing x x'
+  · specialize this _ mx' _ mx mu₁.symm (mu₁.resolve_right mu₁')
+    rwa [edist_comm, edist_comm x'] at this
+  let CH := χ t u₁ u₂ J
+  let T₁ := fun z ↦ exp (.I * 𝒬 u₁ z) * adjointCarlesonSum (t u₁) f₁ z
+  let T₂ := fun z ↦ exp (.I * 𝒬 u₂ z) * adjointCarlesonSum (t u₂ ∩ 𝔖₀ t u₁ u₂) f₂ z
+  change ‖CH x * T₁ x * conj (T₂ x) - CH x' * T₁ x' * conj (T₂ x')‖ₑ ≤ _
+  calc
+    _ ≤ _ := edist_triangle4 _ (CH x' * T₁ x * conj (T₂ x)) (CH x' * T₁ x' * conj (T₂ x)) _
+    _ = edist (CH x) (CH x') * ‖T₁ x‖ₑ * ‖T₂ x‖ₑ + CH x' * edist (T₁ x) (T₁ x') * ‖T₂ x‖ₑ +
+        CH x' * ‖T₁ x'‖ₑ * edist (T₂ x) (T₂ x') := by
+      simp_rw [edist_eq_enorm_sub, ← sub_mul, ← mul_sub, enorm_mul, ← RingHom.map_sub,
+        RCLike.enorm_conj, ← ofReal_sub, Complex.enorm_real, NNReal.enorm_eq]
+      rfl
+    _ ≤ C7_5_2 a * C7_5_9s a * C7_5_10 a * P7_5_4 t u₁ u₂ f₁ f₂ J * (edist x x' / D ^ s J) +
+        C7_5_9d a * C7_5_10 a * P7_5_4 t u₁ u₂ f₁ f₂ J * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ +
+        C7_5_9s a * C7_5_9d a * P7_5_4 t u₁ u₂ f₁ f₂ J * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ := by
+      gcongr ?_ + ?_ + ?_
+      · exact holder_correlation_tree_1 hu₁ hu₂ hu h2u hJ hf₁ hf₂ mx mu₁'
+      · exact holder_correlation_tree_2 hu₁ hu₂ hu h2u hJ hf₁ hf₂ mx mx'
+      · exact holder_correlation_tree_3 hu₁ hu₂ hu h2u hJ hf₁ hf₂ mx mx'
+    _ ≤ _ := holder_correlation_tree_final hu₁ hu₂ hu h2u hJ hf₁ hf₂ mx mx'
 
 /-! ### Subsection 7.5.3 and Lemma 7.4.5 -/
 

--- a/Carleson/ForestOperator/LargeSeparation.lean
+++ b/Carleson/ForestOperator/LargeSeparation.lean
@@ -955,19 +955,12 @@ lemma limited_scale_impact (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ 
 
 open scoped Classical in
 lemma local_tree_control_sumsumsup (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂)
-    (h2u : 𝓘 u₁ ≤ 𝓘 u₂) (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf : BoundedCompactSupport f) :
-    ⨆ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f x‖₊ ≤
+    (h2u : 𝓘 u₁ ≤ 𝓘 u₂) (hJ : J ∈ 𝓙₅ t u₁ u₂) :
+    ⨆ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f x‖ₑ ≤
     ∑ k ∈ Finset.Icc (s J) (s J + 3),
     ∑ p ∈ {p | 𝔰 p = k ∧ ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8⁻¹ * D ^ s J))},
       ⨆ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarleson p f x‖ₑ :=
   calc
-    _ = ⨆ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f x‖ₑ := by
-      rw [ENNReal.coe_biSup]; · rfl
-      simp_rw [bddAbove_def, mem_range, forall_exists_index, forall_apply_eq_imp_iff]
-      obtain ⟨C, hC⟩ := hf.bddAbove_norm_adjointCarlesonSum (ℭ := t u₂ \ 𝔖₀ t u₁ u₂)
-      refine ⟨C.toNNReal, fun x ↦ ?_⟩
-      simp only [mem_upperBounds, mem_range, forall_exists_index, forall_apply_eq_imp_iff] at hC
-      exact NNReal.le_toNNReal_of_coe_le (hC x)
     _ ≤ ⨆ x ∈ ball (c J) (8⁻¹ * D ^ s J),
         ∑ p ∈ (t u₂ \ 𝔖₀ t u₁ u₂).toFinset, ‖adjointCarleson p f x‖ₑ := by
       apply iSup₂_mono fun x mx ↦ ?_
@@ -1060,14 +1053,14 @@ irreducible_def C7_5_7 (a : ℕ) : ℝ≥0 := 2 ^ (104 * (a : ℝ) ^ 3)
 /-- Lemma 7.5.7. -/
 lemma local_tree_control (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂)
     (h2u : 𝓘 u₁ ≤ 𝓘 u₂) (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf : BoundedCompactSupport f) :
-    ⨆ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f x‖₊ ≤
+    ⨆ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f x‖ₑ ≤
     C7_5_7 a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f x := by
   classical
   calc
     _ ≤ ∑ k ∈ Finset.Icc (s J) (s J + 3),
         ∑ p ∈ {p | 𝔰 p = k ∧ ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8⁻¹ * D ^ s J))},
           ⨆ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarleson p f x‖ₑ :=
-      local_tree_control_sumsumsup hu₁ hu₂ hu h2u hJ hf
+      local_tree_control_sumsumsup hu₁ hu₂ hu h2u hJ
     _ ≤ ∑ k ∈ Finset.Icc (s J) (s J + 3),
         ∑ p ∈ {p | 𝔰 p = k ∧ ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8⁻¹ * D ^ s J))},
           2 ^ (103 * a ^ 3) * (volume (ball (c J) (16 * D ^ k)))⁻¹ * ∫⁻ x in E p, ‖f x‖ₑ := by
@@ -1468,19 +1461,28 @@ lemma global_tree_control1_supbound (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (h
       congr; rw [C7_5_9d, C7_5_9s, ENNReal.coe_mul, ENNReal.coe_pow, ENNReal.coe_ofNat, mul_assoc,
         ← pow_succ, add_assoc]; rfl
 
-/-- The constant used in `global_tree_control2`.
-Has value `2 ^ (155 * a ^ 3)` in the blueprint. -/
--- Todo: define this recursively in terms of previous constants
-irreducible_def C7_5_10 (a : ℕ) : ℝ≥0 := 2 ^ (155 * (a : ℝ) ^ 3)
+/-- The constant used in `global_tree_control2`. -/
+irreducible_def C7_5_10 (a : ℕ) : ℝ≥0 := C7_5_7 a + C7_5_9s a
 
 /-- Lemma 7.5.10 -/
 lemma global_tree_control2 (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂)
-    (h2u : 𝓘 u₁ ≤ 𝓘 u₂) (hJ : J ∈ 𝓙₅ t u₁ u₂)
-    (hf : BoundedCompactSupport f) :
-    ⨆ x ∈ ball (c J) (8 * D ^ s J), ‖adjointCarlesonSum (t u₂ ∩ 𝔖₀ t u₁ u₂) f x‖₊ ≤
-    ⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₂) f x‖₊ +
-    C7_5_10 a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 (‖f ·‖) x := by
-  sorry
+    (h2u : 𝓘 u₁ ≤ 𝓘 u₂) (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf : BoundedCompactSupport f) :
+    ⨆ x ∈ ball (c J) (8 * D ^ s J), ‖adjointCarlesonSum (t u₂ ∩ 𝔖₀ t u₁ u₂) f x‖ₑ ≤
+    (⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₂) f x‖ₑ) +
+    C7_5_10 a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f x :=
+  calc
+    _ ≤ _ := global_tree_control1_supbound hu₁ hu₂ hu h2u _ (.inr rfl) hJ hf
+    _ = (⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J),
+        ‖adjointCarlesonSum (t u₂) f x - adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f x‖ₑ) +
+        C7_5_9s a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f x := by
+      congr! with x mx; exact adjointCarlesonSum_inter
+    _ ≤ (⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₂) f x‖ₑ) +
+        (⨆ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f x‖ₑ) +
+        C7_5_9s a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f x := by
+      gcongr; exact ENNReal.biInf_enorm_sub_le
+    _ ≤ _ := by
+      rw [C7_5_10, ENNReal.coe_add, add_mul, add_assoc]
+      gcongr; exact local_tree_control hu₁ hu₂ hu h2u hJ hf
 
 /-- The constant used in `holder_correlation_tree`.
 Has value `2 ^ (535 * a ^ 3)` in the blueprint. -/

--- a/Carleson/ToMathlib/Data/ENNReal.lean
+++ b/Carleson/ToMathlib/Data/ENNReal.lean
@@ -119,6 +119,18 @@ lemma exists_enorm_sub_eps_le_biInf
     add_le_iff_nonpos_right] at key
   rw [← NNReal.coe_pos] at εpos; linarith only [εpos, key]
 
+lemma biInf_enorm_sub_le {f g : ι → E} :
+    ⨅ x ∈ s, ‖f x - g x‖ₑ ≤ (⨅ x ∈ s, ‖f x‖ₑ) + (⨆ x ∈ s, ‖g x‖ₑ) := by
+  rcases s.eq_empty_or_nonempty with rfl | hs; · simp
+  refine ENNReal.le_of_forall_pos_le_add fun ε εpos _ ↦ ?_
+  obtain ⟨x, mx, hx⟩ := exists_enorm_sub_eps_le_biInf (f := f) εpos hs
+  calc
+    _ ≤ ‖f x - g x‖ₑ := biInf_le (fun i ↦ ‖f i - g i‖ₑ) mx
+    _ ≤ ‖f x‖ₑ + ‖g x‖ₑ := enorm_sub_le
+    _ ≤ ε + (⨅ x ∈ s, ‖f x‖ₑ) + ⨆ x ∈ s, ‖g x‖ₑ :=
+      add_le_add (by rwa [← tsub_le_iff_left]) (le_biSup (‖g ·‖ₑ) mx)
+    _ = _ := by rw [add_rotate]
+
 end ENNReal
 
 /-- Transfer an inequality over `ℝ` to one of `ENorm`s over `ℝ≥0∞`. -/

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -5727,7 +5727,7 @@ $$
         \uses{global-tree-control-1, local-tree-control}
         We have for all $J \in \mathcal{J}'$ and all bounded $g$ with bounded support
         $$
-            \sup_{B(J)} |T^*_{\fT(\fu_2) \cap \mathfrak{S}} g| \le \inf_{B^\circ{}(J)} |T^*_{\fT(\fu_2)} g| + 2^{155a^3} \inf_{J} M_{\mathcal{B},1}|g|\,.
+            \sup_{B(J)} |T^*_{\fT(\fu_2) \cap \mathfrak{S}} g| \le \inf_{B^\circ{}(J)} |T^*_{\fT(\fu_2)} g| + 2^{151a^3+4a+3} \inf_{J} M_{\mathcal{B},1}|g|\,.
         $$
     \end{lemma}
 
@@ -5735,55 +5735,61 @@ $$
         \leanok
         By \Cref{global-tree-control-1}
         $$
-            \sup_{B(J)} |T^*_{\fT(\fu_2) \cap \mathfrak{S}} g| \le \inf_{B^\circ{}(J)} |T_{\fT(\fu_2) \cap \mathfrak{S}}^* g| + 2^{154a^3} \inf_{J} M_{\mathcal{B}, 1} |g|
+            \sup_{B(J)} |T^*_{\fT(\fu_2) \cap \mathfrak{S}} g| \le \inf_{B^\circ{}(J)} |T_{\fT(\fu_2) \cap \mathfrak{S}}^* g| + 2^{151a^3+4a+2} \inf_{J} M_{\mathcal{B}, 1} |g|
         $$
         $$
-            \le \inf_{B^\circ{}(J)} |T_{\fT(\fu_2)}^* g| + \sup_{B^\circ{}(J)} |T_{\fT(\fu_2) \setminus \mathfrak{S}}^* g| + 2^{154a^3} \inf_{J} M_{\mathcal{B}, 1} |g|\,,
+            \le \inf_{B^\circ{}(J)} |T_{\fT(\fu_2)}^* g| + \sup_{B^\circ{}(J)} |T_{\fT(\fu_2) \setminus \mathfrak{S}}^* g| + 2^{151a^3+4a+2} \inf_{J} M_{\mathcal{B}, 1} |g|\,,
         $$
         and by \Cref{local-tree-control}
         $$
-            \le \inf_{B^\circ{}(J)} |T_{\fT(\fu_2)}^* g| + (2^{104a^3} + 2^{154a^3}) \inf_{J} M_{\mathcal{B}, 1} |g|\,.
+            \le \inf_{B^\circ{}(J)} |T_{\fT(\fu_2)}^* g| + (2^{104a^3} + 2^{151a^3+4a+2}) \inf_{J} M_{\mathcal{B}, 1} |g|\,.
         $$
         This completes the proof.
     \end{proof}
 
-
-
     \begin{proof}[Proof of \Cref{Holder-correlation-tree}]
         \proves{Holder-correlation-tree}
-        Let $P$ be the product on the right hand side of \eqref{hHolder}, and $h_J$ as defined in \eqref{def-hj}.
-
-        By \eqref{eq-pao-2} and \Cref{adjoint-tile-support}, the function $h_J$ is supported in $B(J) \cap \scI(\fu_1)$.
-        By \eqref{eq-pao-2} and \Cref{global-tree-control-1}, we have for all $y \in B(J)$:
-        $$
-            |h_J(y)| \le 2^{308a^3} P\,.
-        $$
+        Let $P$ be the product on the right hand side of \eqref{hHolder}, and $h_J$ be as defined in \eqref{def-hj}.
+        %By \eqref{eq-pao-2} and \Cref{adjoint-tile-support}, the function $h_J$ is supported in $B(J) \cap \scI(\fu_1)$.
+        %By \eqref{eq-pao-2}, \Cref{global-tree-control-1} and \Cref{global-tree-control-2}, we have for all $y \in B(J)$:
+        %$$
+        %    |h_J(y)| \le 2^{308a^3} P\,.
+        %$$
         We have by the triangle inequality
         \begin{align}
             &|h_J(y) - h_J(y')|\nonumber\\
             \label{eq-h-Lip-1}
             &\le |\chi_J(y) - \chi_J(y')| |T_{\fT(\fu_1)}^* g_1(y)| |T_{\fT(\fu_2) \cap \mathfrak{S}}^* g_2(y)|\\
             \label{eq-h-Lip-2}
-            & + |\chi_J(y')| |T_{\fT(\fu_1)}^* g_1(y) - T_{\fT(\fu_1)}^* g_1(y')| |T_{\fT(\fu_2) \cap \mathfrak{S}}^* g_2(y)|\\
+            & + |\chi_J(y')| |e(\fcc(\fu_1)(y)) T_{\fT(\fu_1)}^* g_1(y) - e(\fcc(\fu_1)(y')) T_{\fT(\fu_1)}^* g_1(y')| |T_{\fT(\fu_2) \cap \mathfrak{S}}^* g_2(y)|\\
             \label{eq-h-Lip-3}
-            & + |\chi_J(y')| |T_{\fT(\fu_1)}^* g_1(y')| |T_{\fT(\fu_2) \cap \mathfrak{S}}^* g_2(y) - T_{\fT(\fu_2) \cap \mathfrak{S}}^* g_2(y')|\,.
+            & + |\chi_J(y')| |T_{\fT(\fu_1)}^* g_1(y')| |e(\fcc(\fu_2)(y)) T_{\fT(\fu_2) \cap \mathfrak{S}}^* g_2(y) - e(\fcc(\fu_2)(y')) T_{\fT(\fu_2) \cap \mathfrak{S}}^* g_2(y')|\,.
         \end{align}
 
         As $h_J$ is supported in $\scI(\fu_1)$, we can assume without loss of generality that $y' \in \scI(\fu_1)$.
         If $y \notin \scI(\fu_1)$, then \eqref{eq-h-Lip-1} vanishes. If $y \in \scI(\fu_1)$ then we have by \eqref{eq-pao-3}, \Cref{global-tree-control-1} and \Cref{global-tree-control-2}
+        % C7_5_2       C7_5_9s           C7_5_10
+        % 2^{226a^3} * 2^{151a^3+4a+2} * 2^{151a^3+4a+3}
+        % 2^{528a^3+8a+5}
         $$
-            \eqref{eq-h-Lip-1} \le 2^{534a^3} \frac{\rho(y,y')}{D^{s(J)}} P\,,
+            \eqref{eq-h-Lip-1} \le 2^{528a^3+8a+5} \frac{\rho(y,y')}{D^{s(J)}} P\,,
         $$
         where $P$ denotes the product on the right hand side of \eqref{hHolder}.
 
         By \eqref{eq-pao-2}, \Cref{global-tree-control-1} and \Cref{global-tree-control-2}, we have
+        % C7_5_9d           C7_5_10
+        % 2^{151a^3+4a+1} * 2^{151a^3+4a+3}
+        % 2^{302a^3+8a+4}
         $$
-            \eqref{eq-h-Lip-2} \le 2^{310a^3} P\,.
-         $$
+            \eqref{eq-h-Lip-2} \le 2^{302a^3+8a+4} \left(\frac{\rho(y,y')}{D^{s(J)}}\right)^{1/a} P\,.
+        $$
 
         By \eqref{eq-pao-2}, and twice \Cref{global-tree-control-1}, we have
+        % C7_5_9s           C7_5_9d
+        % 2^{151a^3+4a+2} * 2^{151a^3+4a+1}
+        % 2^{302a^3+8a+3}
         $$
-            \eqref{eq-h-Lip-3} \le 2^{308a^3} P\,.
+            \eqref{eq-h-Lip-3} \le 2^{302a^3+8a+3} \left(\frac{\rho(y,y')}{D^{s(J)}}\right)^{1/a} P\,.
         $$
         Using that $\rho(y,y') \le 16D^{s(J)}$ and $a \ge 4$, the lemma follows.
     \end{proof}

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -5732,6 +5732,7 @@ $$
     \end{lemma}
 
     \begin{proof}
+        \leanok
         By \Cref{global-tree-control-1}
         $$
             \sup_{B(J)} |T^*_{\fT(\fu_2) \cap \mathfrak{S}} g| \le \inf_{B^\circ{}(J)} |T_{\fT(\fu_2) \cap \mathfrak{S}}^* g| + 2^{154a^3} \inf_{J} M_{\mathcal{B}, 1} |g|


### PR DESCRIPTION
There appears to be an error in the final inequality of the proof of Lemma 7.5.4 (`holder_correlation_tree_final`). The bounds for each summand include an extra factor of `(1 / D ^ s J) ^ (a : ℝ)⁻¹ = D ^ (-s J / a : ℝ)` over the form required by the `HolderOnWith`, and if `s J` is a large negative number this obviously cannot be bounded by 1 or any other "small" constant, only `D ^ (S / a : ℝ)` which may be impossibly large.