### PR TITLE
Lower-semicontinuity of maximal function - Task 135

### DIFF
--- a/Carleson/ToMathlib/HardyLittlewood.lean
+++ b/Carleson/ToMathlib/HardyLittlewood.lean
@@ -265,8 +265,7 @@ lemma continuous_integral_ball [OpensMeasurableSpace X]
 
 /-- Use the dominated convergence theorem
 e.g. [Folland, Real Analysis. Modern Techniques and Their Applications, Lemma 3.16] -/
-lemma continuous_average_ball [μ.IsOpenPosMeasure] [μ.IsOpenPosMeasure]
-    [IsFiniteMeasureOnCompacts μ] [OpensMeasurableSpace X]
+lemma continuous_average_ball [μ.IsOpenPosMeasure] [IsFiniteMeasureOnCompacts μ] [OpensMeasurableSpace X]
     [ProperSpace X] (hf : LocallyIntegrable f μ)
     (hμ : ∀ z : X, ∀ r > (0 : ℝ), μ (sphere z r) = 0) :
     ContinuousOn (fun x : X × ℝ ↦ ⨍⁻ y in ball x.1 x.2, ‖f y‖ₑ ∂μ) (univ ×ˢ Ioi 0) := by

--- a/Carleson/ToMathlib/HardyLittlewood.lean
+++ b/Carleson/ToMathlib/HardyLittlewood.lean
@@ -596,12 +596,8 @@ lemma lowerSemiContinuous_MB :
       exact lt_iSup_iff.mpr (by use i; refine lt_iSup_iff.mpr (by use hi₀))
   rw [this]
   refine isOpen_biUnion (fun i hi ↦ ?_)
-  rw [@indicator_const_preimage_eq_union]
-  split_ifs with h₀ h₁
-  · simp
-  · simp
-  · simp_all
-  · simp
+  refine LowerSemicontinuous.isOpen_preimage ?_ y
+  refine IsOpen.lowerSemicontinuous_indicator isOpen_ball (zero_le _)
 
 theorem hasWeakType_maximalFunction_equal_exponents₀ [BorelSpace X]
     {p : ℝ≥0} (h𝓑 : 𝓑.Countable) {R : ℝ} (hR : ∀ i ∈ 𝓑, r i ≤ R) (hp : 1 ≤ p) :
@@ -808,9 +804,27 @@ theorem hasWeakType_globalMaximalFunction [BorelSpace X] [IsFiniteMeasureOnCompa
   exact hasWeakType_maximalFunction countable_globalMaximalFunction hp₁ hp₁₂
 
 /-- Use `lowerSemiContinuous_MB` -/
-lemma lowerSemiContinuous_globalMaximalFunction (hf : LocallyIntegrable f μ) :
+lemma lowerSemiContinuous_globalMaximalFunction :
     LowerSemicontinuous (globalMaximalFunction μ 1 f) := by
-  sorry
+  by_cases h : A = 0; · unfold globalMaximalFunction; simp_rw [h]; simp [lowerSemicontinuous_const]
+  have : globalMaximalFunction μ 1 f = fun x : X ↦
+      ofNNReal A ^ 2 * MB μ ((covering_separable_space X).choose ×ˢ (univ : Set ℤ))
+      (fun x ↦ x.1) (fun x ↦ 2 ^ x.2) (fun x ↦ ‖f x‖ ^ (1 : ℝ)) x ^ (1 : ℝ)⁻¹ :=
+    funext fun x ↦ congr_arg (HMul.hMul ((A : ℝ≥0∞) ^ 2)) (maximalFunction_eq_MB (zero_le_one' ℝ))
+  rw [this]
+  simp only [gt_iff_lt, Real.rpow_one, inv_one, rpow_one]
+  refine lowerSemicontinuous_iff_isOpen_preimage.mpr fun y ↦ ?_
+  by_cases hy : y = ∞; · rw [hy]; simp
+  have : (fun x : X ↦ ofNNReal A ^ 2 * MB μ ((covering_separable_space X).choose ×ˢ (univ : Set ℤ))
+      (fun x ↦ x.1) (fun x ↦ 2 ^ x.2) (fun x ↦ ‖f x‖) x)⁻¹' Ioi y =
+      (fun x : X ↦ MB μ ((covering_separable_space X).choose ×ˢ (univ : Set ℤ)) (fun x ↦ x.1)
+      (fun x ↦ 2 ^ x.2) (fun x ↦ ‖f x‖ ) x)⁻¹' Ioi (y / A ^ 2) := by
+    ext x
+    simp only [gt_iff_lt, Real.rpow_one, mem_preimage, mem_Ioi]
+    refine ⟨fun h₀ ↦ div_lt_of_lt_mul' h₀, fun h₀ ↦ ?_⟩; rw [mul_comm]; exact
+        (ENNReal.div_lt_iff (Or.inl (ENNReal.pow_ne_zero (coe_ne_zero.mpr h) 2)) (Or.inr hy)).mp h₀
+  rw [this]
+  exact LowerSemicontinuous.isOpen_preimage lowerSemiContinuous_MB _
 
 theorem globalMaximalFunction_ae_lt_top [BorelSpace X] [IsFiniteMeasureOnCompacts μ]
     [Nonempty X] [μ.IsOpenPosMeasure] {p₁ p₂ : ℝ≥0} (hp₁ : 1 ≤ p₁) (hp₁₂ : p₁ < p₂)

--- a/Carleson/ToMathlib/HardyLittlewood.lean
+++ b/Carleson/ToMathlib/HardyLittlewood.lean
@@ -573,9 +573,35 @@ theorem hasStrongType_maximalFunction
       exact hestfin k
 
 /-- Use `lowerSemicontinuous_iff_isOpen_preimage` and `continuous_average_ball` -/
-lemma lowerSemiContinuous_MB (hf : LocallyIntegrable f μ) :
+lemma lowerSemiContinuous_MB :
     LowerSemicontinuous (MB μ 𝓑 c r f) := by
-  sorry
+  apply lowerSemicontinuous_iff_isOpen_preimage.mpr
+  intro y
+  unfold MB maximalFunction
+  simp only [rpow_one, inv_one]
+  have : ((fun x ↦ (⨆ i ∈ 𝓑, (ball (c i) (r i)).indicator
+      (fun x ↦ ⨍⁻ (y : X) in ball (c i) (r i), ‖f y‖ₑ ∂μ) x)) ⁻¹' Ioi y) =
+      ⋃ i ∈ 𝓑, (ball (c i) (r i)).indicator
+      (fun x ↦ ⨍⁻ (y : X) in ball (c i) (r i), ‖f y‖ₑ ∂μ) ⁻¹' Ioi y := by
+    ext x
+    simp only [pow_one, mem_preimage, mem_Ioi, mem_iUnion, exists_prop]
+    constructor
+    · intro h
+      by_contra h₀
+      simp only [not_exists, not_and, not_lt] at h₀
+      have := iSup₂_le_iff.mpr h₀
+      order
+    · intro h
+      obtain ⟨i, ⟨hi₀, hi₁⟩⟩ := h
+      exact lt_iSup_iff.mpr (by use i; refine lt_iSup_iff.mpr (by use hi₀))
+  rw [this]
+  refine isOpen_biUnion (fun i hi ↦ ?_)
+  rw [@indicator_const_preimage_eq_union]
+  split_ifs with h₀ h₁
+  · simp
+  · simp
+  · simp_all
+  · simp
 
 theorem hasWeakType_maximalFunction_equal_exponents₀ [BorelSpace X]
     {p : ℝ≥0} (h𝓑 : 𝓑.Countable) {R : ℝ} (hR : ∀ i ∈ 𝓑, r i ≤ R) (hp : 1 ≤ p) :


### PR DESCRIPTION
Proof of the lower-semicontinuity of the maximal function and lower-semicontinuity of the global maximal function.

Although not used in the proof, I also proved `continuous_average_ball` under an extra assumption. Without that assumption I proved `lowerSemicontinuous_integral_ball`. I'm not sure these are still useful, because they are currently not used. Feel free to discard.