### PR TITLE
First part of Lemma 7.6.2, to Equation (7.6.3)

### DIFF
--- a/Carleson/ForestOperator/RemainingTiles.lean
+++ b/Carleson/ForestOperator/RemainingTiles.lean
@@ -1,4 +1,5 @@
 import Carleson.ForestOperator.AlmostOrthogonality
+import Carleson.ToMathlib.Analysis.Normed.Group.Basic
 
 open ShortVariables TileStructure
 variable {X : Type*} {a : ℕ} {q : ℝ} {K : X → X → ℂ} {σ₁ σ₂ : X → ℤ} {F G : Set X}
@@ -81,8 +82,7 @@ lemma union_𝓙₆ (hu₁ : u₁ ∈ t) :
       contradiction
 
 /-- Part of Lemma 7.6.1. -/
-lemma pairwiseDisjoint_𝓙₆ :
-    (𝓙₆ t u₁).PairwiseDisjoint (fun I ↦ (I : Set X)) := by
+lemma pairwiseDisjoint_𝓙₆ : (𝓙₆ t u₁).PairwiseDisjoint (fun I ↦ (I : Set X)) := by
   have ss : (𝓙 (t u₁) ∩ Iic (𝓘 u₁)) ⊆ 𝓙 (t u₁) := inter_subset_left
   exact PairwiseDisjoint.subset (pairwiseDisjoint_𝓙 (𝔖 := t u₁)) ss
 
@@ -220,15 +220,22 @@ lemma thin_scale_impact (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠
       rw [pow_add, pow_mul']; gcongr; exacts [by norm_num, Nat.lt_two_pow_self.le]
     _ ≤ _ := by gcongr <;> omega
 
+/-- Lemma 7.6.3 with a floor on the constant to avoid casting. -/
+lemma thin_scale_impact' (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂)
+    (h2u : 𝓘 u₁ ≤ 𝓘 u₂) (hp : p ∈ t u₂ \ 𝔖₀ t u₁ u₂) (hJ : J ∈ 𝓙₆ t u₁)
+    (hd : ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8 * D ^ s J))) :
+    𝔰 p ≤ s J - ⌊C7_6_3 a n⌋ := by
+  rw [← Int.cast_le (R := ℝ), Int.cast_sub]
+  apply (thin_scale_impact hu₁ hu₂ hu h2u hp hJ hd).trans; gcongr; exact Int.floor_le _
+
 /-- The constant used in `square_function_count`. -/
 irreducible_def C7_6_4 (a : ℕ) (s : ℤ) : ℝ≥0 := 2 ^ (14 * (a : ℝ) + 1) * (8 * D ^ (- s)) ^ κ
 
-open scoped Classical in
-set_option linter.flexible false in -- Addressing the linter makes the code less readable.
+open Classical in
 /-- Lemma 7.6.4. -/
 lemma square_function_count (hJ : J ∈ 𝓙₆ t u₁) (s' : ℤ) :
     ⨍⁻ x in J, (∑ I ∈ {I : Grid X | s I = s J - s' ∧ Disjoint (I : Set X) (𝓘 u₁) ∧
-    ¬ Disjoint (J : Set X) (ball (c I) (8 * D ^ s I)) },
+    ¬Disjoint (J : Set X) (ball (c I) (8 * D ^ s I)) },
     (ball (c I) (8 * D ^ s I)).indicator 1 x) ^ 2 ∂volume ≤ C7_6_4 a s' := by
   rcases lt_or_ge (↑S + s J) s' with hs' | hs'
   · suffices ({I : Grid X | s I = s J - s' ∧ Disjoint (I : Set X) (𝓘 u₁) ∧
@@ -362,13 +369,141 @@ Has value `2 ^ (118 * a ^ 3 - 100 / (202 * a) * Z * n * κ)` in the blueprint. -
 -- Todo: define this recursively in terms of previous constants
 irreducible_def C7_6_2 (a n : ℕ) : ℝ≥0 := 2 ^ (118 * (a : ℝ) ^ 3 - 100 / (202 * a) * Z * n * κ)
 
-/-- Lemma 7.6.2. Todo: add needed hypothesis to LaTeX -/
-lemma bound_for_tree_projection (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂)
-    (h2u : 𝓘 u₁ ≤ 𝓘 u₂) (hf : IsBounded (range f)) (h2f : HasCompactSupport f)
-    (h3f : AEStronglyMeasurable f) :
+open Classical in
+lemma sum_𝓙₆_indicator_sq_eq {f : Grid X → X → ℝ≥0∞} :
+    (∑ J ∈ (𝓙₆ t u₁).toFinset, (J : Set X).indicator (f J) x) ^ 2 =
+    ∑ J ∈ (𝓙₆ t u₁).toFinset, (J : Set X).indicator (f J · ^ 2) x := by
+  rw [sq, Finset.sum_mul_sum, ← Finset.sum_product']
+  have dsub : (𝓙₆ t u₁).toFinset.diag ⊆ (𝓙₆ t u₁).toFinset ×ˢ (𝓙₆ t u₁).toFinset :=
+    Finset.filter_subset ..
+  rw [← Finset.sum_subset dsub]; swap
+  · intro p mp np
+    simp_rw [Finset.mem_product, Finset.mem_diag, mem_toFinset, not_and] at mp np
+    specialize np mp.1
+    rw [← inter_indicator_mul, (pairwiseDisjoint_𝓙₆ mp.1 mp.2 np).inter_eq]
+    simp
+  simp_rw [Finset.sum_diag, ← inter_indicator_mul, inter_self, ← sq]
+
+open Classical in
+lemma btp_expansion (hf : BoundedCompactSupport f) (mf : AEStronglyMeasurable f) :
+    eLpNorm (approxOnCube (𝓙₆ t u₁) (‖adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f ·‖)) 2 volume =
+    (∑ J ∈ (𝓙₆ t u₁).toFinset, (volume (J : Set X))⁻¹ *
+    (∫⁻ y in J, ‖adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f y‖ₑ) ^ 2) ^ (2 : ℝ)⁻¹ := by
+  have Vpos {J : Grid X} : 0 < volume (J : Set X) := volume_coeGrid_pos (defaultD_pos' a)
+  have Vlt {J : Grid X} : volume (J : Set X) < ⊤ := volume_coeGrid_lt_top
+  calc
+    _ = (∫⁻ x, ∑ J ∈ (𝓙₆ t u₁).toFinset, (J : Set X).indicator (fun _ ↦
+        ‖⨍ y in J, ‖adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f y‖‖ₑ ^ 2) x) ^ (2 : ℝ)⁻¹ := by
+      unfold approxOnCube
+      simp_rw [eLpNorm_eq_lintegral_rpow_enorm two_ne_zero ENNReal.ofNat_ne_top,
+        ENNReal.toReal_ofNat, one_div]
+      congr! with x; rw [ENNReal.enorm_sum_eq_sum_enorm]; swap
+      · refine fun J mJ ↦ indicator_nonneg (fun y my ↦ ?_) _
+        rw [average_eq, smul_eq_mul]
+        exact mul_nonneg (by positivity) (integral_nonneg fun _ ↦ norm_nonneg _)
+      rw [show (2 : ℝ) = (2 : ℕ) by rfl, ENNReal.rpow_natCast, filter_mem_univ_eq_toFinset]
+      simp_rw [enorm_indicator_eq_indicator_enorm, sum_𝓙₆_indicator_sq_eq]
+    _ = (∑ J ∈ (𝓙₆ t u₁).toFinset, ∫⁻ x in (J : Set X), (fun _ ↦
+        ‖⨍ y in J, ‖adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f y‖‖ₑ ^ 2) x) ^ (2 : ℝ)⁻¹ := by
+      congr 1; simp_rw [← lintegral_indicator coeGrid_measurable]
+      exact lintegral_finset_sum _ fun J mJ ↦ measurable_const.indicator coeGrid_measurable
+    _ = (∑ J ∈ (𝓙₆ t u₁).toFinset, ∫⁻ x in (J : Set X),
+        (⨍⁻ y in J, ‖adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f y‖ₑ ∂volume) ^ 2) ^ (2 : ℝ)⁻¹ := by
+      simp only [lintegral_const]; congr! with J mJ
+      have vn0 : volume.real (J : Set X) ≠ 0 := by
+        rw [measureReal_def, ENNReal.toReal_ne_zero]; exact ⟨Vpos.ne', Vlt.ne⟩
+      rw [setLAverage_eq, setAverage_eq, smul_eq_mul, enorm_mul, enorm_inv vn0,
+        ← ENNReal.div_eq_inv_mul, measureReal_def, Real.enorm_of_nonneg ENNReal.toReal_nonneg,
+        ENNReal.ofReal_toReal Vlt.ne]; congr
+      rw [integral_norm_eq_lintegral_enorm mf.adjointCarlesonSum.restrict]; apply enorm_toReal
+      rw [← lt_top_iff_ne_top, ← eLpNorm_one_eq_lintegral_enorm]
+      exact (hf.adjointCarlesonSum.restrict.memLp 1).2
+    _ = _ := by
+      congr! with J mJ
+      rw [setLIntegral_const, setLAverage_eq, ENNReal.div_eq_inv_mul, mul_pow, ← mul_rotate, sq,
+        ← mul_assoc, ENNReal.mul_inv_cancel Vpos.ne' Vlt.ne, one_mul]
+
+open Classical in
+/-- Equation (7.6.3) of Lemma 7.6.2. -/
+lemma e763 (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂) (h2u : 𝓘 u₁ ≤ 𝓘 u₂)
+    (hf : BoundedCompactSupport f) (mf : AEStronglyMeasurable f) :
     eLpNorm (approxOnCube (𝓙₆ t u₁) (‖adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f ·‖)) 2 volume ≤
-    C7_6_2 a n *
-    eLpNorm ((𝓘 u₁ : Set X).indicator (MB volume 𝓑 c𝓑 r𝓑 (‖f ·‖) ·)) 2 volume := by
+    ∑ k ∈ Finset.Icc ⌊C7_6_3 a n⌋ (2 * S),
+    (∑ J ∈ (𝓙₆ t u₁).toFinset, (volume (J : Set X))⁻¹ *
+    (∫⁻ y in J, ∑ p ∈ (t u₂ \ 𝔖₀ t u₁ u₂).toFinset with
+      ¬Disjoint ↑J (ball (𝔠 p) (8 * D ^ 𝔰 p)) ∧ 𝔰 p = s J - k,
+    ‖adjointCarleson p f y‖ₑ) ^ 2) ^ (2 : ℝ)⁻¹ := by
+  calc
+    _ = _ := btp_expansion hf mf
+    _ = (∑ J ∈ (𝓙₆ t u₁).toFinset, (volume (J : Set X))⁻¹ * (∫⁻ y in J,
+        ‖∑ p ∈ (t u₂ \ 𝔖₀ t u₁ u₂).toFinset with ¬Disjoint ↑J (ball (𝔠 p) (8 * D ^ 𝔰 p)),
+          adjointCarleson p f y‖ₑ) ^ 2) ^ (2 : ℝ)⁻¹ := by
+      congr! 4 with J mJ
+      refine setLIntegral_congr_fun coeGrid_measurable (.of_forall fun y my ↦ ?_)
+      unfold adjointCarlesonSum; congr 1
+      rw [filter_mem_univ_eq_toFinset]; refine (Finset.sum_filter_of_ne fun p mp hd ↦ ?_).symm
+      rw [adjoint_tile_support1] at hd
+      exact not_disjoint_iff.mpr ⟨_, my,
+        ball_subset_ball (by gcongr; norm_num) (mem_of_indicator_ne_zero hd)⟩
+    _ = (∑ J ∈ (𝓙₆ t u₁).toFinset, (volume (J : Set X))⁻¹ * (∫⁻ y in J,
+        ‖∑ k ∈ Finset.Icc ⌊C7_6_3 a n⌋ (2 * S),
+        ∑ p ∈ (t u₂ \ 𝔖₀ t u₁ u₂).toFinset with
+          ¬Disjoint ↑J (ball (𝔠 p) (8 * D ^ 𝔰 p)) ∧ s J - 𝔰 p = k,
+        adjointCarleson p f y‖ₑ) ^ 2) ^ (2 : ℝ)⁻¹ := by
+      congr! with J mJ y; simp_rw [← Finset.filter_filter]
+      refine (Finset.sum_fiberwise_of_maps_to (fun p mp ↦ ?_) _).symm
+      rw [Finset.mem_filter] at mp; rw [mem_toFinset] at mp mJ; obtain ⟨mp, dp⟩ := mp
+      have dpJ : ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8 * D ^ s J)) := by
+        contrapose! dp; refine dp.symm.mono_left (Grid_subset_ball.trans (ball_subset_ball ?_))
+        change (4 : ℝ) * D ^ s J ≤ _; gcongr; norm_num
+      rw [Finset.mem_Icc]
+      constructor
+      · have tsi := thin_scale_impact' hu₁ hu₂ hu h2u mp mJ dpJ
+        omega
+      · have : s J ≤ S := scale_mem_Icc.2
+        have : -S ≤ 𝔰 p := scale_mem_Icc.1
+        omega
+    _ ≤ (∑ J ∈ (𝓙₆ t u₁).toFinset, (volume (J : Set X))⁻¹ *
+        (∫⁻ y in J, ∑ k ∈ Finset.Icc ⌊C7_6_3 a n⌋ (2 * S),
+        ∑ p ∈ (t u₂ \ 𝔖₀ t u₁ u₂).toFinset with
+          ¬Disjoint ↑J (ball (𝔠 p) (8 * D ^ 𝔰 p)) ∧ s J - 𝔰 p = k,
+        ‖adjointCarleson p f y‖ₑ) ^ 2) ^ (2 : ℝ)⁻¹ := by -- Triangle inequality
+      gcongr with J mJ y
+      exact (enorm_sum_le _ _).trans (Finset.sum_le_sum fun k mk ↦ enorm_sum_le _ _)
+    _ = (∑ J ∈ (𝓙₆ t u₁).toFinset, (volume (J : Set X))⁻¹ *
+        (∑ k ∈ Finset.Icc ⌊C7_6_3 a n⌋ (2 * S), ∫⁻ y in J,
+        ∑ p ∈ (t u₂ \ 𝔖₀ t u₁ u₂).toFinset with
+          ¬Disjoint ↑J (ball (𝔠 p) (8 * D ^ 𝔰 p)) ∧ s J - 𝔰 p = k,
+        ‖adjointCarleson p f y‖ₑ) ^ 2) ^ (2 : ℝ)⁻¹ := by
+      congr! with J mJ
+      exact lintegral_finset_sum' _ fun k mk ↦ Finset.aemeasurable_sum _ fun p mp ↦
+        mf.adjointCarleson.aemeasurable.enorm.restrict
+    _ = (∑ J ∈ (𝓙₆ t u₁).toFinset, (∑ k ∈ Finset.Icc ⌊C7_6_3 a n⌋ (2 * S),
+        volume (J : Set X) ^ (-2 : ℝ)⁻¹ * ∫⁻ y in J, ∑ p ∈ (t u₂ \ 𝔖₀ t u₁ u₂).toFinset with
+          ¬Disjoint ↑J (ball (𝔠 p) (8 * D ^ 𝔰 p)) ∧ 𝔰 p = s J - k,
+        ‖adjointCarleson p f y‖ₑ) ^ (2 : ℝ)) ^ (1 / 2 : ℝ) := by
+      rw [one_div]; congr! with J mJ
+      rw [← ENNReal.rpow_neg_one, show (-1 : ℝ) = (-2)⁻¹ * (2 : ℕ) by norm_num, ENNReal.rpow_mul,
+        ENNReal.rpow_natCast, ← mul_pow, show (2 : ℝ) = (2 : ℕ) by rfl, ENNReal.rpow_natCast,
+        Finset.mul_sum]
+      congr! 9 with k mk y p; omega
+    _ ≤ ∑ k ∈ Finset.Icc ⌊C7_6_3 a n⌋ (2 * S),
+        (∑ J ∈ (𝓙₆ t u₁).toFinset, (volume (J : Set X) ^ (-2 : ℝ)⁻¹ *
+        ∫⁻ y in J, ∑ p ∈ (t u₂ \ 𝔖₀ t u₁ u₂).toFinset with
+          ¬Disjoint ↑J (ball (𝔠 p) (8 * D ^ 𝔰 p)) ∧ 𝔰 p = s J - k,
+        ‖adjointCarleson p f y‖ₑ) ^ (2 : ℝ)) ^ (1 / 2 : ℝ) := -- Minkowski inequality
+      ENNReal.Lp_add_le_sum one_le_two
+    _ = _ := by
+      rw [one_div]; congr! with k mk J mJ
+      nth_rw 2 [show (2 : ℝ) = (2 : ℕ) by rfl]
+      rw [ENNReal.rpow_natCast, mul_pow, ← ENNReal.rpow_natCast, ← ENNReal.rpow_mul,
+        show (-2)⁻¹ * (2 : ℕ) = (-1 : ℝ) by norm_num, ENNReal.rpow_neg_one]
+
+/-- Lemma 7.6.2. Todo: add needed hypothesis to LaTeX -/
+lemma bound_for_tree_projection (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂) (h2u : 𝓘 u₁ ≤ 𝓘 u₂)
+    (hf : BoundedCompactSupport f) (mf : AEStronglyMeasurable f) :
+    eLpNorm (approxOnCube (𝓙₆ t u₁) (‖adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f ·‖)) 2 volume ≤
+    C7_6_2 a n * eLpNorm ((𝓘 u₁ : Set X).indicator (MB volume 𝓑 c𝓑 r𝓑 f ·)) 2 volume := by
   sorry
 
 /-- The constant used in `correlation_near_tree_parts`.

--- a/Carleson/ToMathlib/Data/ENNReal.lean
+++ b/Carleson/ToMathlib/Data/ENNReal.lean
@@ -79,6 +79,18 @@ lemma edist_sum_le_sum_edist {f g : α → E} : edist (∑ i ∈ t, f i) (∑ i 
     simp only [Finset.sum_cons]
     exact (edist_add_add_le _ _ _ _).trans (add_le_add_left ihs _)
 
+lemma enorm_sum_eq_sum_enorm {f : α → ℝ} (hf : ∀ i ∈ t, 0 ≤ f i) :
+    ‖∑ i ∈ t, f i‖ₑ = ∑ i ∈ t, ‖f i‖ₑ := by
+  induction t using Finset.cons_induction with
+  | empty => simp
+  | cons a t ha ihs =>
+    simp only [Finset.sum_cons]
+    simp only [Finset.mem_cons, forall_eq_or_imp] at hf
+    have n₁ := hf.1
+    have n₂ := Finset.sum_nonneg hf.2
+    rw [Real.enorm_of_nonneg (add_nonneg n₁ n₂), ENNReal.ofReal_add n₁ n₂,
+      ← Real.enorm_of_nonneg n₁, ← Real.enorm_of_nonneg n₂, ihs hf.2]
+
 /-- The reverse triangle inequality for `enorm`. -/
 -- TODO: does a seminormed abelian additive group also have an ENormedAddMonoid structure?
 lemma enorm_enorm_sub_enorm_le {E} [NormedAddCommGroup E] {x y : E} : ‖‖x‖ₑ - ‖y‖ₑ‖ₑ ≤ ‖x - y‖ₑ := by

--- a/Carleson/ToMathlib/MeasureTheory/Integral/MeanInequalities.lean
+++ b/Carleson/ToMathlib/MeasureTheory/Integral/MeanInequalities.lean
@@ -11,6 +11,23 @@ variable {α : Type*} [MeasurableSpace α] {μ : Measure α}
 
 namespace ENNReal
 
+/-- **Minkowski inequality** for finite sums of `ENNReal`s. -/
+theorem Lp_add_le_sum
+    {ι κ : Type*} {s : Finset ι} {t : Finset κ} {f : ι → κ → ℝ≥0∞} {p : ℝ} (hp : 1 ≤ p) :
+    (∑ i ∈ s, (∑ j ∈ t, f i j) ^ p) ^ (1 / p) ≤ ∑ j ∈ t, (∑ i ∈ s, f i j ^ p) ^ (1 / p) := by
+  have ppos : 0 < p := by positivity
+  have pinvpos : 0 < 1 / p := by positivity
+  induction t using Finset.cons_induction with
+  | empty =>
+    simp_rw [sum_empty, ENNReal.zero_rpow_of_pos ppos, sum_const_zero, nonpos_iff_eq_zero,
+      ENNReal.zero_rpow_of_pos pinvpos]
+  | cons a t h ih =>
+    simp_rw [sum_cons]
+    calc
+      _ ≤ (∑ x ∈ s, f x a ^ p) ^ (1 / p) + (∑ i ∈ s, (∑ j ∈ t, f i j) ^ p) ^ (1 / p) :=
+        Lp_add_le _ _ _ hp
+      _ ≤ _ := by gcongr
+
 -- Add after `lintegral_prod_norm_pow_le`
 /-- A version of Hölder with multiple arguments, allowing `∞` as an exponent. -/
 theorem lintegral_prod_norm_pow_le' {α ι : Type*} [MeasurableSpace α] {μ : Measure α}

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -5979,7 +5979,7 @@ $$
         \label{square-function-count}
         \leanok
         \lean{TileStructure.Forest.square_function_count}
-        For each $J \in \mathcal{J}'$ and all $s \ge 0$, we have
+        For each $J \in \mathcal{J}'$ and all $s$, we have
         $$
             \frac{1}{\mu(J)} \int_J \Bigg(\sum_{\substack{I \in \mathcal{D}, s(I) = s(J) - s\\ I \cap \scI(\fu_1) = \emptyset\\
         J \cap B(I) \ne \emptyset}} \mathbf{1}_{B(I)}\bigg)^2 \, \mathrm{d}\mu \le 2^{14a+1} (8 D^{-s})^\kappa\,.
@@ -6019,17 +6019,20 @@ $$
         \|P_{\mathcal{J}'}|T_{\fT(\fu_2) \setminus \mathfrak{S}}^* g_2|\|_2
     $$
     $$
-        = \left(\sum_{J \in \mathcal{J}'} \frac{1}{\mu(J)} \left|\int_J \sum_{\fp \in \fT(\fu_2) \setminus \mathfrak{S}} T_{\fp}^* g_2 \, \mathrm{d}\mu(y) \right|^2 \right)^{1/2}\,.
+        = \left(\sum_{J \in \mathcal{J}'} \frac{1}{\mu(J)} \left(\int_J \left| \sum_{\fp \in \fT(\fu_2) \setminus \mathfrak{S}} T_{\fp}^* g_2(y) \right| \, \mathrm{d}\mu(y) \right)^2 \right)^{1/2}\,.
     $$
-    We split the innermost sum according to the scale of the tile $\fp$, and then apply the triangle inequality and Minkowski's inequality:
+    By \Cref{adjoint-tile-support}, the innermost sum in the last display is $0$ if $J \cap B(\scI(\fp)) = \emptyset$.
+    Then we split that sum according to the scale of $\fp$ relative to the scale of $J$.
+    By \Cref{thin-scale-impact}, $s_1 \le s(J) - \ps(\fp) \le 2S$ with $s_1 := \lfloor\frac{Zn}{202a^3} - 2\rfloor$:
     $$
-        \le \sum_{s = -S}^S \left( \sum_{J \in \mathcal{J}'} \frac{1}{\mu(J)} \left|\int_J \sum_{\substack{\fp \in \fT(\fu_2) \setminus \mathfrak{S}\\ \ps(\fp) = s}} T_{\fp}^* g_2 \, \mathrm{d}\mu(y) \right|^2\right)^{1/2}\,.
+        = \left(\sum_{J \in \mathcal{J}'} \frac{1}{\mu(J)} \left(\int_J \left| \sum_{s=s_1}^{2S} \sum_{\substack{\fp \in \fT(\fu_2) \setminus \mathfrak{S}\\ \ps(\fp) = s(J) - s\\
+        J \cap B(\scI(\fp)) \ne \emptyset}} T_{\fp}^* g_2(y) \right| \, \mathrm{d}\mu(y) \right)^2 \right)^{1/2}\,.
     $$
-    By \Cref{adjoint-tile-support}, the integral in the last display is $0$ if $J \cap B(\scI(\fp)) = \emptyset$. By \Cref{thin-scale-impact}, it follows with $s_1 := \frac{Zn}{202a^3} - 2$:
+    Then we apply the triangle inequality and Minkowski's inequality to get
     \begin{equation}
     \label{eq-sep-tree-small-1}
-        = \sum_{s = s_1}^{s_1 + 2S} \Bigg( \sum_{J \in \mathcal{J}'} \frac{1}{\mu(J)} \Bigg|\int_J \sum_{\substack{\fp \in \fT(\fu_2) \setminus \mathfrak{S}\\ \ps(\fp) = s(J) - s\\
-        J \cap B(\scI(\fp)) \ne \emptyset}} T_{\fp}^* g_2 \, \mathrm{d}\mu(y) \Bigg|^2\Bigg)^{1/2}\,.
+        \le \sum_{s=s_1}^{2S} \left( \sum_{J \in \mathcal{J}'} \frac{1}{\mu(J)} \left(\int_J \sum_{\substack{\fp \in \fT(\fu_2) \setminus \mathfrak{S}\\ \ps(\fp) = s(J) - s\\
+        J \cap B(\scI(\fp)) \ne \emptyset}} |T_{\fp}^* g_2(y)| \, \mathrm{d}\mu(y) \right)^2\right)^{1/2}\,.
     \end{equation}
     We have by \Cref{adjoint-tile-support} and \eqref{eq-Ks-size}
     $$
@@ -6067,22 +6070,22 @@ $$
     By \Cref{overlap-implies-distance}, we have $\scI(\fp) \cap \scI(\fu_1) = \emptyset$ for all $\fp \in \fT(\fu_2) \setminus \mathfrak{S}$.
     Thus we can estimate \eqref{eq-sep-tree-small-1} by
     $$
-        2^{103a^3} \sum_{s = s_1}^{s_1 + 2S} \Bigg( \sum_{J \in \mathcal{J}'} \frac{1}{\mu(J)} \Bigg|\int_J \sum_{\substack{I \in \mathcal{D}, s(I) = s(J) - s\\ I \cap \scI(\fu_1) = \emptyset\\
+        2^{103a^3} \sum_{s=s_1}^{2S} \Bigg( \sum_{J \in \mathcal{J}'} \frac{1}{\mu(J)} \Bigg|\int_J \sum_{\substack{I \in \mathcal{D}, s(I) = s(J) - s\\ I \cap \scI(\fu_1) = \emptyset\\
         J \cap B(I) \ne \emptyset}} M_{\mathcal{B},1} |g_2| \mathbf{1}_{B(I)} \, \mathrm{d}\mu \Bigg|^2\Bigg)^{\frac 1 2}\,,
     $$
     which is by Cauchy-Schwarz at most
     \begin{equation}
     \label{eq-sep-tree-small-2}
-        2^{103a^3} \sum_{s = s_1}^{s_1 + 2S} \Bigg( \sum_{J \in \mathcal{J}'} \int_J ( M_{\mathcal{B},1} |g_2|)^2 \frac{1}{\mu(J)} \int_J \Bigg(\sum_{\substack{I \in \mathcal{D}, s(I) = s(J) - s\\ I \cap \scI(\fu_1) = \emptyset\\
+        2^{103a^3} \sum_{s=s_1}^{2S} \Bigg( \sum_{J \in \mathcal{J}'} \int_J ( M_{\mathcal{B},1} |g_2|)^2 \frac{1}{\mu(J)} \int_J \Bigg(\sum_{\substack{I \in \mathcal{D}, s(I) = s(J) - s\\ I \cap \scI(\fu_1) = \emptyset\\
         J \cap B(I) \ne \emptyset}} \mathbf{1}_{B(I)}\bigg)^2 \, \mathrm{d}\mu \Bigg)^{\frac 12}\,.
     \end{equation}
     Using \Cref{square-function-count}, we bound \eqref{eq-sep-tree-small-2} by
     $$
-        2^{103a^3} \sum_{s = s_1}^{s_1 + 2S} \left(\sum_{J \in \mathcal{J}'} \int_J (M_{\mathcal{B},1} |g_2|)^2 2^{104a^2} (8 D^{-s})^\kappa\right)^{\frac 1 2}\,,
+        2^{103a^3} \sum_{s=s_1}^{2S} \left(\sum_{J \in \mathcal{J}'} \int_J (M_{\mathcal{B},1} |g_2|)^2 2^{104a^2} (8 D^{-s})^\kappa\right)^{\frac 1 2}\,,
     $$
     and, since dyadic cubes in $\mathcal{J}'$ form a partition of $\scI(\fu_1)$ by \Cref{dyadic-partition-2}, $\kappa \le 1$ by \eqref{definekappa}, and $a \ge 4$
     $$
-        \le 2^{116a^3} \sum_{s = s_1}^{s_1 + 2S} D^{-s\kappa/2} \|\mathbf{1}_{\scI(\fu_1)} M_{\mathcal{B},1} |g_2|\|_2
+        \le 2^{116a^3} \sum_{s=s_1}^{2S} D^{-s\kappa/2} \|\mathbf{1}_{\scI(\fu_1)} M_{\mathcal{B},1} |g_2|\|_2
     $$
     $$
         \le 2^{116a^3} D^{-s_1 \kappa /2} \frac{1}{1 - D^{-\kappa/2}} \|\mathbf{1}_{\scI(\fu_1)} M_{\mathcal{B},1} |g_2|\|_2\,.


### PR DESCRIPTION
Note that the blueprint is already slightly incorrect in this part of the proof – the splitting by scale difference must be done before applying the inequalities, not the other way around.