### PR TITLE
Fix lemmas/blueprint to double the Hölder function ball size (do not merge)

### DIFF
--- a/Carleson/Defs.lean
+++ b/Carleson/Defs.lean
@@ -171,16 +171,16 @@ class IsCancellative (τ : ℝ) [CompatibleFunctions ℝ X A] : Prop where
   /- We register a definition with strong assumptions, which makes them easier to prove.
   However, `enorm_integral_exp_le` removes them for easier application. -/
   enorm_integral_exp_le' {x : X} {r : ℝ} {ϕ : X → ℂ} (hr : 0 < r) (h1 : iLipENorm ϕ x r ≠ ∞)
-    (h2 : tsupport ϕ ⊆ ball x r) {f g : Θ X} :
+    (h2 : support ϕ ⊆ ball x r) {f g : Θ X} :
     ‖∫ x, exp (I * (f x - g x)) * ϕ x‖ₑ ≤
     (A : ℝ≥0∞) * volume (ball x r) * iLipENorm ϕ x r * (1 + nndist_{x, r} f g) ^ (- τ)
 
 lemma enorm_integral_exp_le [CompatibleFunctions ℝ X A] {τ : ℝ} [IsCancellative X τ]
-    {x : X} {r : ℝ} {ϕ : X → ℂ} (h2 : tsupport ϕ ⊆ ball x r) {f g : Θ X} :
+    {x : X} {r : ℝ} {ϕ : X → ℂ} (h2 : support ϕ ⊆ ball x r) {f g : Θ X} :
     ‖∫ x, exp (I * (f x - g x)) * ϕ x‖ₑ ≤
     (A : ℝ≥0∞) * volume (ball x r) * iLipENorm ϕ x r * (1 + nndist_{x, r} f g) ^ (- τ) := by
   rcases le_or_lt r 0 with hr | hr
-  · simp only [ball_eq_empty.2 hr, subset_empty_iff, tsupport_eq_empty_iff] at h2
+  · simp only [ball_eq_empty.2 hr, subset_empty_iff, support_eq_empty_iff] at h2
     simp [h2]
   rcases eq_or_ne A 0 with rfl | hA
   · have : (volume : Measure X) = 0 := by
@@ -197,7 +197,7 @@ lemma enorm_integral_exp_le [CompatibleFunctions ℝ X A] {τ : ℝ} [IsCancella
 /-- Constructor of `IsCancellative` in terms of real norms instead of extended reals. -/
 lemma isCancellative_of_norm_integral_exp_le (τ : ℝ) [CompatibleFunctions ℝ X A]
     (h : ∀ {x : X} {r : ℝ} {ϕ : X → ℂ} (_hr : 0 < r) (_h1 : iLipENorm ϕ x r ≠ ∞)
-    (_h2 : tsupport ϕ ⊆ ball x r) {f g : Θ X},
+    (_h2 : support ϕ ⊆ ball x r) {f g : Θ X},
       ‖∫ x in ball x r, exp (I * (f x - g x)) * ϕ x‖ ≤
       A * volume.real (ball x r) * iLipNNNorm ϕ x r * (1 + dist_{x, r} f g) ^ (- τ)) :
     IsCancellative X τ := by
@@ -210,7 +210,7 @@ lemma isCancellative_of_norm_integral_exp_le (τ : ℝ) [CompatibleFunctions ℝ
     have : ϕ y = 0 := by
       apply nmem_support.1
       contrapose! hy
-      exact (subset_tsupport _).trans h2 hy
+      exact h2 hy
     simp [this]
   · rw [ENNReal.ofReal_mul (by positivity), ENNReal.ofReal_mul (by positivity),
       ENNReal.ofReal_mul (by positivity)]

--- a/Carleson/ForestOperator/Forests.lean
+++ b/Carleson/ForestOperator/Forests.lean
@@ -4,10 +4,7 @@ import Carleson.ToMathlib.Analysis.SpecialFunctions.Pow.Deriv
 import Carleson.ToMathlib.MeasureTheory.Function.L1Integrable
 import Carleson.ToMathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
 import Carleson.ToMathlib.Order.Chain
-import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Data.Complex.ExponentialBounds
-import Mathlib.Tactic.NormNum.BigOperators
-import Mathlib.Tactic.NormNum.NatFactorial
 
 open ShortVariables TileStructure
 variable {X : Type*} {a : ℕ} {q : ℝ} {K : X → X → ℂ} {σ₁ σ₂ : X → ℤ} {F G : Set X}

--- a/Carleson/ForestOperator/LargeSeparation.lean
+++ b/Carleson/ForestOperator/LargeSeparation.lean
@@ -338,7 +338,7 @@ lemma quarter_add_two_mul_D_mul_card_le (hJ : J ∈ 𝓙₅ t u₁ u₂) :
             rw [show 8 * (D : ℝ) / 25 * D ^ s J = 8 / 25 * (D ^ s J * D) by ring,
               ← zpow_add_one₀ (by simp), ← add_mul, div_eq_inv_mul, ← add_mul]
             gcongr; norm_num
-  have vpos : 0 < volume (ball (c J) (9 * ↑D ^ (s J + 1))) := by
+  have vpos : 0 < volume (ball (c J) (9 * D ^ (s J + 1))) := by
     apply measure_ball_pos volume; unfold defaultD; positivity
   rw [ENNReal.mul_le_mul_right vpos.ne' measure_ball_lt_top.ne] at dbl
   exact_mod_cast dbl
@@ -983,19 +983,19 @@ lemma local_tree_control_sumsumsup (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu
     _ ≤ _ := by gcongr; exact Finset.subset_univ _
 
 lemma local_tree_control_sup_bound {k : ℤ} (mk : k ∈ Finset.Icc (s J) (s J + 3))
-    (mp : 𝔰 p = k ∧ ¬Disjoint (ball (𝔠 p) (8 * ↑D ^ 𝔰 p)) (ball (c J) (8⁻¹ * ↑D ^ s J)))
+    (mp : 𝔰 p = k ∧ ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8⁻¹ * D ^ s J)))
     (nfm : AEMeasurable fun x ↦ ‖f x‖ₑ) :
     ⨆ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarleson p f x‖ₑ ≤
     2 ^ (103 * a ^ 3) * (volume (ball (c J) (16 * D ^ k)))⁻¹ * ∫⁻ x in E p, ‖f x‖ₑ :=
   calc
-    _ ≤ ⨆ x ∈ ball (c J) (8⁻¹ * ↑D ^ s J),
+    _ ≤ ⨆ x ∈ ball (c J) (8⁻¹ * D ^ s J),
         ∫⁻ y in E p, ‖conj (Ks (𝔰 p) y x) * exp (.I * (Q y y - Q y x)) * f y‖ₑ :=
       iSup₂_mono fun x mx ↦ enorm_integral_le_lintegral_enorm _
-    _ = ⨆ x ∈ ball (c J) (8⁻¹ * ↑D ^ s J), ∫⁻ y in E p, ‖Ks (𝔰 p) y x‖ₑ * ‖f y‖ₑ := by
+    _ = ⨆ x ∈ ball (c J) (8⁻¹ * D ^ s J), ∫⁻ y in E p, ‖Ks (𝔰 p) y x‖ₑ * ‖f y‖ₑ := by
       congr! with x mx y
       rw [enorm_mul, enorm_mul, enorm_eq_nnnorm, RCLike.nnnorm_conj]
       nth_rw 1 [← enorm_norm, norm_exp_I_mul_sub_ofReal, enorm_one, mul_one, ← enorm_eq_nnnorm]
-    _ ≤ ⨆ x ∈ ball (c J) (8⁻¹ * ↑D ^ s J), ∫⁻ y in E p,
+    _ ≤ ⨆ x ∈ ball (c J) (8⁻¹ * D ^ s J), ∫⁻ y in E p,
         C2_1_3 a / volume (ball y (D ^ 𝔰 p)) * ‖f y‖ₑ := by gcongr; exact enorm_Ks_le
     _ = ∫⁻ x in E p, C2_1_3 a / volume (ball x (D ^ 𝔰 p)) * ‖f x‖ₑ := by
       have := one_le_D (a := a)

--- a/Carleson/ForestOperator/LargeSeparation.lean
+++ b/Carleson/ForestOperator/LargeSeparation.lean
@@ -1,9 +1,6 @@
-import Carleson.ForestOperator.AlmostOrthogonality
-import Mathlib.Tactic.Rify
-import Carleson.ToMathlib.BoundedCompactSupport
-import Carleson.ToMathlib.Data.ENNReal
-import Carleson.ToMathlib.Data.NNReal
 import Carleson.Calculations
+import Carleson.ForestOperator.AlmostOrthogonality
+import Carleson.ToMathlib.Data.NNReal
 
 open ShortVariables TileStructure
 variable {X : Type*} {a : ℕ} {q : ℝ} {K : X → X → ℂ} {σ₁ σ₂ : X → ℤ} {F G : Set X}
@@ -1113,78 +1110,44 @@ lemma local_tree_control (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ �
 /-- Lemma 7.5.8. -/
 lemma scales_impacting_interval (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂)
     (h2u : 𝓘 u₁ ≤ 𝓘 u₂) (hJ : J ∈ 𝓙₅ t u₁ u₂) (hp : p ∈ t u₁ ∪ (t u₂ ∩ 𝔖₀ t u₁ u₂))
-    (h : ¬ Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8 * D ^ s J))) : s J ≤ 𝔰 p := by
-  rcases hJ with ⟨hJLeft, _⟩
+    (h : ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (16 * D ^ s J))) : s J ≤ 𝔰 p := by
+  obtain ⟨hJLeft, -⟩ := hJ
   apply 𝓙_subset_𝓙₀ at hJLeft
-  apply Set.mem_or_mem_of_mem_union at hp
-  have belongs : p ∈ t.𝔖₀ u₁ u₂ := by
+  rw [mem_union] at hp
+  have belongs : p ∈ 𝔖₀ t u₁ u₂ := by
     cases hp with
     | inl h1 => exact 𝔗_subset_𝔖₀ hu₁ hu₂ hu h2u h1
-    | inr h2 => exact Set.mem_of_mem_inter_right h2
+    | inr h2 => exact h2.2
   cases hJLeft with
-  | inl scaleVerySmall =>
-    exact trans scaleVerySmall (scale_mem_Icc.left)
+  | inl scaleVerySmall => exact scaleVerySmall ▸ scale_mem_Icc.1
   | inr noGridInBall =>
     have pGridIsNotInBall := noGridInBall p belongs
     rw [not_subset] at pGridIsNotInBall
-    rcases pGridIsNotInBall with ⟨x, ⟨xInTile, xIsNotInBall⟩⟩
-    rw [Metric.mem_ball'] at xIsNotInBall
-    by_contra! contr
-    apply xIsNotInBall
-    simp only [not_disjoint_iff] at h
-    rcases h with ⟨middleX, xxx, yyy⟩
-    calc dist (c J) x
-    _ = dist (x) (c J) := by
-      apply dist_comm
-    _ ≤ dist (x) (𝔠 p) + dist (𝔠 p) (c J) := dist_triangle ..
-    _ < dist (x) (𝔠 p) + 16 * D ^ s J := by
-      gcongr
-      calc dist (𝔠 p) (c J)
-        _ ≤ dist middleX (𝔠 p) + dist middleX (c J) := by
-          nth_rw 2 [dist_comm]
-          apply dist_triangle
-        _ < 8 * D ^ 𝔰 p + 8 * D ^ s J := by
-          exact add_lt_add xxx yyy
-        _ = 8 * D ^ s J + 8 * D ^ 𝔰 p := by
-          rw [add_comm]
-        _ < 8 * D ^ (s J) + 8 * D ^ (s J) := by
-          gcongr
-          exact one_lt_D (X := X)
-        _ = 16 * D ^ s J := by
-          linarith
-    _ < 4 * D ^ 𝔰 p + 16 * D ^ s J := by
-      gcongr
-      rw [dist_comm]
-      apply Metric.mem_ball'.mp
-      apply Grid_subset_ball (X := X) (i := 𝓘 p)
-      exact xInTile
-    _ < 100 * D ^ (s J + 1) := by
-      apply (div_lt_div_iff_of_pos_right zero_lt_four).mp
-      ring_nf
-      rewrite (config := {occs := .pos [1]}) [add_comm]
-      apply lt_tsub_iff_left.mp
-      have DIsPos := one_lt_D (X := X)
-      calc (D : ℝ) ^ 𝔰 p
-        _ < D ^ (s J) := by gcongr; exact DIsPos
-        _ < D ^ (s J) * (25 * D - 4) := by
-          rewrite (config := {occs := .pos [1]}) [mul_comm]
-          apply lt_mul_left
-          · positivity
-          · linarith
-        _ = (D ^ (s J) * D) * 25 - D ^ (s J) * 4 := by ring
-        _ = D ^ ((s J) + 1) * 25 - D ^ (s J) * 4 := by
-          rw [zpow_add_one₀ (by positivity)]
-        _ = D ^ (1 + (s J)) * 25 - D ^ (s J) * 4 := by ring_nf
+    obtain ⟨x, ⟨xInTile, xIsNotInBall⟩⟩ := pGridIsNotInBall
+    rw [mem_ball'] at xIsNotInBall; contrapose! xIsNotInBall; rw [dist_comm]
+    calc
+      _ ≤ dist x (𝔠 p) + dist (𝔠 p) (c J) := dist_triangle ..
+      _ < 4 * D ^ 𝔰 p + 8 * D ^ 𝔰 p + 16 * D ^ s J := by
+        rw [add_assoc]; gcongr
+        · exact mem_ball.mp (Grid_subset_ball xInTile)
+        · exact dist_lt_of_not_disjoint_ball h
+      _ ≤ 4 * D ^ s J + 8 * D ^ s J + 16 * D ^ s J := by gcongr <;> exact one_le_D
+      _ ≤ _ := by
+        rw [← add_mul, ← add_mul, zpow_add_one₀ (defaultD_pos a).ne', mul_comm _ (D : ℝ),
+          ← mul_assoc]; gcongr
+        calc
+          _ ≤ 100 * (1 : ℝ) := by norm_num
+          _ ≤ _ := by gcongr; exact one_le_D
 
 lemma volume_cpDsp_bound {J : Grid X}
-    (hd : ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8 * D ^ s J))) (hs : s J ≤ 𝔰 p) :
+    (hd : ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (16 * D ^ s J))) (hs : s J ≤ 𝔰 p) :
     volume (ball (c J) (32 * D ^ 𝔰 p)) / 2 ^ (4 * a) ≤ volume (ball (𝔠 p) (4 * D ^ 𝔰 p)) := by
   apply ENNReal.div_le_of_le_mul'
   have h : dist (𝔠 p) (c J) + 32 * D ^ 𝔰 p ≤ 16 * (4 * D ^ 𝔰 p) := by
     calc
-      _ ≤ 8 * (D : ℝ) ^ 𝔰 p + 8 * D ^ s J + 32 * ↑D ^ 𝔰 p := by
+      _ ≤ 8 * (D : ℝ) ^ 𝔰 p + 16 * D ^ s J + 32 * D ^ 𝔰 p := by
         gcongr; exact (dist_lt_of_not_disjoint_ball hd).le
-      _ ≤ 8 * (D : ℝ) ^ 𝔰 p + 8 * D ^ 𝔰 p + 32 * ↑D ^ 𝔰 p := by
+      _ ≤ 8 * (D : ℝ) ^ 𝔰 p + 16 * D ^ 𝔰 p + 32 * D ^ 𝔰 p := by
         gcongr; exact one_le_D
       _ ≤ _ := by rw [← add_mul, ← add_mul, ← mul_assoc]; gcongr; norm_num
   convert measure_ball_le_of_dist_le' (μ := volume) (by norm_num) h
@@ -1193,12 +1156,12 @@ lemma volume_cpDsp_bound {J : Grid X}
 
 open scoped Classical in
 lemma gtc_integral_bound {k : ℤ} {ℭ : Set (𝔓 X)}
-    (hs : ∀ p ∈ ℭ, ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8 * D ^ s J)) → s J ≤ 𝔰 p) :
-    ∑ p ∈ ℭ with ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8 * D ^ s J)) ∧ 𝔰 p = k,
+    (hs : ∀ p ∈ ℭ, ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (16 * D ^ s J)) → s J ≤ 𝔰 p) :
+    ∑ p ∈ ℭ with ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (16 * D ^ s J)) ∧ 𝔰 p = k,
       ∫⁻ x in E p, ‖f x‖ₑ ≤
     ∫⁻ x in ball (c J) (32 * D ^ k), ‖f x‖ₑ := by
   set V := ℭ.toFinset.filter
-      (fun p ↦ ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8 * D ^ s J)) ∧ 𝔰 p = k)
+      (fun p ↦ ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (16 * D ^ s J)) ∧ 𝔰 p = k)
   calc
     _ = ∫⁻ x in ⋃ p ∈ V, E p, ‖f x‖ₑ := by
       refine (lintegral_biUnion_finset (fun p₁ mp₁ p₂ mp₂ hn ↦ ?_)
@@ -1217,16 +1180,16 @@ lemma gtc_integral_bound {k : ℤ} {ℭ : Set (𝔓 X)}
       refine (E_subset_𝓘.trans Grid_subset_ball).trans (ball_subset_ball' ?_)
       rw [← mp.2.2]; change (4 : ℝ) * D ^ 𝔰 p + dist (𝔠 p) (c J) ≤ _
       calc
-        _ ≤ (4 : ℝ) * D ^ 𝔰 p + 8 * D ^ 𝔰 p + 8 * D ^ s J := by
+        _ ≤ (4 : ℝ) * D ^ 𝔰 p + 8 * D ^ 𝔰 p + 16 * D ^ s J := by
           rw [add_assoc]; gcongr; exact (dist_lt_of_not_disjoint_ball mp.2.1).le
-        _ ≤ (4 : ℝ) * D ^ 𝔰 p + 8 * D ^ 𝔰 p + 8 * D ^ 𝔰 p := by gcongr; exact one_le_D
+        _ ≤ (4 : ℝ) * D ^ 𝔰 p + 8 * D ^ 𝔰 p + 16 * D ^ 𝔰 p := by gcongr; exact one_le_D
         _ ≤ _ := by rw [← add_mul, ← add_mul]; gcongr; norm_num
 
 /-- Part 1 of equation (7.5.18) of Lemma 7.5.9. -/
 lemma global_tree_control1_edist_part1
     (hu : u ∈ t) {ℭ : Set (𝔓 X)} (hℭ : ℭ ⊆ t u) (hf : BoundedCompactSupport f)
-    (hs : ∀ p ∈ ℭ, ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8 * D ^ s J)) → s J ≤ 𝔰 p)
-    (hx : x ∈ ball (c J) (8 * D ^ s J)) (hx' : x' ∈ ball (c J) (8 * D ^ s J)) :
+    (hs : ∀ p ∈ ℭ, ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (16 * D ^ s J)) → s J ≤ 𝔰 p)
+    (hx : x ∈ ball (c J) (16 * D ^ s J)) (hx' : x' ∈ ball (c J) (16 * D ^ s J)) :
     edist (exp (.I * 𝒬 u x) * adjointCarlesonSum ℭ f x)
       (exp (.I * 𝒬 u x') * adjointCarlesonSum ℭ f x') ≤
     C7_5_5 a * 2 ^ (4 * a) * edist x x' ^ (a : ℝ)⁻¹ * ∑ k ∈ Finset.Icc (s J) S,
@@ -1236,21 +1199,21 @@ lemma global_tree_control1_edist_part1
         (exp (.I * 𝒬 u x') * adjointCarleson p f x') := by
       simp_rw [adjointCarlesonSum, Finset.mul_sum, toFinset_ofFinset]
       exact ENNReal.edist_sum_le_sum_edist
-    _ = ∑ p ∈ ℭ with ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8 * D ^ s J)),
+    _ = ∑ p ∈ ℭ with ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (16 * D ^ s J)),
         edist (exp (.I * 𝒬 u x) * adjointCarleson p f x)
           (exp (.I * 𝒬 u x') * adjointCarleson p f x') := by
       refine (Finset.sum_filter_of_ne fun p mp hp ↦ ?_).symm; contrapose! hp
-      replace hp : Disjoint (ball (𝔠 p) (5 * D ^ 𝔰 p)) (ball (c J) (8 * D ^ s J)) :=
+      replace hp : Disjoint (ball (𝔠 p) (5 * D ^ 𝔰 p)) (ball (c J) (16 * D ^ s J)) :=
         hp.mono_left (ball_subset_ball (by gcongr; norm_num))
       rw [adjoint_tile_support1, indicator_of_not_mem (disjoint_right.mp hp hx), mul_zero,
         indicator_of_not_mem (disjoint_right.mp hp hx'), mul_zero, edist_self]
-    _ ≤ ∑ p ∈ ℭ with ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8 * D ^ s J)),
+    _ ≤ ∑ p ∈ ℭ with ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (16 * D ^ s J)),
         C7_5_5 a / volume (ball (𝔠 p) (4 * D ^ 𝔰 p)) *
           (edist x x' / D ^ 𝔰 p) ^ (a : ℝ)⁻¹ * ∫⁻ x in E p, ‖f x‖ₑ := by
       gcongr with p mp; rw [Finset.mem_filter, mem_toFinset] at mp
       exact holder_correlation_tile hu (hℭ mp.1) hf
     _ = C7_5_5 a * edist x x' ^ (a : ℝ)⁻¹ *
-        ∑ p ∈ ℭ with ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8 * D ^ s J)),
+        ∑ p ∈ ℭ with ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (16 * D ^ s J)),
           D ^ (-𝔰 p / (a : ℝ)) / volume (ball (𝔠 p) (4 * D ^ 𝔰 p)) * ∫⁻ x in E p, ‖f x‖ₑ := by
       rw [Finset.mul_sum]; congr! 1 with p mp
       rw [← mul_assoc, ← mul_div_assoc, mul_assoc _ _ ((D : ℝ≥0∞) ^ _), mul_comm _ (_ * _),
@@ -1259,26 +1222,26 @@ lemma global_tree_control1_edist_part1
         ← ENNReal.zpow_neg (by simp) (by simp), ← ENNReal.rpow_intCast, ← ENNReal.rpow_mul,
         ← div_eq_mul_inv, Int.cast_neg]
     _ = C7_5_5 a * edist x x' ^ (a : ℝ)⁻¹ * ∑ k ∈ Finset.Icc (s J) S,
-        ∑ p ∈ ℭ with ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8 * D ^ s J)) ∧ 𝔰 p = k,
+        ∑ p ∈ ℭ with ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (16 * D ^ s J)) ∧ 𝔰 p = k,
           D ^ (-𝔰 p / (a : ℝ)) / volume (ball (𝔠 p) (4 * D ^ 𝔰 p)) * ∫⁻ x in E p, ‖f x‖ₑ := by
       congr 1; simp_rw [← Finset.filter_filter]
       refine (Finset.sum_fiberwise_of_maps_to (fun p mp ↦ ?_) _).symm
       rw [Finset.mem_Icc]; rw [Finset.mem_filter, mem_toFinset] at mp
       exact ⟨hs p mp.1 mp.2, scale_mem_Icc.2⟩
     _ = C7_5_5 a * edist x x' ^ (a : ℝ)⁻¹ * ∑ k ∈ Finset.Icc (s J) S, D ^ (-k / (a : ℝ)) *
-        ∑ p ∈ ℭ with ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8 * D ^ s J)) ∧ 𝔰 p = k,
+        ∑ p ∈ ℭ with ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (16 * D ^ s J)) ∧ 𝔰 p = k,
           (∫⁻ x in E p, ‖f x‖ₑ) / volume (ball (𝔠 p) (4 * D ^ 𝔰 p)) := by
       congr! 2 with k mk; rw [Finset.mul_sum]; congr! 1 with p mp
       rw [mul_comm, ← mul_div_assoc, ← mul_div_assoc, mul_comm]; congr
       rw [Finset.mem_filter] at mp; exact mp.2.2
     _ ≤ C7_5_5 a * edist x x' ^ (a : ℝ)⁻¹ * ∑ k ∈ Finset.Icc (s J) S, D ^ (-k / (a : ℝ)) *
-        ∑ p ∈ ℭ with ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8 * D ^ s J)) ∧ 𝔰 p = k,
+        ∑ p ∈ ℭ with ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (16 * D ^ s J)) ∧ 𝔰 p = k,
           (∫⁻ x in E p, ‖f x‖ₑ) / (volume (ball (c J) (32 * D ^ k)) / 2 ^ (4 * a)) := by
       gcongr with k mk p mp; rw [Finset.mem_filter, mem_toFinset] at mp
       rw [← mp.2.2]; exact volume_cpDsp_bound mp.2.1 (hs p mp.1 mp.2.1)
     _ = C7_5_5 a * 2 ^ (4 * a) * edist x x' ^ (a : ℝ)⁻¹ * ∑ k ∈ Finset.Icc (s J) S,
         D ^ (-k / (a : ℝ)) * (volume (ball (c J) (32 * D ^ k)))⁻¹ *
-        ∑ p ∈ ℭ with ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8 * D ^ s J)) ∧ 𝔰 p = k,
+        ∑ p ∈ ℭ with ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (16 * D ^ s J)) ∧ 𝔰 p = k,
           ∫⁻ x in E p, ‖f x‖ₑ := by
       rw [← mul_rotate _ _ (2 ^ (4 * a)), mul_comm (_ ^ _), mul_assoc (_ * _),
         Finset.mul_sum (a := 2 ^ (4 * a))]; congr! 2 with k mk
@@ -1320,8 +1283,8 @@ irreducible_def C7_5_9d (a : ℕ) : ℝ≥0 := C7_5_5 a * 2 ^ (4 * a + 1)
 /-- Part 2 of equation (7.5.18) of Lemma 7.5.9. -/
 lemma global_tree_control1_edist_part2
     (hu : u ∈ t) {ℭ : Set (𝔓 X)} (hℭ : ℭ ⊆ t u) (hf : BoundedCompactSupport f)
-    (hs : ∀ p ∈ ℭ, ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8 * D ^ s J)) → s J ≤ 𝔰 p)
-    (hx : x ∈ ball (c J) (8 * D ^ s J)) (hx' : x' ∈ ball (c J) (8 * D ^ s J)) :
+    (hs : ∀ p ∈ ℭ, ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (16 * D ^ s J)) → s J ≤ 𝔰 p)
+    (hx : x ∈ ball (c J) (16 * D ^ s J)) (hx' : x' ∈ ball (c J) (16 * D ^ s J)) :
     edist (exp (.I * 𝒬 u x) * adjointCarlesonSum ℭ f x)
       (exp (.I * 𝒬 u x') * adjointCarlesonSum ℭ f x') ≤
     C7_5_9d a * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f x := by
@@ -1345,11 +1308,11 @@ lemma global_tree_control1_edist_part2
         (∑ k ∈ Finset.Icc (s J) S, (D : ℝ≥0∞) ^ ((s J - k) / (a : ℝ))) *
         ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f x := by
       have fla := four_le_a X
-      have dpos : 0 < (D : ℝ≥0∞) ^ s J := by apply ENNReal.zpow_pos (by simp) (by simp)
-      have dlt : (D : ℝ≥0∞) ^ s J < ⊤ := by apply ENNReal.zpow_lt_top (by simp) (by simp)
+      have dpos : 0 < (D : ℝ≥0∞) ^ s J := ENNReal.zpow_pos (by simp) (by simp) _
+      have dlt : (D : ℝ≥0∞) ^ s J < ⊤ := ENNReal.zpow_lt_top (by simp) (by simp) _
       have bpos : ((D : ℝ≥0∞) ^ s J) ^ (a : ℝ)⁻¹ ≠ 0 := (ENNReal.rpow_pos dpos dlt.ne).ne'
-      have bnt : ((D : ℝ≥0∞) ^ s J) ^ (a : ℝ)⁻¹ ≠ ⊤ := by
-        exact ENNReal.rpow_ne_top_of_nonneg (by positivity) dlt.ne
+      have bnt : ((D : ℝ≥0∞) ^ s J) ^ (a : ℝ)⁻¹ ≠ ⊤ :=
+        ENNReal.rpow_ne_top_of_nonneg (by positivity) dlt.ne
       rw [← ENNReal.inv_mul_cancel_right (a := (_ ^ (a : ℝ)⁻¹)) bpos bnt, mul_comm _ _⁻¹,
         ← ENNReal.div_eq_inv_mul, ← ENNReal.div_rpow_of_nonneg _ _ (by positivity), ← mul_assoc,
         mul_assoc _ _ (∑ k ∈ _, _), Finset.mul_sum]
@@ -1366,7 +1329,7 @@ lemma global_tree_control1_edist_part2
 /-- Equation (7.5.18) of Lemma 7.5.9 for `ℭ = t u₁`. -/
 lemma global_tree_control1_edist_left (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂)
     (h2u : 𝓘 u₁ ≤ 𝓘 u₂) (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf : BoundedCompactSupport f)
-    (hx : x ∈ ball (c J) (8 * D ^ s J)) (hx' : x' ∈ ball (c J) (8 * D ^ s J)) :
+    (hx : x ∈ ball (c J) (16 * D ^ s J)) (hx' : x' ∈ ball (c J) (16 * D ^ s J)) :
     edist (exp (.I * 𝒬 u₁ x) * adjointCarlesonSum (t u₁) f x)
       (exp (.I * 𝒬 u₁ x') * adjointCarlesonSum (t u₁) f x') ≤
     C7_5_9d a * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f x :=
@@ -1376,7 +1339,7 @@ lemma global_tree_control1_edist_left (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) 
 /-- Equation (7.5.18) of Lemma 7.5.9 for `ℭ = t u₂ ∩ 𝔖₀ t u₁ u₂`. -/
 lemma global_tree_control1_edist_right (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂)
     (h2u : 𝓘 u₁ ≤ 𝓘 u₂) (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf : BoundedCompactSupport f)
-    (hx : x ∈ ball (c J) (8 * D ^ s J)) (hx' : x' ∈ ball (c J) (8 * D ^ s J)) :
+    (hx : x ∈ ball (c J) (16 * D ^ s J)) (hx' : x' ∈ ball (c J) (16 * D ^ s J)) :
     edist (exp (.I * 𝒬 u₂ x) * adjointCarlesonSum (t u₂ ∩ 𝔖₀ t u₁ u₂) f x)
       (exp (.I * 𝒬 u₂ x') * adjointCarlesonSum (t u₂ ∩ 𝔖₀ t u₁ u₂) f x') ≤
     C7_5_9d a * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f x :=
@@ -1384,7 +1347,7 @@ lemma global_tree_control1_edist_right (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t)
     (fun _ mp dp ↦ scales_impacting_interval hu₁ hu₂ hu h2u hJ (mem_union_right _ mp) dp) hx hx'
 
 /-- The constant used in `global_tree_control1_supbound`. -/
-irreducible_def C7_5_9s (a : ℕ) : ℝ≥0 := C7_5_5 a * 2 ^ (4 * a + 2)
+irreducible_def C7_5_9s (a : ℕ) : ℝ≥0 := C7_5_5 a * 2 ^ (4 * a + 3)
 
 lemma one_le_C7_5_9s : 1 ≤ C7_5_9s a := by
   simp only [C7_5_9s, C7_5_5]; norm_cast
@@ -1392,18 +1355,18 @@ lemma one_le_C7_5_9s : 1 ≤ C7_5_9s a := by
 
 lemma C7_5_9d_le_C7_5_9s : C7_5_9d a ≤ C7_5_9s a := by
   simp only [C7_5_9d, C7_5_9s]
-  exact mul_le_mul_left' (pow_le_pow_right' one_le_two (add_le_add_left one_le_two _)) _
+  exact mul_le_mul_left' (pow_le_pow_right' one_le_two (add_le_add_left NeZero.one_le _)) _
 
 /-- Equation (7.5.17) of Lemma 7.5.9. -/
 lemma global_tree_control1_supbound (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂)
     (h2u : 𝓘 u₁ ≤ 𝓘 u₂) (ℭ : Set (𝔓 X)) (hℭ : ℭ = t u₁ ∨ ℭ = t u₂ ∩ 𝔖₀ t u₁ u₂)
     (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf : BoundedCompactSupport f) :
-    ⨆ x ∈ ball (c J) (8 * D ^ s J), ‖adjointCarlesonSum ℭ f x‖ₑ ≤
+    ⨆ x ∈ ball (c J) (16 * D ^ s J), ‖adjointCarlesonSum ℭ f x‖ₑ ≤
     (⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum ℭ f x‖ₑ) +
     C7_5_9s a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f x := by
   rw [← tsub_le_iff_left]; refine ENNReal.le_of_forall_pos_le_add fun ε εpos blt ↦ ?_
-  obtain ⟨x, hx, ex⟩ : ∃ x₀ ∈ ball (c J) (8 * D ^ s J),
-      ⨆ x ∈ ball (c J) (8 * D ^ s J), ‖adjointCarlesonSum ℭ f x‖ₑ ≤
+  obtain ⟨x, hx, ex⟩ : ∃ x₀ ∈ ball (c J) (16 * D ^ s J),
+      ⨆ x ∈ ball (c J) (16 * D ^ s J), ‖adjointCarlesonSum ℭ f x‖ₑ ≤
       ‖adjointCarlesonSum ℭ f x₀‖ₑ + (ε / 2 : ℝ≥0) := by
     apply ENNReal.exists_biSup_le_enorm_add_eps (by positivity)
       ⟨c J, mem_ball_self (by unfold defaultD; positivity)⟩
@@ -1426,7 +1389,7 @@ lemma global_tree_control1_supbound (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (h
       rw [add_rotate, add_assoc]; simp
     _ ≤ (C7_5_9d a * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f x) + ε := by
       refine add_le_add_right ?_ _
-      replace hx' : x' ∈ ball (c J) (8 * D ^ s J) := by
+      replace hx' : x' ∈ ball (c J) (16 * D ^ s J) := by
         exact (ball_subset_ball (by gcongr; norm_num)) hx'
       rcases hℭ with rfl | rfl
       · nth_rw 2 [← one_mul ‖_‖ₑ]; rw [← enorm_exp_I_mul_ofReal (𝒬 u₁ x), ← enorm_mul]
@@ -1437,12 +1400,12 @@ lemma global_tree_control1_supbound (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (h
         nth_rw 3 [← one_mul ‖_‖ₑ]; rw [← enorm_exp_I_mul_ofReal (𝒬 u₂ x'), ← enorm_mul]
         exact ENNReal.enorm_enorm_sub_enorm_le.trans
           (global_tree_control1_edist_right hu₁ hu₂ hu h2u hJ hf hx hx')
-    _ ≤ (C7_5_9d a * 2 * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f x) + ε := by
+    _ ≤ (C7_5_9d a * 2 ^ ((2 : ℕ) : ℝ) * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f x) + ε := by
       gcongr; rw [mem_ball] at hx hx'; rw [edist_dist]
       calc
-        _ ≤ (ENNReal.ofReal ((8 + 8⁻¹) * D ^ s J) / ↑D ^ s J) ^ (a : ℝ)⁻¹ := by
+        _ ≤ (ENNReal.ofReal ((16 + 8⁻¹) * D ^ s J) / D ^ s J) ^ (a : ℝ)⁻¹ := by
           gcongr; rw [add_mul]; exact ((dist_triangle_right ..).trans_lt (add_lt_add hx hx')).le
-        _ ≤ 16 ^ (a : ℝ)⁻¹ := by
+        _ ≤ (2 ^ (8 : ℝ)) ^ (a : ℝ)⁻¹ := by
           have Dpos : 0 < (D : ℝ≥0∞) ^ s J := ENNReal.zpow_pos (by simp) (by simp) _
           have Dlt : (D : ℝ≥0∞) ^ s J < ⊤ := ENNReal.zpow_lt_top (by simp) (by simp) _
           rw [ENNReal.ofReal_mul (by norm_num), ← Real.rpow_intCast,
@@ -1450,14 +1413,13 @@ lemma global_tree_control1_supbound (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (h
             show ENNReal.ofReal D = D by norm_cast, ENNReal.rpow_intCast,
             ENNReal.mul_div_cancel_right Dpos.ne' Dlt.ne]
           exact ENNReal.rpow_le_rpow (by norm_num) (by positivity)
-        _ ≤ 16 ^ (4 : ℝ)⁻¹ := by
+        _ ≤ (2 ^ (8 : ℝ)) ^ (4 : ℝ)⁻¹ := by
           gcongr; exacts [by norm_num, by norm_cast; linarith [four_le_a X]]
-        _ = _ := by
-          rw [show (16 : ℝ≥0∞) = 2 ^ (4 : ℝ) by norm_num, ← ENNReal.rpow_mul,
-            show (4 : ℝ) * 4⁻¹ = 1 by norm_num, ENNReal.rpow_one]
+        _ = _ := by rw [← ENNReal.rpow_mul]; norm_num
     _ = _ := by
-      congr; rw [C7_5_9d, C7_5_9s, ENNReal.coe_mul, ENNReal.coe_pow, ENNReal.coe_ofNat, mul_assoc,
-        ← pow_succ, add_assoc]; rfl
+      congr
+      rw [C7_5_9d, C7_5_9s, ENNReal.coe_mul, ENNReal.coe_pow, ENNReal.coe_ofNat, mul_assoc,
+        ENNReal.rpow_natCast, ← pow_add]; rfl
 
 /-- The constant used in `global_tree_control2`. -/
 irreducible_def C7_5_10 (a : ℕ) : ℝ≥0 := C7_5_7 a + C7_5_9s a
@@ -1470,7 +1432,7 @@ lemma one_le_C7_5_10 : 1 ≤ C7_5_10 a := one_le_C7_5_9s.trans C7_5_9s_le_C7_5_1
 /-- Lemma 7.5.10 -/
 lemma global_tree_control2 (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂)
     (h2u : 𝓘 u₁ ≤ 𝓘 u₂) (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf : BoundedCompactSupport f) :
-    ⨆ x ∈ ball (c J) (8 * D ^ s J), ‖adjointCarlesonSum (t u₂ ∩ 𝔖₀ t u₁ u₂) f x‖ₑ ≤
+    ⨆ x ∈ ball (c J) (16 * D ^ s J), ‖adjointCarlesonSum (t u₂ ∩ 𝔖₀ t u₁ u₂) f x‖ₑ ≤
     (⨅ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₂) f x‖ₑ) +
     C7_5_10 a * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f x :=
   calc
@@ -1507,13 +1469,13 @@ lemma support_holderFunction_subset (u₂ : 𝔓 X) (f₁ f₂ : X → ℂ) (J :
 
 lemma enorm_holderFunction_le (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂) (h2u : 𝓘 u₁ ≤ 𝓘 u₂)
     (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf₁ : BoundedCompactSupport f₁) (hf₂ : BoundedCompactSupport f₂)
-    (mx : x ∈ ball (c J) (8 * D ^ s J)) :
+    (mx : x ∈ ball (c J) (16 * D ^ s J)) :
     ‖holderFunction t u₁ u₂ f₁ f₂ J x‖ₑ ≤ C7_5_9s a * C7_5_10 a * P7_5_4 t u₁ u₂ f₁ f₂ J := by
   simp_rw [holderFunction, enorm_mul, RCLike.enorm_conj, enorm_mul, enorm_exp_I_mul_ofReal, one_mul,
     Complex.enorm_real, NNReal.enorm_eq]
   calc
-    _ ≤ 1 * (⨆ z ∈ ball (c J) (8 * D ^ s J), ‖adjointCarlesonSum (t u₁) f₁ z‖ₑ) *
-        ⨆ z ∈ ball (c J) (8 * D ^ s J), ‖adjointCarlesonSum (t u₂ ∩ 𝔖₀ t u₁ u₂) f₂ z‖ₑ := by
+    _ ≤ 1 * (⨆ z ∈ ball (c J) (16 * D ^ s J), ‖adjointCarlesonSum (t u₁) f₁ z‖ₑ) *
+        ⨆ z ∈ ball (c J) (16 * D ^ s J), ‖adjointCarlesonSum (t u₂ ∩ 𝔖₀ t u₁ u₂) f₂ z‖ₑ := by
       gcongr
       · rw [ENNReal.coe_le_one_iff]
         exact (χ_le_indicator hJ).trans ((indicator_le fun _ _ ↦ le_refl _) _)
@@ -1535,7 +1497,7 @@ lemma enorm_holderFunction_le (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u�
 
 lemma holder_correlation_tree_1 (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂) (h2u : 𝓘 u₁ ≤ 𝓘 u₂)
     (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf₁ : BoundedCompactSupport f₁) (hf₂ : BoundedCompactSupport f₂)
-    (mx : x ∈ ball (c J) (8 * D ^ s J)) (mx' : x' ∈ 𝓘 u₁) :
+    (mx : x ∈ ball (c J) (16 * D ^ s J)) (mx' : x' ∈ 𝓘 u₁) :
     edist (χ t u₁ u₂ J x) (χ t u₁ u₂ J x') *
     ‖exp (.I * 𝒬 u₁ x) * adjointCarlesonSum (t u₁) f₁ x‖ₑ *
     ‖exp (.I * 𝒬 u₂ x) * adjointCarlesonSum (t u₂ ∩ 𝔖₀ t u₁ u₂) f₂ x‖ₑ ≤
@@ -1577,7 +1539,7 @@ lemma holder_correlation_tree_1 (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : 
 
 lemma holder_correlation_tree_2 (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂) (h2u : 𝓘 u₁ ≤ 𝓘 u₂)
     (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf₁ : BoundedCompactSupport f₁) (hf₂ : BoundedCompactSupport f₂)
-    (mx : x ∈ ball (c J) (8 * D ^ s J)) (mx' : x' ∈ ball (c J) (8 * D ^ s J)) :
+    (mx : x ∈ ball (c J) (16 * D ^ s J)) (mx' : x' ∈ ball (c J) (16 * D ^ s J)) :
     χ t u₁ u₂ J x' * edist (exp (.I * 𝒬 u₁ x) * adjointCarlesonSum (t u₁) f₁ x)
       (exp (.I * 𝒬 u₁ x') * adjointCarlesonSum (t u₁) f₁ x') *
     ‖exp (.I * 𝒬 u₂ x) * adjointCarlesonSum (t u₂ ∩ 𝔖₀ t u₁ u₂) f₂ x‖ₑ ≤
@@ -1608,7 +1570,7 @@ lemma holder_correlation_tree_2 (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : 
 
 lemma holder_correlation_tree_3 (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂) (h2u : 𝓘 u₁ ≤ 𝓘 u₂)
     (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf₁ : BoundedCompactSupport f₁) (hf₂ : BoundedCompactSupport f₂)
-    (mx : x ∈ ball (c J) (8 * D ^ s J)) (mx' : x' ∈ ball (c J) (8 * D ^ s J)) :
+    (mx : x ∈ ball (c J) (16 * D ^ s J)) (mx' : x' ∈ ball (c J) (16 * D ^ s J)) :
     χ t u₁ u₂ J x' * ‖exp (.I * 𝒬 u₁ x') * adjointCarlesonSum (t u₁) f₁ x'‖ₑ *
     edist (exp (.I * 𝒬 u₂ x) * adjointCarlesonSum (t u₂ ∩ 𝔖₀ t u₁ u₂) f₂ x)
       (exp (.I * 𝒬 u₂ x') * adjointCarlesonSum (t u₂ ∩ 𝔖₀ t u₁ u₂) f₂ x') ≤
@@ -1640,11 +1602,11 @@ lemma holder_correlation_tree_3 (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : 
 
 /-- An intermediate constant in Lemma 7.5.4. -/
 def I7_5_4 (a : ℕ) : ℝ≥0 :=
-  16 * C7_5_2 a * C7_5_9s a * C7_5_10 a + C7_5_9d a * C7_5_10 a + C7_5_9s a * C7_5_9d a
+  32 * C7_5_2 a * C7_5_9s a * C7_5_10 a + C7_5_9d a * C7_5_10 a + C7_5_9s a * C7_5_9d a
 
 lemma edist_holderFunction_le (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂) (h2u : 𝓘 u₁ ≤ 𝓘 u₂)
     (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf₁ : BoundedCompactSupport f₁) (hf₂ : BoundedCompactSupport f₂)
-    (mx : x ∈ ball (c J) (8 * D ^ s J)) (mx' : x' ∈ ball (c J) (8 * D ^ s J)) :
+    (mx : x ∈ ball (c J) (16 * D ^ s J)) (mx' : x' ∈ ball (c J) (16 * D ^ s J)) :
     edist (holderFunction t u₁ u₂ f₁ f₂ J x) (holderFunction t u₁ u₂ f₁ f₂ J x') ≤
     I7_5_4 a * P7_5_4 t u₁ u₂ f₁ f₂ J * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ := by
   by_cases mu₁ : x ∉ 𝓘 u₁ ∧ x' ∉ 𝓘 u₁
@@ -1673,7 +1635,7 @@ lemma edist_holderFunction_le (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u�
       · exact holder_correlation_tree_2 hu₁ hu₂ hu h2u hJ hf₁ hf₂ mx mx'
       · exact holder_correlation_tree_3 hu₁ hu₂ hu h2u hJ hf₁ hf₂ mx mx'
     _ ≤ C7_5_2 a * C7_5_9s a * C7_5_10 a * P7_5_4 t u₁ u₂ f₁ f₂ J *
-          (16 * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹) +
+          (32 * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹) +
         C7_5_9d a * C7_5_10 a * P7_5_4 t u₁ u₂ f₁ f₂ J * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ +
         C7_5_9s a * C7_5_9d a * P7_5_4 t u₁ u₂ f₁ f₂ J * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ := by
       gcongr
@@ -1683,17 +1645,17 @@ lemma edist_holderFunction_le (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u�
         rw [inv_le_one_iff₀]; right; exact_mod_cast a_pos X
       · nth_rw 1 [← mul_one (_ / _), ← ENNReal.one_rpow (a : ℝ)⁻¹]
         refine mul_le_mul' (ENNReal.div_le_of_le_mul ?_) (ENNReal.rpow_le_rpow h.le (by positivity))
-        have hc : 16 * (D : ℝ≥0∞) ^ s J = ENNReal.ofReal (16 * D ^ s J) := by
+        have hc : 32 * (D : ℝ≥0∞) ^ s J = ENNReal.ofReal (32 * D ^ s J) := by
           rw [ENNReal.ofReal_mul (by norm_num), ← Real.rpow_intCast,
             ← ENNReal.ofReal_rpow_of_pos (defaultD_pos a), ENNReal.rpow_intCast,
             ENNReal.ofReal_natCast, ENNReal.ofReal_ofNat]
         rw [edist_dist, hc]; apply ENNReal.ofReal_le_ofReal
         calc
           _ ≤ dist x (c J) + dist x' (c J) := dist_triangle_right ..
-          _ ≤ 8 * ↑D ^ s J + 8 * ↑D ^ s J := add_le_add (mem_ball.mp mx).le (mem_ball.mp mx').le
+          _ ≤ 16 * D ^ s J + 16 * D ^ s J := add_le_add (mem_ball.mp mx).le (mem_ball.mp mx').le
           _ = _ := by ring
     _ = _ := by
-      rw [← mul_assoc, mul_comm _ 16]; simp_rw [← mul_assoc]
+      rw [← mul_assoc, mul_comm _ 32]; simp_rw [← mul_assoc]
       rw [← add_mul, ← add_mul]; congr
       rw [← add_mul, ← add_mul]; congr
 
@@ -1702,17 +1664,17 @@ Has value `2 ^ (529 * a ^ 3)` in the blueprint. -/
 -- Todo: define this recursively in terms of previous constants
 irreducible_def C7_5_4 (a : ℕ) : ℝ≥0 := 2 ^ (529 * (a : ℝ) ^ 3)
 
-lemma le_C7_5_4 (a4 : 4 ≤ a) : C7_5_9s a * C7_5_10 a + 8 ^ τ * I7_5_4 a ≤ C7_5_4 a :=
+lemma le_C7_5_4 (a4 : 4 ≤ a) : C7_5_9s a * C7_5_10 a + 16 ^ τ * I7_5_4 a ≤ C7_5_4 a :=
   calc
     _ ≤ C7_5_9s a * C7_5_10 a + 2 * I7_5_4 a := by
       gcongr
-      rw [defaultτ, show (8 : ℝ≥0) = 2 ^ (3 : ℝ) by norm_num, ← NNReal.rpow_mul, ← div_eq_mul_inv]
+      rw [defaultτ, show (16 : ℝ≥0) = 2 ^ (4 : ℝ) by norm_num, ← NNReal.rpow_mul, ← div_eq_mul_inv]
       nth_rw 2 [← NNReal.rpow_one 2]; apply NNReal.rpow_le_rpow_of_exponent_le one_le_two
       rw [div_le_one_iff]; norm_cast; omega
-    _ ≤ 16 * C7_5_2 a * C7_5_9s a * C7_5_10 a +
-        2 * (16 * C7_5_2 a * C7_5_9s a * C7_5_10 a +
-        4 * C7_5_2 a * C7_5_9s a * C7_5_10 a +
-        4 * C7_5_2 a * C7_5_9s a * C7_5_10 a) := by
+    _ ≤ 32 * C7_5_2 a * C7_5_9s a * C7_5_10 a +
+        2 * (32 * C7_5_2 a * C7_5_9s a * C7_5_10 a +
+        8 * C7_5_2 a * C7_5_9s a * C7_5_10 a +
+        8 * C7_5_2 a * C7_5_9s a * C7_5_10 a) := by
       unfold I7_5_4; gcongr ?_ + 2 * (_ + ?_ + ?_)
       · nth_rw 1 [← one_mul (_ * _), mul_assoc]; gcongr
         exact one_le_mul (by norm_num) one_le_C7_5_2
@@ -1725,12 +1687,12 @@ lemma le_C7_5_4 (a4 : 4 ≤ a) : C7_5_9s a * C7_5_10 a + 8 ^ τ * I7_5_4 a ≤ C
         · exact one_le_C7_5_2
         · exact C7_5_9d_le_C7_5_9s
         · exact C7_5_9s_le_C7_5_10
-    _ = 2 ^ 6 * C7_5_2 a * C7_5_9s a * C7_5_10 a := by ring
-    _ ≤ 2 ^ 6 * C7_5_2 a * C7_5_9s a * (2 * C7_5_9s a) := by
+    _ = 2 ^ 7 * C7_5_2 a * C7_5_9s a * C7_5_10 a := by ring
+    _ ≤ 2 ^ 7 * C7_5_2 a * C7_5_9s a * (2 * C7_5_9s a) := by
       rw [C7_5_10, C7_5_9s, two_mul, C7_5_7, C7_5_5]; gcongr; norm_cast
       rw [← pow_add]; apply pow_le_pow_right' one_le_two; omega
-    _ = 2 ^ 7 * C7_5_2 a * C7_5_9s a ^ 2 := by ring
-    _ = 2 ^ (528 * a ^ 3 + 8 * a + 11) := by
+    _ = 2 ^ 8 * C7_5_2 a * C7_5_9s a ^ 2 := by ring
+    _ = 2 ^ (528 * a ^ 3 + 8 * a + 14) := by
       rw [C7_5_2, ← Nat.cast_pow, show (226 : ℝ) = (226 : ℕ) by rfl, ← Nat.cast_mul,
         NNReal.rpow_natCast, ← pow_add, C7_5_9s, C7_5_5, ← Nat.cast_pow,
         show (151 : ℝ) = (151 : ℕ) by rfl, ← Nat.cast_mul, NNReal.rpow_natCast]
@@ -1740,21 +1702,21 @@ lemma le_C7_5_4 (a4 : 4 ≤ a) : C7_5_9s a * C7_5_10 a + 8 ^ τ * I7_5_4 a ≤ C
         NNReal.rpow_natCast, add_assoc, show 529 * a ^ 3 = 528 * a ^ 3 + a ^ 3 by ring]
       refine pow_le_pow_right' one_le_two (add_le_add_left ?_ _)
       calc
-        _ ≤ 2 * 4 * a + 1 * 3 * 4 := by omega
-        _ ≤ 2 * a * a + 2 * a * a := by gcongr <;> omega
+        _ ≤ 2 * 4 * a + 1 * 4 * 4 := by omega
+        _ ≤ 2 * a * a + 2 * a * a := by gcongr; omega
         _ = 4 * a ^ 2 := by ring
         _ ≤ _ := by rw [pow_succ' _ 2]; gcongr
 
 /-- Lemma 7.5.4. -/
 lemma holder_correlation_tree (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂) (h2u : 𝓘 u₁ ≤ 𝓘 u₂)
     (hJ : J ∈ 𝓙₅ t u₁ u₂) (hf₁ : BoundedCompactSupport f₁) (hf₂ : BoundedCompactSupport f₂) :
-    iHolENorm (holderFunction t u₁ u₂ f₁ f₂ J) (c J) (8 * D ^ s J) ≤
+    iHolENorm (holderFunction t u₁ u₂ f₁ f₂ J) (c J) (16 * D ^ s J) ≤
     C7_5_4 a * P7_5_4 t u₁ u₂ f₁ f₂ J := by
   unfold iHolENorm
   calc
     _ ≤ C7_5_9s a * C7_5_10 a * P7_5_4 t u₁ u₂ f₁ f₂ J +
-        ENNReal.ofReal (8 * ↑D ^ s J) ^ τ *
-        ⨆ x ∈ ball (c J) (8 * ↑D ^ s J), ⨆ y ∈ ball (c J) (8 * ↑D ^ s J), ⨆ (_ : x ≠ y),
+        ENNReal.ofReal (16 * D ^ s J) ^ τ *
+        ⨆ x ∈ ball (c J) (16 * D ^ s J), ⨆ y ∈ ball (c J) (16 * D ^ s J), ⨆ (_ : x ≠ y),
           (I7_5_4 a * P7_5_4 t u₁ u₂ f₁ f₂ J * ((D : ℝ≥0∞) ^ s J)⁻¹ ^ (a : ℝ)⁻¹) := by
       gcongr with x mx x' mx' hn
       · exact iSup₂_le_iff.mpr fun x mx ↦ enorm_holderFunction_le hu₁ hu₂ hu h2u hJ hf₁ hf₂ mx
@@ -1768,10 +1730,10 @@ lemma holder_correlation_tree (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u�
               div_eq_mul_inv, div_eq_mul_inv, ← mul_rotate _ (edist x x'),
               ENNReal.inv_mul_cancel dn0 (edist_ne_top x x'), one_mul]
     _ ≤ C7_5_9s a * C7_5_10 a * P7_5_4 t u₁ u₂ f₁ f₂ J +
-        ENNReal.ofReal (8 * ↑D ^ s J) ^ τ *
+        ENNReal.ofReal (16 * D ^ s J) ^ τ *
         (I7_5_4 a * P7_5_4 t u₁ u₂ f₁ f₂ J * ((D : ℝ≥0∞) ^ s J)⁻¹ ^ (a : ℝ)⁻¹) := by
       gcongr; exact iSup₂_le fun _ _ ↦ iSup₂_le fun _ _ ↦ iSup_le fun _ ↦ le_rfl
-    _ = (C7_5_9s a * C7_5_10 a + 8 ^ τ * I7_5_4 a) * P7_5_4 t u₁ u₂ f₁ f₂ J := by
+    _ = (C7_5_9s a * C7_5_10 a + 16 ^ τ * I7_5_4 a) * P7_5_4 t u₁ u₂ f₁ f₂ J := by
       have dn0 : ((D : ℝ≥0∞) ^ s J) ^ (a : ℝ)⁻¹ ≠ 0 := by
         rw [← pos_iff_ne_zero]; refine ENNReal.rpow_pos_of_nonneg ?_ (by positivity)
         exact ENNReal.zpow_pos (by unfold defaultD; positivity) (ENNReal.natCast_ne_top _) _
@@ -1786,7 +1748,7 @@ lemma holder_correlation_tree (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u�
         ENNReal.mul_inv_cancel dn0 dnt, mul_one, mul_rotate (_ ^ _)]
     _ ≤ _ := by
       gcongr
-      rw [show (8 : ℝ≥0∞) = (8 : ℝ≥0) by rfl, ← ENNReal.coe_rpow_of_nonneg _ (τ_nonneg X),
+      rw [show (16 : ℝ≥0∞) = (16 : ℝ≥0) by rfl, ← ENNReal.coe_rpow_of_nonneg _ (τ_nonneg X),
         ← ENNReal.coe_mul, ← ENNReal.coe_mul, ← ENNReal.coe_add, ENNReal.coe_le_coe]
       exact le_C7_5_4 (four_le_a X)
 

--- a/Carleson/HolderVanDerCorput.lean
+++ b/Carleson/HolderVanDerCorput.lean
@@ -167,7 +167,7 @@ lemma support_holderApprox_subset {z : X} {R t : ℝ} (hR : 0 < R)
   convert support_holderApprox_subset_aux hR hϕ ht using 2
   ring
 
--- unused
+/- unused
 lemma tsupport_holderApprox_subset {z : X} {R t : ℝ} (hR : 0 < R)
     {ϕ : X → ℂ} (hϕ : tsupport ϕ ⊆ ball z R) (ht : t ∈ Ioc (0 : ℝ) 1) :
     tsupport (holderApprox R t ϕ) ⊆ ball z (2 * R) := by
@@ -178,6 +178,7 @@ lemma tsupport_holderApprox_subset {z : X} {R t : ℝ} (hR : 0 < R)
     (closure_mono A).trans closure_ball_subset_closedBall
   apply this.trans (closedBall_subset_ball ?_)
   linarith [R'_pos.2]
+-/
 
 open Filter
 

--- a/Carleson/HolderVanDerCorput.lean
+++ b/Carleson/HolderVanDerCorput.lean
@@ -167,7 +167,7 @@ lemma support_holderApprox_subset {z : X} {R t : ℝ} (hR : 0 < R)
   convert support_holderApprox_subset_aux hR hϕ ht using 2
   ring
 
-/-- Part of Lemma 8.0.1. -/
+-- unused
 lemma tsupport_holderApprox_subset {z : X} {R t : ℝ} (hR : 0 < R)
     {ϕ : X → ℂ} (hϕ : tsupport ϕ ⊆ ball z R) (ht : t ∈ Ioc (0 : ℝ) 1) :
     tsupport (holderApprox R t ϕ) ⊆ ball z (2 * R) := by
@@ -520,15 +520,15 @@ end DivisionMonoid
 
 /-- Proposition 2.0.5. -/
 theorem holder_van_der_corput {z : X} {R : ℝ} {ϕ : X → ℂ}
-    (ϕ_tsupp : tsupport ϕ ⊆ ball z R) {f g : Θ X} :
+    (ϕ_supp : support ϕ ⊆ ball z R) {f g : Θ X} :
     ‖∫ x, exp (I * (f x - g x)) * ϕ x‖ₑ ≤
     (C2_0_5 a : ℝ≥0∞) * volume (ball z R) * iHolENorm ϕ z (2 * R) *
       (1 + nndist_{z, R} f g) ^ (- (2 * a^2 + a^3 : ℝ)⁻¹) := by
   have : 4 ≤ a := four_le_a X
   have : (4 : ℝ) ≤ a := mod_cast four_le_a X
   rcases le_or_lt R 0 with hR | hR
-  · simp [ball_eq_empty.2 hR, subset_empty_iff, tsupport_eq_empty_iff] at ϕ_tsupp
-    simp [ϕ_tsupp]
+  · simp [ball_eq_empty.2 hR, subset_empty_iff, support_eq_empty_iff] at ϕ_supp
+    simp [ϕ_supp]
   rcases eq_or_ne (iHolENorm ϕ z (2 * R)) ∞ with h2ϕ | h2ϕ
   · apply le_top.trans_eq
     symm
@@ -542,18 +542,12 @@ theorem holder_van_der_corput {z : X} {R : ℝ} {ϕ : X → ℂ}
     · simp only [le_add_iff_nonneg_right,  NNReal.zero_le_coe]
     · simp only [defaultτ, Left.neg_nonpos_iff]
       positivity
-  have ϕ_supp : support ϕ ⊆ ball z R := (subset_tsupport _).trans ϕ_tsupp
-  have ϕ_cont : Continuous ϕ := by
-    apply ContinuousOn.continuous_of_tsupport_subset
-      ((HolderOnWith.of_iHolENorm_ne_top h2ϕ).continuousOn (nnτ_pos X)) isOpen_ball
-    apply ϕ_tsupp.trans (ball_subset_ball (by linarith))
+  have ϕ_cont : Continuous ϕ := continuous_of_iHolENorm_ne_top' ϕ_supp h2ϕ
   have ϕ_comp : HasCompactSupport ϕ := by
     apply HasCompactSupport.of_support_subset_isCompact (isCompact_closedBall z R)
     exact ϕ_supp.trans ball_subset_closedBall
   let ϕ' := holderApprox R t ϕ
   have ϕ'_supp : support ϕ' ⊆ ball z (2 * R) := support_holderApprox_subset hR ϕ_supp ⟨t_pos, t_one⟩
-  have ϕ'_tsupp : tsupport ϕ' ⊆ ball z (2 * R) :=
-    tsupport_holderApprox_subset hR ϕ_tsupp ⟨t_pos, t_one⟩
   have ϕ'_cont : Continuous ϕ' := by
     apply LipschitzWith.continuous
     apply lipschitzWith_holderApprox hR t_pos t_one ϕ_cont ϕ_supp
@@ -586,7 +580,7 @@ theorem holder_van_der_corput {z : X} {R : ℝ} {ϕ : X → ℂ}
     _ ≤ 2 ^ a * volume (ball z (2 * R))
       * iLipENorm ϕ' z (2 * R) * (1 + nndist_{z, 2 * R} f g) ^ (- τ) := by
       simpa only [defaultA, Nat.cast_pow, Nat.cast_ofNat] using enorm_integral_exp_le
-        (x := z) (r := 2 * R) (ϕ := ϕ') ϕ'_tsupp (f := f) (g := g)
+        (x := z) (r := 2 * R) (ϕ := ϕ') ϕ'_supp (f := f) (g := g)
     _ ≤ 2 ^ a * (2 ^ a * volume (ball z R))
         * (2 ^ (4 * a) * (ENNReal.ofReal t) ^ (-1 - a : ℝ) * iHolENorm ϕ z (2 * R))
         * (1 + nndist_{z, R} f g) ^ (- τ) := by

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -6330,7 +6330,7 @@ Recall that $\tau = 1/a$.
 \begin{lemma}[Lipschitz Holder approximation]
     \label{Lipschitz-Holder-approximation}
     \leanok
-    \lean{tsupport_holderApprox_subset, enorm_holderApprox_sub_le, iLipENorm_holderApprox_le}
+    \lean{support_holderApprox_subset, enorm_holderApprox_sub_le, iLipENorm_holderApprox_le}
     Let $z\in X$ and $R>0$. Let $\varphi: X \to \mathbb{C}$ be a function supported in the ball
     $B:=B(z,R)$ with finite norm $\|\varphi\|_{C^\tau(B(z, 2R))}$.
     Let $0<t \leq 1$. There exists a function $\tilde \varphi : X \to \mathbb{C}$, supported in $B(z,2R)$, such that for every $x\in X$

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -5426,7 +5426,7 @@ $$
         We have for all $J \in \mathcal{J}'$ that
       \begin{equation}
             \label{hHolder}
-            \|h_J\|_{C^{\tau}(B(c(J), 8D^{s(J)}))} \le 2^{529a^3} \prod_{j = 1,2} (\inf_{B(c(J), \frac{1}{8}D^{s(J)})} |T_{\fT(\fu_j)}^* g_j| + \inf_J M_{\mathcal{B}, 1} |g_j|)\,.
+            \|h_J\|_{C^{\tau}(B(c(J), 16D^{s(J)}))} \le 2^{529a^3} \prod_{j = 1,2} (\inf_{B(c(J), \frac{1}{8}D^{s(J)})} |T_{\fT(\fu_j)}^* g_j| + \inf_J M_{\mathcal{B}, 1} |g_j|)\,.
         \end{equation}
     \end{lemma}
 
@@ -5556,6 +5556,9 @@ $$
     \end{equation*}
     We also denote
     \begin{equation*}
+     BB(J) := B(c(J), 16D^{s(J)}),
+    \end{equation*}
+    \begin{equation*}
      B^\circ{}(J) := B(c(J), \frac{1}{8}D^{s(J)})\, .
     \end{equation*}
 
@@ -5662,12 +5665,12 @@ $$
         \leanok
         \lean{TileStructure.Forest.scales_impacting_interval}
         \uses{overlap-implies-distance}
-        Let $\fC = \fT(\fu_1)$ or $\fC = \fT(\fu_2) \cap \mathfrak{S}$. Then for each $J \in \mathcal{J}'$ and $\fp \in \fC$ with $B(\scI(\fp)) \cap B(J) \neq \emptyset$, we have $\ps(\fp) \ge s(J)$.
+        Let $\fC = \fT(\fu_1)$ or $\fC = \fT(\fu_2) \cap \mathfrak{S}$. Then for each $J \in \mathcal{J}'$ and $\fp \in \fC$ with $B(\scI(\fp)) \cap BB(J) \neq \emptyset$, we have $\ps(\fp) \ge s(J)$.
     \end{lemma}
 
     \begin{proof}
         \leanok
-        By \Cref{overlap-implies-distance}, we have that in both cases, $\fC \subset \mathfrak{S}$. If $\fp \in \fC$ with $B(\scI(\fp)) \cap B(J) \neq \emptyset$ and $\ps(\fp) < s(J)$, then $\scI(\fp) \subset B(c(J), 100 D^{s(J) + 1})$. Since $\fp \in \mathfrak{S}$, it follows from the definition of $\mathcal{J}'$ that $s(J) = -S$, which contradicts $\ps(\fp) < s(J)$.
+        By \Cref{overlap-implies-distance}, we have that in both cases, $\fC \subset \mathfrak{S}$. If $\fp \in \fC$ with $B(\scI(\fp)) \cap BB(J) \neq \emptyset$ and $\ps(\fp) < s(J)$, then $\scI(\fp) \subset B(c(J), 100 D^{s(J) + 1})$. Since $\fp \in \mathfrak{S}$, it follows from the definition of $\mathcal{J}'$ that $s(J) = -S$, which contradicts $\ps(\fp) < s(J)$.
     \end{proof}
 
     \begin{lemma}[global tree control 1]
@@ -5678,9 +5681,9 @@ $$
         Let $\fC_1 = \fT(\fu_1)$ and $\fC_2 = \fT(\fu_2) \cap \mathfrak{S}$. Then for $i = 1,2$ and each $J \in \mathcal{J}'$ and all bounded $g$ with bounded support, we have
         \begin{align}
             \label{TreeUB}
-            \sup_{B(J)} |T_{\fC_i}^*g| \leq \inf_{B^\circ{}(J)} |T^*_{\fC_i} g| + 2^{151a^3+4a+2} \inf_{J} M_{\mathcal{B}, 1} |g|
+            \sup_{B(J)} |T_{\fC_i}^*g| \leq \inf_{B^\circ{}(J)} |T^*_{\fC_i} g| + 2^{151a^3+4a+3} \inf_{J} M_{\mathcal{B}, 1} |g|
         \end{align}
-        and for all $y,y' \in B(J)$
+        and for all $y,y' \in BB(J)$
         $$
             |e(\fcc(\fu_i)(y)) T_{\fC_i}^* g(y) - e(\fcc(\fu_i)(y')) T_{\fC_i}^* g(y')|
         $$
@@ -5693,18 +5696,18 @@ $$
     \begin{proof}
         \leanok
         Note that \eqref{TreeUB} follows from \eqref{TreeHolder}, since for $y'\in B^\circ{}(J)$, by the triangle inequality,
-        $$\left(\frac{\rho(y,y')}{D^{s(J)}}\right)^{1/a}\le \Big(8 + \frac{1}8\Big)^{1/a}\le 2.$$
+        $$\left(\frac{\rho(y,y')}{D^{s(J)}}\right)^{1/a}\le \Big(16 + \frac{1}8\Big)^{1/a}\le 2^2.$$
 
-        By the triangle inequality, \Cref{adjoint-tile-support} and \Cref{Holder-correlation-tile}, we have for all $y, y' \in B(J)$
+        By the triangle inequality, \Cref{adjoint-tile-support} and \Cref{Holder-correlation-tile}, we have for all $y, y' \in BB(J)$
         \begin{equation}
             \label{eq-C-Lip}
             |e(\fcc(\fu_i)(y)) T_{\fC_i}^* g(y) - e(\fcc(\fu_i)(y')) T_{\fC_i}^* g(y')|
         \end{equation}
         $$
-            \leq \sum_{\substack{\fp \in \fC_i\\ B(\scI(\fp)) \cap B(J) \neq \emptyset}} |e(\fcc(\fu_i)(y)) T_{\fp}^* g(y) - e(\fcc(\fu_i)(y')) T_{\fp}^* g(y')|
+            \le \sum_{\substack{\fp \in \fC_i\\ B(\scI(\fp)) \cap BB(J) \neq \emptyset}} |e(\fcc(\fu_i)(y)) T_{\fp}^* g(y) - e(\fcc(\fu_i)(y')) T_{\fp}^* g(y')|
         $$
         $$
-            \le 2^{151a^3}\rho(y,y')^{1/a} \sum_{\substack{\fp \in \fC_i\\ B(\scI(\fp)) \cap B(J) \neq \emptyset}} \frac{D^{- \ps(\fp)/a}}{\mu(B(\pc(\fp), 4D^{\ps(\fp)}))} \int_{E(\fp)} |g| \, \mathrm{d}\mu\,.
+            \le 2^{151a^3}\rho(y,y')^{1/a} \sum_{\substack{\fp \in \fC_i\\ B(\scI(\fp)) \cap BB(J) \neq \emptyset}} \frac{D^{- \ps(\fp)/a}}{\mu(B(\pc(\fp), 4D^{\ps(\fp)}))} \int_{E(\fp)} |g| \, \mathrm{d}\mu\,.
         $$
         By \Cref{scales-impacting-interval}, we have $\ps(\fp) \ge s(J)$ for all $\fp$ occurring in the sum. Further, for each $s \ge s(J)$, the sets $E(\fp)$ for $\fp \in \fP$ with $\ps(\fp) = s$ are pairwise disjoint by \eqref{defineep} and \eqref{eq-dis-freq-cover}, and contained in $B(c(J), 32D^{s})$ by \eqref{eq-vol-sp-cube} and the triangle inequality. Using also the doubling estimate \eqref{doublingx}, we obtain that the expression in the last display can be estimated by
         $$
@@ -5727,7 +5730,7 @@ $$
         \uses{global-tree-control-1, local-tree-control}
         We have for all $J \in \mathcal{J}'$ and all bounded $g$ with bounded support
         $$
-            \sup_{B(J)} |T^*_{\fT(\fu_2) \cap \mathfrak{S}} g| \le \inf_{B^\circ{}(J)} |T^*_{\fT(\fu_2)} g| + 2^{151a^3+4a+3} \inf_{J} M_{\mathcal{B},1}|g|\,.
+            \sup_{B(J)} |T^*_{\fT(\fu_2) \cap \mathfrak{S}} g| \le \inf_{B^\circ{}(J)} |T^*_{\fT(\fu_2)} g| + 2^{151a^3+4a+4} \inf_{J} M_{\mathcal{B},1}|g|\,.
         $$
     \end{lemma}
 
@@ -5735,14 +5738,14 @@ $$
         \leanok
         By \Cref{global-tree-control-1}
         $$
-            \sup_{B(J)} |T^*_{\fT(\fu_2) \cap \mathfrak{S}} g| \le \inf_{B^\circ{}(J)} |T_{\fT(\fu_2) \cap \mathfrak{S}}^* g| + 2^{151a^3+4a+2} \inf_{J} M_{\mathcal{B}, 1} |g|
+            \sup_{B(J)} |T^*_{\fT(\fu_2) \cap \mathfrak{S}} g| \le \inf_{B^\circ{}(J)} |T_{\fT(\fu_2) \cap \mathfrak{S}}^* g| + 2^{151a^3+4a+3} \inf_{J} M_{\mathcal{B}, 1} |g|
         $$
         $$
-            \le \inf_{B^\circ{}(J)} |T_{\fT(\fu_2)}^* g| + \sup_{B^\circ{}(J)} |T_{\fT(\fu_2) \setminus \mathfrak{S}}^* g| + 2^{151a^3+4a+2} \inf_{J} M_{\mathcal{B}, 1} |g|\,,
+            \le \inf_{B^\circ{}(J)} |T_{\fT(\fu_2)}^* g| + \sup_{B^\circ{}(J)} |T_{\fT(\fu_2) \setminus \mathfrak{S}}^* g| + 2^{151a^3+4a+3} \inf_{J} M_{\mathcal{B}, 1} |g|\,,
         $$
         and by \Cref{local-tree-control}
         $$
-            \le \inf_{B^\circ{}(J)} |T_{\fT(\fu_2)}^* g| + (2^{104a^3} + 2^{151a^3+4a+2}) \inf_{J} M_{\mathcal{B}, 1} |g|\,.
+            \le \inf_{B^\circ{}(J)} |T_{\fT(\fu_2)}^* g| + (2^{104a^3} + 2^{151a^3+4a+3}) \inf_{J} M_{\mathcal{B}, 1} |g|\,.
         $$
         This completes the proof.
     \end{proof}
@@ -5751,10 +5754,10 @@ $$
         \leanok
         \proves{Holder-correlation-tree}
         Let $P$ be the product on the right hand side of \eqref{hHolder}, and $h_J$ be as defined in \eqref{def-hj}.
-        By \eqref{eq-pao-2} and \Cref{adjoint-tile-support}, the function $h_J$ is supported in $B(J) \cap \scI(\fu_1)$.
-        By \eqref{eq-pao-2}, \Cref{global-tree-control-1} and \Cref{global-tree-control-2}, we have for all $y \in B(J)$:
+        By \eqref{eq-pao-2} and \Cref{adjoint-tile-support}, the function $h_J$ is supported in $BB(J) \cap \scI(\fu_1)$.
+        By \eqref{eq-pao-2}, \Cref{global-tree-control-1} and \Cref{global-tree-control-2}, we have for all $y \in BB(J)$:
         $$
-            |h_J(y)| \le 2^{302a^3+8a+5} P\,.
+            |h_J(y)| \le 2^{302a^3+8a+7} P\,.
         $$
         We have by the triangle inequality
         \begin{align}
@@ -5770,29 +5773,29 @@ $$
         As $h_J$ is supported in $\scI(\fu_1)$, we can assume without loss of generality that $y' \in \scI(\fu_1)$.
         If $y \notin \scI(\fu_1)$, then \eqref{eq-h-Lip-1} vanishes. If $y \in \scI(\fu_1)$ then we have by \eqref{eq-pao-3}, \Cref{global-tree-control-1} and \Cref{global-tree-control-2}
         % C7_5_2       C7_5_9s           C7_5_10
-        % 2^{226a^3} * 2^{151a^3+4a+2} * 2^{151a^3+4a+3}
-        % 2^{528a^3+8a+5}
+        % 2^{226a^3} * 2^{151a^3+4a+3} * 2^{151a^3+4a+4}
+        % 2^{528a^3+8a+7}
         $$
-            \eqref{eq-h-Lip-1} \le 2^{528a^3+8a+5} \frac{\rho(y,y')}{D^{s(J)}} P\,,
+            \eqref{eq-h-Lip-1} \le 2^{528a^3+8a+7} \frac{\rho(y,y')}{D^{s(J)}} P\,,
         $$
         where $P$ denotes the product on the right hand side of \eqref{hHolder}.
 
         By \eqref{eq-pao-2}, \Cref{global-tree-control-1} and \Cref{global-tree-control-2}, we have
         % C7_5_9d           C7_5_10
-        % 2^{151a^3+4a+1} * 2^{151a^3+4a+3}
-        % 2^{302a^3+8a+4}
+        % 2^{151a^3+4a+1} * 2^{151a^3+4a+4}
+        % 2^{302a^3+8a+5}
         $$
-            \eqref{eq-h-Lip-2} \le 2^{302a^3+8a+4} \left(\frac{\rho(y,y')}{D^{s(J)}}\right)^{1/a} P\,.
+            \eqref{eq-h-Lip-2} \le 2^{302a^3+8a+5} \left(\frac{\rho(y,y')}{D^{s(J)}}\right)^{1/a} P\,.
         $$
 
         By \eqref{eq-pao-2}, and twice \Cref{global-tree-control-1}, we have
         % C7_5_9s           C7_5_9d
-        % 2^{151a^3+4a+2} * 2^{151a^3+4a+1}
-        % 2^{302a^3+8a+3}
+        % 2^{151a^3+4a+3} * 2^{151a^3+4a+1}
+        % 2^{302a^3+8a+4}
         $$
-            \eqref{eq-h-Lip-3} \le 2^{302a^3+8a+3} \left(\frac{\rho(y,y')}{D^{s(J)}}\right)^{1/a} P\,.
+            \eqref{eq-h-Lip-3} \le 2^{302a^3+8a+4} \left(\frac{\rho(y,y')}{D^{s(J)}}\right)^{1/a} P\,.
         $$
-        Using that $\rho(y,y') \le 16D^{s(J)}$ and $a \ge 4$, the lemma follows.
+        Using that $\rho(y,y') \le 32D^{s(J)}$ and $a \ge 4$, the lemma follows.
     \end{proof}
 
 \subsection{The van der Corput estimate}
@@ -5838,9 +5841,9 @@ $$
     $$
     Using \Cref{Holder-van-der-Corput} with the ball $B(J)$, we bound this by
     $$
-        \le 2^{8a} \sum_{J \in \mathcal{J}'} \mu(B(J)) \|h_J\|_{C^{\tau}(B(J))} (1 + d_{B(J)}(\fcc(\fu_1), \fcc(\fu_1)))^{-1/(2a^2+a^3)}\,.
+        \le 2^{8a} \sum_{J \in \mathcal{J}'} \mu(B(J)) \|h_J\|_{C^{\tau}(BB(J))} (1 + d_{B(J)}(\fcc(\fu_2), \fcc(\fu_1)))^{-1/(2a^2+a^3)}\,.
     $$
-    Using \Cref{Holder-correlation-tree}, \Cref{lower-oscillation-bound} and $a \ge 4$, we have that the above is bounded from above by
+    Using \Cref{Holder-correlation-tree}, \Cref{lower-oscillation-bound} and $a \ge 4$, we bound the above by
     \begin{multline}
         \label{eq-big-sep-1}
         \le 2^{540a^3} 2^{-Zn/(4a^2 + 2a^3)} \sum_{J \in \mathcal{J}'} \mu(B(J)) \\


### PR DESCRIPTION
As applied in Lemma 7.4.5, Proposition 2.0.5 produces the term `iHolENorm (holderFunction t u₁ u₂ f₁ f₂ J) (c J) (16 * D ^ s J)`, but Lemma 7.5.4 currently only provides a bound on `iHolENorm (holderFunction t u₁ u₂ f₁ f₂ J) (c J) (8 * D ^ s J)`, and the two need not be related (see [here](https://leanprover.zulipchat.com/#narrow/channel/442935-Carleson/topic/Small.20imprecision.20in.20Lemma.208.2E0.2E1/near/509918623)).

This PR is just to show the back-fixes necessary to prove Lemma 7.4.5, done in #364 – fixing the statement of Lemma 7.5.4 to provide a bound on the first norm, and changing `tsupport` to `support` (otherwise the required assumption of Proposition 2.0.5 is not true). It should not be merged.