### PR TITLE
Cleanup of Lemma 6.1.5 proof + natural powers

### DIFF
--- a/Carleson/Antichain/TileCorrelation.lean
+++ b/Carleson/Antichain/TileCorrelation.lean
@@ -176,10 +176,6 @@ lemma correlation_kernel_bound {s₁ s₂ : ℤ} {x₁ x₂ : X} (hs : s₁ ≤ 
     _ ≤ _ := by
       rw [← ENNReal.add_div]; refine ENNReal.div_le_div_right ?_ _
       rw [C2_1_3, C_6_2_1]; norm_cast
-      have hc : (2 ^ (102 * a ^ 3) : ℝ).toNNReal = ((2 ^ (102 * a ^ 3) : ℕ) : ℝ≥0) := by
-        rw [Real.toNNReal_eq_natCast (by positivity), Nat.cast_pow, Nat.cast_ofNat]
-      rw [show (2 : ℝ≥0) = Real.toNNReal 2 by simp, NNReal.rpow_natCast,
-        ← Real.toNNReal_pow zero_le_two, hc, ← Nat.cast_pow, ← Nat.cast_add, Nat.cast_le]
       calc
         _ ≤ 2 ^ (253 * a ^ 3) + 2 ^ (253 * a ^ 3) := by
           rw [← pow_mul, show 102 * a ^ 3 * 2 = 204 * a ^ 3 by ring]; gcongr <;> norm_num

--- a/Carleson/Antichain/TileCorrelation.lean
+++ b/Carleson/Antichain/TileCorrelation.lean
@@ -18,7 +18,7 @@ variable {X : Type*} {a : ℕ} {q : ℝ} {K : X → X → ℂ} {σ₁ σ₂ : X 
   [ProofData a q K σ₁ σ₂ F G]
 
 /-- Def 6.2.1 (Lemma 6.2.1). -/
-def correlation (s₁ s₂ : ℤ) (x₁ x₂ y : X) : ℂ := (conj (Ks s₁ x₁ y)) * (Ks s₂ x₂ y)
+def correlation (s₁ s₂ : ℤ) (x₁ x₂ y : X) : ℂ := conj (Ks s₁ x₁ y) * Ks s₂ x₂ y
 
 section FunProp
 
@@ -39,7 +39,7 @@ end FunProp
 
 -- Eq. 6.2.2 (Lemma 6.2.1)
 lemma mem_ball_of_correlation_ne_zero {s₁ s₂ : ℤ} {x₁ x₂ y : X}
-    (hy : correlation s₁ s₂ x₁ x₂ y ≠ 0) : y ∈ (ball x₁ (↑D ^s₁)) := by
+    (hy : correlation s₁ s₂ x₁ x₂ y ≠ 0) : y ∈ (ball x₁ (D ^s₁)) := by
   have hKs : Ks s₁ x₁ y ≠ 0 := by
     simp only [correlation, ne_eq, mul_eq_zero, map_eq_zero, not_or] at hy
     exact hy.1
@@ -48,7 +48,7 @@ lemma mem_ball_of_correlation_ne_zero {s₁ s₂ : ℤ} {x₁ x₂ y : X}
     (half_lt_self_iff.mpr (defaultD_pow_pos a s₁))
 
 lemma mem_ball_of_mem_tsupport_correlation {s₁ s₂ : ℤ} {x₁ x₂ y : X}
-    (hy : y ∈ tsupport (correlation s₁ s₂ x₁ x₂)) : y ∈ (ball x₁ (↑D ^s₁)) := by
+    (hy : y ∈ tsupport (correlation s₁ s₂ x₁ x₂)) : y ∈ (ball x₁ (D ^s₁)) := by
   have hKs : (x₁, y) ∈ tsupport fun x ↦ (Ks s₁ x.1 x.2) := by
     simp only [tsupport, closure, support_subset_iff, ne_eq, Prod.forall, mem_sInter,
       mem_setOf_eq, and_imp] at hy ⊢
@@ -69,7 +69,7 @@ lemma mem_ball_of_mem_tsupport_correlation {s₁ s₂ : ℤ} {x₁ x₂ y : X}
     (half_lt_self_iff.mpr (defaultD_pow_pos a s₁))
 
 /-- The constant from lemma 6.2.1. -/
-def C_6_2_1 (a : ℕ) : ℝ≥0 := 2^(254 * a^3)
+def C_6_2_1 (a : ℕ) : ℝ≥0 := 2 ^ (254 * a ^ 3)
 
 --TODO: PR to Mathlib
 lemma ENNReal.mul_div_mul_comm {a b c d : ℝ≥0∞} (hc : c ≠ ⊤) (hd : d ≠ ⊤) :
@@ -77,183 +77,118 @@ lemma ENNReal.mul_div_mul_comm {a b c d : ℝ≥0∞} (hc : c ≠ ⊤) (hd : d �
   simp only [div_eq_mul_inv, ENNReal.mul_inv (Or.inr hd) (Or.inl hc)]
   ring
 
-lemma aux_6_2_3 (s₁ s₂ : ℤ) (x₁ x₂ y y' : X)  :
+lemma aux_6_2_3 (s₁ s₂ : ℤ) (x₁ x₂ y y' : X) :
   ‖Ks s₂ x₂ y‖ₑ * ‖Ks s₁ x₁ y - Ks s₁ x₁ y'‖ₑ ≤
-  ↑(C2_1_3 ↑a) / volume (ball x₂ (↑D ^ s₂)) *
-    (↑(D2_1_3 ↑a) / volume (ball x₁ (↑D ^ s₁)) * (↑(nndist y y') ^ τ / ↑((D : ℝ≥0) ^ s₁) ^ τ)) := by
-  have hτ : 0 ≤ τ := by simp only [defaultτ, inv_nonneg, Nat.cast_nonneg]
+  C2_1_3 a / volume (ball x₂ (D ^ s₂)) *
+  (D2_1_3 a / volume (ball x₁ (D ^ s₁)) * (edist y y' ^ τ / (D ^ s₁) ^ τ)) := by
   apply mul_le_mul enorm_Ks_le _ (zero_le _) (zero_le _)
   convert nnnorm_Ks_sub_Ks_le
-  rw [← ENNReal.div_rpow_of_nonneg _ _ hτ]
-  simp only [defaultτ]
-  congr
-  rw [ENNReal.coe_zpow (by simp)]
-  rfl
+  rw [← ENNReal.div_rpow_of_nonneg _ _ (τ_nonneg X)]
+  simp only [defaultτ]; congr
+  simp only [coe_nnreal_ennreal_nndist]
+
+/-- Equation (6.2.5) of Lemma 6.2.1. -/
+lemma e625 {s₁ s₂ : ℤ} {x₁ x₂ y y' : X} (hy' : y ≠ y') (hs : s₁ ≤ s₂) :
+    (2 * D ^ s₁) ^ τ *
+    (‖correlation s₁ s₂ x₁ x₂ y - correlation s₁ s₂ x₁ x₂ y'‖ₑ / (edist y y') ^ τ) ≤
+    2 ^ (253 * a ^ 3) / (volume (ball x₁ (D ^ s₁)) * volume (ball x₂ (D ^ s₂))) := by
+  rw [mul_comm]
+  refine ENNReal.mul_le_of_le_div ?_
+  rw [ENNReal.div_le_iff_le_mul (.inl _) (.inl _)]; rotate_left
+  · rw [← ENNReal.inv_ne_top, ← ENNReal.rpow_neg]
+    exact ENNReal.rpow_ne_top_of_nonneg' (edist_pos.mpr hy') (edist_ne_top y y')
+  · exact ENNReal.rpow_ne_top_of_nonneg (τ_nonneg X) (edist_ne_top y y')
+  calc
+    _ = ‖conj (Ks s₁ x₁ y) * Ks s₂ x₂ y - conj (Ks s₁ x₁ y') * Ks s₂ x₂ y +
+        (conj (Ks s₁ x₁ y') * Ks s₂ x₂ y - conj (Ks s₁ x₁ y') * Ks s₂ x₂ y')‖ₑ := by
+      simp only [correlation, sub_add_sub_cancel]
+    _ ≤ ‖conj (Ks s₁ x₁ y) * Ks s₂ x₂ y - conj (Ks s₁ x₁ y') * Ks s₂ x₂ y ‖ₑ +
+        ‖conj (Ks s₁ x₁ y') * Ks s₂ x₂ y - conj (Ks s₁ x₁ y') * Ks s₂ x₂ y'‖ₑ := enorm_add_le _ _
+    _ = ‖Ks s₁ x₁ y - Ks s₁ x₁ y'‖ₑ * ‖Ks s₂ x₂ y‖ₑ +
+        ‖Ks s₁ x₁ y'‖ₑ * ‖Ks s₂ x₂ y - Ks s₂ x₂ y'‖ₑ := by
+      simp only [← sub_mul, ← mul_sub, enorm_mul, RCLike.enorm_conj, ← map_sub]
+    _ ≤ 2 ^ (252 * a ^ 3) / (volume (ball x₁ (D ^ s₁)) * volume (ball x₂ (D ^ s₂))) *
+        (edist y y' ^ τ / (D ^ s₁) ^ τ + edist y y' ^ τ / (D ^ s₂) ^ τ) := by
+      have h2 : (2 : ℝ≥0∞) ^ (252 * a ^ 3) = C2_1_3 a * D2_1_3 a := by
+        simp only [C2_1_3, NNReal.coe_natCast, D2_1_3]
+        norm_cast
+        ring
+      rw [mul_comm, mul_add, h2, mul_comm (volume _)]
+      rw [ENNReal.mul_div_mul_comm measure_ball_ne_top measure_ball_ne_top, mul_assoc]
+      apply add_le_add (aux_6_2_3 s₁ s₂ x₁ x₂ y y')
+      rw [← neg_sub, enorm_neg]
+      convert aux_6_2_3 s₂ s₁ x₂ x₁ y' y using 1
+      simp only [← mul_assoc, ← ENNReal.mul_div_mul_comm measure_ball_ne_top measure_ball_ne_top]
+      rw [mul_comm (volume _), edist_comm]
+    _ ≤ 2 ^ (252 * a ^ 3) / (volume (ball x₁ (D ^ s₁)) * volume (ball x₂ (D ^ s₂))) *
+        (2 * (edist y y' ^ τ / (D ^ s₁) ^ τ)) := by
+      rw [two_mul]; gcongr
+      · exact τ_nonneg X
+      · exact_mod_cast one_le_D
+    _ = 2 ^ (252 * a ^ 3) * 2 / (volume (ball x₁ (D ^ s₁)) * volume (ball x₂ (D ^ s₂))) *
+        (edist y y' ^ τ / (D ^ s₁) ^ τ) := by
+      rw [← mul_assoc, mul_comm _ 2]
+      congr 1
+      rw [← mul_div_assoc, mul_comm]
+    _ ≤ 2 ^ (253 * a ^ 3) / (volume (ball x₁ (D ^ s₁)) * volume (ball x₂ (D ^ s₂))) *
+        (edist y y' ^ τ / (2 * D ^ s₁) ^ τ) := by
+      rw [ENNReal.mul_rpow_of_nonneg _ _ (τ_nonneg X)]
+      nth_rw 4 [← neg_neg τ]; rw [ENNReal.rpow_neg, ← ENNReal.div_eq_inv_mul, ← ENNReal.div_mul]
+      rotate_left
+      · right; rw [← ENNReal.inv_ne_top, ENNReal.rpow_neg, inv_inv]
+        exact ENNReal.rpow_ne_top_of_nonneg' zero_lt_two ENNReal.ofNat_ne_top
+      · exact .inr (ENNReal.rpow_ne_top_of_nonneg' zero_lt_two ENNReal.ofNat_ne_top)
+      rw [← mul_assoc, ← mul_rotate, ← mul_div_assoc (2 ^ (-τ))]; gcongr ?_ / _ * _
+      rw [show (2 : ℝ≥0∞) ^ (-τ) * 2 ^ (253 * a ^ 3) =
+        2 ^ (252 * a ^ 3) * (2 ^ (a ^ 3) * 2 ^ (-τ)) by ring]; gcongr
+      nth_rw 1 [← ENNReal.rpow_one 2, ← ENNReal.rpow_natCast,
+        ← ENNReal.rpow_add _ _ two_ne_zero ENNReal.ofNat_ne_top]
+      refine ENNReal.rpow_le_rpow_of_exponent_le one_le_two ?_
+      rw [← sub_eq_add_neg, le_sub_iff_add_le']
+      calc
+        _ ≤ (1 : ℝ) + 1 := by gcongr; exact τ_le_one (X := X)
+        _ ≤ a := by norm_cast; linarith only [four_le_a X]
+        _ ≤ _ := mod_cast Nat.le_self_pow three_ne_zero _
+    _ = _ := by rw [← ENNReal.mul_comm_div]
 
 -- TODO: update statement in blueprint
 -- Eq. 6.2.3 (Lemma 6.2.1)
-lemma correlation_kernel_bound (ha : 1 < a) {s₁ s₂ : ℤ} (hs₁ : s₁ ∈ Icc (- (S : ℤ)) s₂)
-   {x₁ x₂ : X} :
-    iHolENorm (correlation s₁ s₂ x₁ x₂) x₁ (2 * ↑D ^s₁) ≤
-      (C_6_2_1 a : ℝ≥0∞) / (volume (ball x₁ (↑D ^s₁)) * volume (ball x₂ (↑D ^s₂))) := by
+lemma correlation_kernel_bound {s₁ s₂ : ℤ} {x₁ x₂ : X} (hs : s₁ ≤ s₂) :
+    iHolENorm (correlation s₁ s₂ x₁ x₂) x₁ (2 * D ^ s₁) ≤
+    C_6_2_1 a / (volume (ball x₁ (D ^ s₁)) * volume (ball x₂ (D ^ s₂))) := by
   -- 6.2.4
   have hφ' (y : X) : ‖correlation s₁ s₂ x₁ x₂ y‖ₑ ≤
-      (C2_1_3 a)^2 / ((volume (ball x₁ (D ^ s₁))) * (volume (ball x₂ (D ^ s₂)))):= by
+      (C2_1_3 a) ^ 2 / (volume (ball x₁ (D ^ s₁)) * volume (ball x₂ (D ^ s₂))):= by
     simp only [correlation, enorm_mul, RCLike.enorm_conj, pow_two,
       ENNReal.mul_div_mul_comm measure_ball_ne_top measure_ball_ne_top]
     exact mul_le_mul enorm_Ks_le enorm_Ks_le (zero_le _) (zero_le _)
   -- 6.2.6 + 6.2.7
-  have hsimp : ∀ (y y' : X),
-      ‖correlation s₁ s₂ x₁ x₂ y - correlation s₁ s₂ x₁ x₂ y'‖ₑ ≤
-        ‖Ks s₁ x₁ y - Ks s₁ x₁ y'‖ₑ * ‖Ks s₂ x₂ y‖ₑ +
-          ‖Ks s₁ x₁ y'‖ₑ * ‖Ks s₂ x₂ y - Ks s₂ x₂ y'‖ₑ := by
-    intro y y'
-    calc ‖correlation s₁ s₂ x₁ x₂ y - correlation s₁ s₂ x₁ x₂ y'‖ₑ
-      _ = ‖conj (Ks s₁ x₁ y) * Ks s₂ x₂ y - conj (Ks s₁ x₁ y') * Ks s₂ x₂ y +
-          (conj (Ks s₁ x₁ y') * Ks s₂ x₂ y - conj (Ks s₁ x₁ y') * (Ks s₂ x₂ y'))‖ₑ := by
-        simp only [correlation, sub_add_sub_cancel]
-      _ ≤ ‖conj (Ks s₁ x₁ y) * Ks s₂ x₂ y - conj (Ks s₁ x₁ y') * Ks s₂ x₂ y ‖ₑ +
-          ‖conj (Ks s₁ x₁ y') * Ks s₂ x₂ y - conj (Ks s₁ x₁ y') * (Ks s₂ x₂ y')‖ₑ :=
-            enorm_add_le _ _
-      _ = ‖Ks s₁ x₁ y - Ks s₁ x₁ y'‖ₑ * ‖Ks s₂ x₂ y‖ₑ +
-          ‖Ks s₁ x₁ y'‖ₑ * ‖Ks s₂ x₂ y - Ks s₂ x₂ y'‖ₑ := by
-          simp only [← sub_mul, ← mul_sub, enorm_mul, RCLike.enorm_conj, ← map_sub]
-  -- 6.2.5
-  have hyy' : ∀ (y y' : X) (hy' : y ≠ y'), (((2 * D  ^ s₁ : ℝ≥0)) ^ τ)  *
-    (‖correlation s₁ s₂ x₁ x₂ y - correlation s₁ s₂ x₁ x₂ y'‖ₑ / (nndist y y')^τ) ≤
-      (2^(253*a^3) / (volume (ball x₁ (↑D ^s₁)) * volume (ball x₂ (↑D ^s₂)))) := by
-    intros y y' hy'
-    rw [mul_comm, ← ENNReal.le_div_iff_mul_le, ENNReal.div_le_iff_le_mul]
-    calc ‖correlation s₁ s₂ x₁ x₂ y - correlation s₁ s₂ x₁ x₂ y'‖ₑ
-      _ ≤ ‖Ks s₁ x₁ y - Ks s₁ x₁ y'‖ₑ * ‖Ks s₂ x₂ y‖ₑ +
-          ‖Ks s₁ x₁ y'‖ₑ * ‖Ks s₂ x₂ y - Ks s₂ x₂ y'‖ₑ := hsimp y y' -- 6.2.6 + 6.2.7
-      _ ≤ 2 ^ (252 * a ^ 3) / (volume (ball x₁ (↑D ^ s₁)) * volume (ball x₂ (↑D ^ s₂))) *
-        (↑(nndist y y') ^ τ / ((D ^ s₁ : ℝ≥0) : ℝ≥0∞) ^ τ +
-          ↑(nndist y y') ^ τ / ((D ^ s₂ : ℝ≥0) : ℝ≥0∞) ^ τ) := by
-        have h2 : (2 : ℝ≥0∞) ^ (252 * a ^ 3) = C2_1_3 a * D2_1_3 a := by
-          simp only [C2_1_3, NNReal.coe_natCast, D2_1_3]
-          norm_cast
-          ring
-        rw [mul_comm, mul_add, h2, mul_comm (volume _)]
-        simp only [ENNReal.mul_div_mul_comm measure_ball_ne_top
-          measure_ball_ne_top, mul_assoc]
-        apply add_le_add (aux_6_2_3 s₁ s₂ x₁ x₂ y y')
-        rw [← neg_sub, enorm_neg]
-        convert aux_6_2_3 s₂ s₁ x₂ x₁ y' y using 1
-        simp only [← mul_assoc, ← ENNReal.mul_div_mul_comm measure_ball_ne_top
-          measure_ball_ne_top]
-        rw [mul_comm (volume _), nndist_comm]
-      _ ≤ 2 ^ (252 * a ^ 3) / (volume (ball x₁ (↑D ^ s₁)) * volume (ball x₂ (↑D ^ s₂))) *
-        (2 * (↑(nndist y y') ^ τ / ((D ^ s₁ : ℝ≥0) : ℝ≥0∞) ^ τ)) := by
-        have hτ : 0 < τ := by
-          simp only [defaultτ, inv_pos, Nat.cast_pos]
-          omega
-        rw [ENNReal.mul_le_mul_left, two_mul, ENNReal.add_le_add_iff_left]
-        apply ENNReal.div_le_div_left
-        rw [ENNReal.rpow_le_rpow_iff, ENNReal.coe_le_coe]
-        exact zpow_le_zpow_right₀ one_le_D hs₁.2
-        · exact hτ
-        · -- I also used this in Psi.lean, with slightly different coercions.
-          have hnetop : (nndist y y' : ℝ≥0∞) / ((D ^ s₁  : ℝ≥0) : ℝ≥0∞) ≠ ⊤ := by
-            simp only [Nat.cast_pow, Nat.cast_ofNat,
-              ENNReal.coe_pow, ENNReal.coe_ofNat, ne_eq, ENNReal.div_eq_top, not_or, not_and',
-              Decidable.not_not]
-            have h' : ((D^ s₁ : ℝ≥0) : ℝ≥0∞)  ≠ 0 := by
-                exact ENNReal.coe_ne_zero.mpr (ne_of_gt (defaultD_pow_pos a s₁))
-            exact ⟨fun h ↦ absurd h h', fun _ ↦ ENNReal.coe_ne_top⟩
-          rw [← ENNReal.div_rpow_of_nonneg _ _ (le_of_lt hτ)]
-          simp only [defaultτ, ne_eq, ENNReal.rpow_eq_top_iff, ENNReal.div_eq_zero_iff,
-            ENNReal.coe_eq_zero, nndist_eq_zero, ENNReal.coe_ne_top, or_false, inv_neg'', inv_pos,
-            Nat.cast_pos, not_or, not_and, not_lt, Nat.cast_nonneg, implies_true,
-            nonpos_iff_eq_zero, true_and]
-          intro htop
-          exact absurd htop hnetop
-        · simp only [ne_eq, ENNReal.div_eq_zero_iff, pow_eq_zero_iff', OfNat.ofNat_ne_zero,
-          mul_eq_zero, not_false_eq_true, pow_eq_zero_iff, false_or, false_and]
-          finiteness
-        · simp only [ne_eq, ENNReal.div_eq_top,
-          pow_eq_zero_iff', OfNat.ofNat_ne_zero, mul_eq_zero, not_false_eq_true, pow_eq_zero_iff,
-          false_or, false_and, true_and, ENNReal.pow_eq_top_iff, ENNReal.ofNat_ne_top, or_false,
-          not_or]
-          exact ⟨ne_of_gt (measure_ball_pos volume x₁ (defaultD_pow_pos a s₁)),
-            ne_of_gt (measure_ball_pos volume x₂ (defaultD_pow_pos a s₂))⟩
-      _ = 2 ^ (252 * a ^ 3) * 2 / (volume (ball x₁ (↑D ^ s₁)) * volume (ball x₂ (↑D ^ s₂))) *
-        ((↑(nndist y y') ^ τ / ((D ^ s₁ : ℝ≥0) : ℝ≥0∞) ^ τ)) := by
-        rw [← mul_assoc, mul_comm _ 2]
-        congr 1
-        rw [← mul_div_assoc, mul_comm]
-      _ ≤ 2 ^ (253 * a ^ 3) / (volume (ball x₁ (↑D ^ s₁)) * volume (ball x₂ (↑D ^ s₂))) *
-        (↑(nndist y y') ^ τ / ((2 * D ^ s₁ : ℝ≥0) : ℝ≥0∞) ^ τ) := by
-        -- todo: modify the proof so that we extract the factor 2 from 2D^s₁.
-        -- Then we will need to use 252a^3 + 2 ≤ 253a^3
-        have h12 : (1 : ℝ≥0∞) ≤ 2 := one_le_two
-        have : 252 * a ^ 3 + 1 ≤ 253 * a ^ 3 := by --used by the second gcongr below
-          rw [Nat.succ_mul 252 (a ^ 3)]
-          exact add_le_add_left (le_of_lt (Nat.one_lt_pow three_ne_zero ha)) _
-        gcongr
-        nth_rewrite 2 [← pow_one 2]
-        rw [← pow_add]
-        gcongr --uses h12
-        exact τ_nonneg X
-        sorry -- todo: fix the calculation
-      _ = 2 ^ (253 * a ^ 3) / (volume (ball x₁ (↑D ^ s₁)) * volume (ball x₂ (↑D ^ s₂))) /
-        ((2 * D ^ s₁ : ℝ≥0) : ℝ≥0∞) ^ τ * ↑(nndist y y') ^ τ := by rw [← ENNReal.mul_comm_div]
-    · left
-      simp only [ne_eq, ENNReal.rpow_eq_zero_iff, not_or, not_and_or]
-      refine ⟨?_, Or.inl ENNReal.coe_ne_top⟩
-      · left
-        simp only [coe_nnreal_ennreal_nndist, edist_eq_zero, hy', not_false_eq_true]
-    · left
-      refine ENNReal.rpow_ne_top_of_nonneg ?hbt.h.hy0 ENNReal.coe_ne_top
-      simp only [defaultτ, inv_nonneg, Nat.cast_nonneg]
-    · left
-      simp only [ne_eq, ENNReal.rpow_eq_zero_iff, not_or, not_and_or]
-      refine ⟨?_, Or.inr <| not_lt.mpr (by simp only [defaultτ, inv_nonneg, Nat.cast_nonneg])⟩
-      · left
-        norm_cast
-        apply ne_of_gt
-        exact mul_pos (by norm_num) <| defaultD_pow_pos a _
-    · left
-      refine ENNReal.rpow_ne_top_of_nonneg ?ht.h.hy0 ENNReal.coe_ne_top
-      simp only [defaultτ, inv_nonneg, Nat.cast_nonneg]
-  calc iHolENorm (correlation s₁ s₂ x₁ x₂) x₁ (2 * ↑D ^s₁)
-    _ ≤ (C2_1_3 a)^2 / ((volume (ball x₁ (↑D ^ s₁))) * (volume (ball x₂ (D ^ s₂)))) +
-        (2^(253*a^3) / (volume (ball x₁ (↑D ^s₁)) * volume (ball x₂ (↑D ^s₂)))) := by
-        simp only [iHolENorm]
-        apply add_le_add
-        · simp only [iSup_le_iff, hφ', implies_true]
-        simp only [ENNReal.mul_iSup, iSup_le_iff]
-        intro z hz z' hz' hzz'
-        convert hyy' z z' hzz'
-        · rw [ENNReal.ofReal, Real.toNNReal_mul zero_le_two, Real.toNNReal_zpow D_nonneg,
-            Real.toNNReal_coe_nat, Real.toNNReal_ofNat]
-        · exact edist_nndist z z'
-    _ ≤ (C_6_2_1 a : ℝ≥0∞) / (volume (ball x₁ (↑D ^s₁)) * volume (ball x₂ (↑D ^s₂))) := by
-      have h12 : (1 : ℝ≥0∞) ≤ 2 := one_le_two
-      have h204 : 204 ≤ 253 := by omega
-      have haux : ((2 ^ (102 * ((a : ℝ≥0) : ℝ) ^ 3) : ℝ≥0) : ℝ≥0∞) ^ 2 ≤ 2 ^ (253 * a ^ 3) :=
-        calc ((2 ^ (102 * ((a : ℝ≥0) : ℝ) ^ 3) : ℝ≥0) : ℝ≥0∞) ^ 2
-          _ = 2 ^ (204 * a ^ 3) := by
-            rw [NNReal.coe_natCast, ← ENNReal.rpow_natCast]
-            norm_cast
-            ring
-          _ ≤ 2 ^ (253 * a ^ 3) := by
-            gcongr -- uses h12, h204
-      simp only [C2_1_3, C_6_2_1]
-      rw [← ENNReal.add_div]
-      gcongr
-      refine le_trans (add_le_add_right haux (2^(253 * a ^ 3))) ?_
-      norm_cast
-      nth_rewrite 1 [← Nat.two_mul, ← pow_one 2, ← pow_add]
-      have ha1 : 1 < a ^ 3 := Nat.one_lt_pow three_ne_zero ha
-      gcongr <;> omega
-
-/- -- Eq. 6.2.3 (Lemma 6.2.1)
-lemma correlation_kernel_bound' (ha : 1 < a) {s₁ s₂ : ℤ} (hs₁ : s₁ ∈ Icc (- (S : ℤ)) s₂)
-    {x₁ x₂ : X} :
-    iHolENorm (correlation s₁ s₂ x₁ x₂) x₁ (2 * ↑D ^s₁) ≤
-      (C_6_2_1 a : ℝ≥0∞) / (volume (ball x₁ (↑D ^s₁)) * volume (ball x₂ (↑D ^s₂))) := by
-  sorry -/
+  calc
+    _ ≤ (C2_1_3 a) ^ 2 / (volume (ball x₁ (D ^ s₁)) * volume (ball x₂ (D ^ s₂))) +
+        2 ^ (253 * a ^ 3) / (volume (ball x₁ (D ^ s₁)) * volume (ball x₂ (D ^ s₂))) := by
+      apply add_le_add (iSup₂_le fun x _ ↦ hφ' x)
+      simp only [ENNReal.mul_iSup, iSup_le_iff]
+      intro z hz z' hz' hzz'
+      convert e625 hzz' hs
+      rw [ENNReal.ofReal_mul zero_le_two, ENNReal.ofReal_ofNat, ← Real.rpow_intCast,
+        ← ENNReal.ofReal_rpow_of_pos (defaultD_pos _), ENNReal.ofReal_natCast,
+        ENNReal.rpow_intCast]
+    _ ≤ _ := by
+      rw [← ENNReal.add_div]; refine ENNReal.div_le_div_right ?_ _
+      rw [C2_1_3, C_6_2_1]; norm_cast
+      have hc : (2 ^ (102 * a ^ 3) : ℝ).toNNReal = ((2 ^ (102 * a ^ 3) : ℕ) : ℝ≥0) := by
+        rw [Real.toNNReal_eq_natCast (by positivity), Nat.cast_pow, Nat.cast_ofNat]
+      rw [show (2 : ℝ≥0) = Real.toNNReal 2 by simp, NNReal.rpow_natCast,
+        ← Real.toNNReal_pow zero_le_two, hc, ← Nat.cast_pow, ← Nat.cast_add, Nat.cast_le]
+      calc
+        _ ≤ 2 ^ (253 * a ^ 3) + 2 ^ (253 * a ^ 3) := by
+          rw [← pow_mul, show 102 * a ^ 3 * 2 = 204 * a ^ 3 by ring]; gcongr <;> norm_num
+        _ ≤ _ := by
+          rw [← two_mul, ← pow_succ', show 1 = 1 ^ 3 by norm_num,
+            show 254 * a ^ 3 = 253 * a ^ 3 + a ^ 3 by ring]
+          gcongr
+          · exact one_le_two
+          · linarith only [four_le_a X]
 
 variable [TileStructure Q D κ S o]
 
@@ -274,12 +209,12 @@ theorem MeasureTheory.exists_ne_zero_of_integral_ne_zero {α E : Type*} [NormedA
 
 -- Lemma 6.2.2
 lemma range_support {p : 𝔓 X} {g : X → ℂ} {y : X} (hpy : adjointCarleson p g y ≠ 0) :
-    y ∈ (ball (𝔠 p) (5 * ↑D ^𝔰 p)) := by
+    y ∈ (ball (𝔠 p) (5 * D ^𝔰 p)) := by
   simp only [adjointCarleson] at hpy
   obtain ⟨x, hxE, hx0⟩ := MeasureTheory.exists_ne_zero_of_setIntegral_ne_zero hpy
-  have hxp : dist x (𝔠 p) < 4 * ↑D ^𝔰 p := -- 6.2.13
+  have hxp : dist x (𝔠 p) < 4 * D ^𝔰 p := -- 6.2.13
     Grid_subset_ball (mem_of_subset_of_mem (fun _ ha ↦ ha.1) hxE)
-  have hyx : dist y x ≤ (1/2) * ↑D ^𝔰 p := by -- 6.2.14
+  have hyx : dist y x ≤ (1/2) * D ^𝔰 p := by -- 6.2.14
     have hK : Ks (𝔰 p) x y ≠ 0 := by
       by_contra h0
       simp only [h0, map_zero, zero_mul, ne_eq, not_true_eq_false] at hx0
@@ -289,8 +224,8 @@ lemma range_support {p : 𝔓 X} {g : X → ℂ} {y : X} (hpy : adjointCarleson 
   have hpos := defaultD_pow_pos a (𝔰 p)
   have hle : (9 : ℝ) / 2 < 5 := by norm_num
   calc dist y (𝔠 p) ≤ dist y x + dist x (𝔠 p) := dist_triangle y x (𝔠 p)
-    _ ≤ (1/2) * ↑D ^𝔰 p + 4 * ↑D ^ 𝔰 p := add_le_add hyx (le_of_lt hxp)
-    _ < 5 * ↑D ^ 𝔰 p := by
+    _ ≤ (1/2) * D ^𝔰 p + 4 * D ^ 𝔰 p := add_le_add hyx (le_of_lt hxp)
+    _ < 5 * D ^ 𝔰 p := by
       ring_nf
       gcongr -- uses hpos, hle.
 
@@ -311,8 +246,8 @@ lemma uncertainty (ha : 1 ≤ a) {p₁ p₂ : 𝔓 X} (hle : 𝔰 p₁ ≤ 𝔰 
   --Needed for ineq. 6.2.17
   have hss : ↑(𝓘 p₁) ⊆ ball (𝔠 p₂) (14 * D^𝔰 p₂) := by
     have h1D : 1 ≤ (D : ℝ) := one_le_defaultD a
-    have hdist : dist (𝔠 p₁) (𝔠 p₂) < 10 * ↑D ^ 𝔰 p₂ := by
-      have h5 : 10 * (D : ℝ)^ 𝔰 p₂ = 5 * ↑D ^ 𝔰 p₂ + 5 * ↑D ^ 𝔰 p₂ := by ring
+    have hdist : dist (𝔠 p₁) (𝔠 p₂) < 10 * D ^ 𝔰 p₂ := by
+      have h5 : 10 * (D : ℝ)^ 𝔰 p₂ = 5 * D ^ 𝔰 p₂ + 5 * D ^ 𝔰 p₂ := by ring
       obtain ⟨y, hy₁, hy₂⟩ := hinter
       rw [mem_ball, dist_comm] at hy₁
       apply lt_of_le_of_lt (dist_triangle (𝔠 p₁) y (𝔠 p₂))
@@ -324,9 +259,9 @@ lemma uncertainty (ha : 1 ≤ a) {p₁ p₂ : 𝔓 X} (hle : 𝔰 p₁ ≤ 𝔰 
     simp only [mem_ball] at hx ⊢
     calc dist x (𝔠 p₂)
       _ ≤ dist x (𝔠 p₁) + dist (𝔠 p₁) (𝔠 p₂) := dist_triangle _ _ _
-      _ < 4 * ↑D ^ 𝔰 p₁ + 10 * ↑D ^ 𝔰 p₂ := add_lt_add hx hdist
-      _ ≤ 4 * ↑D ^ 𝔰 p₂ + 10 * ↑D ^ 𝔰 p₂ := by gcongr -- uses h1D, hle
-      _ = 14 * ↑D ^ 𝔰 p₂ := by ring
+      _ < 4 * D ^ 𝔰 p₁ + 10 * D ^ 𝔰 p₂ := add_lt_add hx hdist
+      _ ≤ 4 * D ^ 𝔰 p₂ + 10 * D ^ 𝔰 p₂ := by gcongr -- uses h1D, hle
+      _ = 14 * D ^ 𝔰 p₂ := by ring
   -- Inequality 6.2.17.
   have hp₁p₂ : dist_(p₁) (Q x₂) (𝒬 p₂) < 2^(6*a) := by
     calc dist_(p₁) (Q x₂) (𝒬 p₂)
@@ -373,8 +308,8 @@ lemma uncertainty (ha : 1 ≤ a) {p₁ p₂ : 𝔓 X} (hle : 𝔰 p₁ ≤ 𝔰 
         intro x hx
         calc dist x x₁
           _ ≤ dist x (𝔠 p₁) + dist (𝔠 p₁) x₁ := dist_triangle _ _ _
-          _ < 4 * ↑D ^ 𝔰 p₁ + 4 * ↑D ^ 𝔰 p₁ := add_lt_add hx h1
-          _ = 8 * ↑D ^ 𝔰 p₁ := by ring
+          _ < 4 * D ^ 𝔰 p₁ + 4 * D ^ 𝔰 p₁ := add_lt_add hx h1
+          _ = 8 * D ^ 𝔰 p₁ := by ring
       exact cdist_mono (subset_trans ball_subset_Grid hI)
     -- 6.2.22
     _ ≤ 2 + 2^(6*a) + 2^(3*a) * dist_{x₁, D^𝔰 p₁} (Q x₁) (Q x₂) := by
@@ -451,19 +386,18 @@ def I12 (p p' : 𝔓 X) (g : X → ℂ) := fun (x1 : X) (x2 : X) ↦
     (correlation (𝔰 p') (𝔰 p) x1 x2 y))) * (g x1) * (g x2)‖ₑ
 
 /-- Inequality 6.2.28 -/ -- TODO: add ‖g ↑x1‖ₑ * ‖g ↑x2‖ₑ in blueprint's RHS
-lemma I12_le' (ha : 1 < a) (p p' : 𝔓 X) (hle : 𝔰 p' ≤ 𝔰 p) (g : X → ℂ) (x1 : E p') (x2 : E p) :
+lemma I12_le' (p p' : 𝔓 X) (hle : 𝔰 p' ≤ 𝔰 p) (g : X → ℂ) (x1 : E p') (x2 : E p) :
     I12 p p' g x1 x2 ≤ (2^(254 * a^3 + 8 * a)) *
       ((1 + edist_{(x1 : X), ((D : ℝ) ^ 𝔰 p')} (Q x1) (Q x2))^(-(2 * a^2 + a^3 : ℝ)⁻¹)) /
-      (volume (ball (x2 : X) (↑D ^𝔰 p))) * ‖g ↑x1‖ₑ * ‖g ↑x2‖ₑ := by
+      (volume (ball (x2 : X) (D ^𝔰 p))) * ‖g ↑x1‖ₑ * ‖g ↑x2‖ₑ := by
   have hD' : 0 < (D : ℝ) ^ 𝔰 p' := defaultD_pow_pos a (𝔰 p')
   have hsupp : support (correlation (𝔰 p') (𝔰 p) (x1 : X) x2) ⊆ ball x1 (D ^ 𝔰 p') :=
     (subset_tsupport _).trans <| fun _ hx ↦  mem_ball_of_mem_tsupport_correlation hx
-  have hs : 𝔰 p' ∈ Icc (- (S : ℤ)) (𝔰 p) := ⟨scale_mem_Icc.1, hle⟩
   -- For compatibility with holder_van_der_corput
   have heq : (2^(254 * a^3 + 8 * a)) *
       ((1 + edist_{(x1 : X), ((D : ℝ) ^ 𝔰 p')} (Q x1) (Q x2))^(-(2 * a^2 + a^3 : ℝ)⁻¹)) /
-      (volume (ball (x2 : X) (↑D ^𝔰 p))) =
-      (2^(254 * a^3 + 8 * a)) / (volume (ball (x2 : X) (↑D ^𝔰 p))) *
+      (volume (ball (x2 : X) (D ^𝔰 p))) =
+      (2^(254 * a^3 + 8 * a)) / (volume (ball (x2 : X) (D ^𝔰 p))) *
       ((1 + edist_{(x1 : X), ((D : ℝ) ^ 𝔰 p')} (Q x1) (Q x2))^(-(2 * a^2 + a^3 : ℝ)⁻¹)) := by
     rw [ENNReal.mul_comm_div, mul_comm, mul_comm _ (2 ^ _), mul_div_assoc]
   rw [I12]
@@ -476,16 +410,16 @@ lemma I12_le' (ha : 1 < a) (p p' : 𝔓 X) (hle : 𝔰 p' ≤ 𝔰 p) (g : X →
   rw [heq, edist_comm]
   --push_cast
   gcongr
-  · have hbdd := correlation_kernel_bound ha hs (x₁ := x1) (x₂ := x2)
-    have hle : (C2_0_5 ↑a : ℝ≥0∞) * volume (ball (x1 : X) (↑D ^ 𝔰 p')) *
-        iHolENorm (a := a) (correlation (𝔰 p') (𝔰 p) (x1 : X) ↑x2) (↑x1) (2 * ↑D ^ 𝔰 p') ≤
-        ↑(C2_0_5 ↑a) * volume (ball ((x1 : X)) (↑D ^ 𝔰 p')) * (↑(C_6_2_1 a) /
-          (volume (ball (x1 : X) (↑D ^ 𝔰 p')) * volume (ball (x2 : X) (↑D ^ 𝔰 p)))) := by
+  · have hbdd := correlation_kernel_bound (a := a) (X := X) hle (x₁ := x1) (x₂ := x2)
+    have hle : (C2_0_5 ↑a : ℝ≥0∞) * volume (ball (x1 : X) (D ^ 𝔰 p')) *
+        iHolENorm (a := a) (correlation (𝔰 p') (𝔰 p) (x1 : X) ↑x2) (↑x1) (2 * D ^ 𝔰 p') ≤
+        ↑(C2_0_5 ↑a) * volume (ball ((x1 : X)) (D ^ 𝔰 p')) * (↑(C_6_2_1 a) /
+          (volume (ball (x1 : X) (D ^ 𝔰 p')) * volume (ball (x2 : X) (D ^ 𝔰 p)))) := by
       gcongr
     -- simp, ring_nf, field_simp did not help.
-    have heq : ↑(C2_0_5 a) * volume (ball (x1 : X) (↑D ^ 𝔰 p')) *
-      (↑(C_6_2_1 a) / (volume (ball (x1 : X) (↑D ^ 𝔰 p')) * volume (ball (x2 : X) (↑D ^ 𝔰 p)))) =
-      ↑(C2_0_5 a) * (↑(C_6_2_1 a) / volume (ball (x2 : X) (↑D ^ 𝔰 p))) := by
+    have heq : ↑(C2_0_5 a) * volume (ball (x1 : X) (D ^ 𝔰 p')) *
+      (↑(C_6_2_1 a) / (volume (ball (x1 : X) (D ^ 𝔰 p')) * volume (ball (x2 : X) (D ^ 𝔰 p)))) =
+      ↑(C2_0_5 a) * (↑(C_6_2_1 a) / volume (ball (x2 : X) (D ^ 𝔰 p))) := by
       simp only [mul_assoc]
       congr 1
       rw [ENNReal.div_eq_inv_mul, ENNReal.mul_inv (Or.inr measure_ball_ne_top)
@@ -532,9 +466,9 @@ lemma I12_le (ha : 4 ≤ a) (p p' : 𝔓 X) (hle : 𝔰 p' ≤ 𝔰 p) (g : X �
     (x1 : E p') (x2 : E p) :
     I12 p p' g x1 x2 ≤
     (2^(254 * a^3 + 8 * a + 1) * ((1 + edist_(p') (𝒬 p') (𝒬 p))^(-(2 * a^2 + a^3 : ℝ)⁻¹))) /
-      (volume (ball (x2 : X) (↑D ^𝔰 p))) * ‖g ↑x1‖ₑ * ‖g ↑x2‖ₑ := by
-  apply le_trans (I12_le' (by linarith) p p' hle g x1 x2)
-  gcongr ?_ *  ‖g ↑x1‖ₑ * ‖g ↑x2‖ₑ
+      (volume (ball (x2 : X) (D ^𝔰 p))) * ‖g ↑x1‖ₑ * ‖g ↑x2‖ₑ := by
+  apply (I12_le' p p' hle g x1 x2).trans
+  gcongr ?_ * ‖g ↑x1‖ₑ * ‖g ↑x2‖ₑ
   rw [pow_add 2 _ 1, pow_one, mul_comm _ 2, mul_assoc, mul_comm 2 (_ * _), mul_assoc]
   gcongr
   -- Now we need to use Lemma 6.2.3. to conclude this inequality.
@@ -557,19 +491,18 @@ lemma I12_le (ha : 4 ≤ a) (p p' : 𝔓 X) (hle : 𝔰 p' ≤ 𝔰 p) (g : X �
   exact ENNReal.one_le_rpow one_le_two hexp
 
 /-- Inequality 6.2.28 -/ -- TODO: add ‖g ↑x1‖₊ * ‖g ↑x2‖₊ in blueprint's RHS
-lemma I12_nnreal_le' (ha : 1 < a) (p p' : 𝔓 X) (hle : 𝔰 p' ≤ 𝔰 p) (g : X → ℂ) (x1 : E p') (x2 : E p) :
+lemma I12_nnreal_le' (p p' : 𝔓 X) (hle : 𝔰 p' ≤ 𝔰 p) (g : X → ℂ) (x1 : E p') (x2 : E p) :
     (I12 p p' g x1 x2).toNNReal ≤ (2^(254 * a^3 + 8 * a)) *
       ((1 + nndist_{(x1 : X), ((D : ℝ) ^ 𝔰 p')} (Q x1) (Q x2))^(-(2 * a^2 + a^3 : ℝ)⁻¹)) /
-      (volume (ball (x2 : X) (↑D ^𝔰 p))).toNNReal * ‖g ↑x1‖₊ * ‖g ↑x2‖₊ := by
+      (volume (ball (x2 : X) (D ^𝔰 p))).toNNReal * ‖g ↑x1‖₊ * ‖g ↑x2‖₊ := by
   have hD : 0 < (D : ℝ) ^ 𝔰 p := defaultD_pow_pos a (𝔰 p)
   have hD' : 0 < (D : ℝ) ^ 𝔰 p' := defaultD_pow_pos a (𝔰 p')
   have hsupp : support (correlation (𝔰 p') (𝔰 p) (x1 : X) x2) ⊆ ball x1 (D ^ 𝔰 p') :=
     (subset_tsupport _).trans <| fun _ hx ↦ (mem_ball_of_mem_tsupport_correlation hx)
-  have hs : 𝔰 p' ∈ Icc (- (S : ℤ)) (𝔰 p) := ⟨scale_mem_Icc.1, hle⟩
   have heq : (2^(254 * a^3 + 8 * a)) *
       ((1 + nndist_{(x1 : X), ((D : ℝ) ^ 𝔰 p')} (Q x2) (Q x1))^(-(2 * a^2 + a^3 : ℝ)⁻¹)) /
-      (volume (ball (x2 : X) (↑D ^𝔰 p))).toNNReal =
-      (2^(254 * a^3 + 8 * a)) / (volume (ball (x2 : X) (↑D ^𝔰 p))).toNNReal *
+      (volume (ball (x2 : X) (D ^𝔰 p))).toNNReal =
+      (2^(254 * a^3 + 8 * a)) / (volume (ball (x2 : X) (D ^𝔰 p))).toNNReal *
       ((1 + nndist_{(x1 : X), ((D : ℝ) ^ 𝔰 p')} (Q x2) (Q x1))^(-(2 * a^2 + a^3 : ℝ)⁻¹)) := by
     rw [div_mul_comm, mul_comm _ (2 ^ _), mul_div_assoc]
   rw [I12]
@@ -584,16 +517,16 @@ lemma I12_nnreal_le' (ha : 1 < a) (p p' : 𝔓 X) (hle : 𝔰 p' ≤ 𝔰 p) (g 
   rw [nndist_comm, heq]
   push_cast
   gcongr
-  · have hbdd := correlation_kernel_bound ha hs (x₁ := x1) (x₂ := x2)
-    have hle : (C2_0_5 ↑a : ℝ≥0∞) * volume (ball (x1 : X) (↑D ^ 𝔰 p')) *
-        iHolENorm (a := a) (correlation (𝔰 p') (𝔰 p) (x1 : X) ↑x2) (↑x1) (2 * ↑D ^ 𝔰 p') ≤
-        ↑(C2_0_5 ↑a) * volume (ball ((x1 : X)) (↑D ^ 𝔰 p')) * (↑(C_6_2_1 a) /
-          (volume (ball (x1 : X) (↑D ^ 𝔰 p')) * volume (ball (x2 : X) (↑D ^ 𝔰 p)))) := by
+  · have hbdd := correlation_kernel_bound (a := a) (X := X) hle (x₁ := x1) (x₂ := x2)
+    have hle : (C2_0_5 ↑a : ℝ≥0∞) * volume (ball (x1 : X) (D ^ 𝔰 p')) *
+        iHolENorm (a := a) (correlation (𝔰 p') (𝔰 p) (x1 : X) ↑x2) (↑x1) (2 * D ^ 𝔰 p') ≤
+        ↑(C2_0_5 ↑a) * volume (ball ((x1 : X)) (D ^ 𝔰 p')) * (↑(C_6_2_1 a) /
+          (volume (ball (x1 : X) (D ^ 𝔰 p')) * volume (ball (x2 : X) (D ^ 𝔰 p)))) := by
       gcongr
     -- simp, ring_nf, field_simp did not help.
-    have heq : ↑(C2_0_5 a) * volume (ball (x1 : X) (↑D ^ 𝔰 p')) *
-      (↑(C_6_2_1 a) / (volume (ball (x1 : X) (↑D ^ 𝔰 p')) * volume (ball (x2 : X) (↑D ^ 𝔰 p)))) =
-      ↑(C2_0_5 a) * (↑(C_6_2_1 a) / volume (ball (x2 : X) (↑D ^ 𝔰 p))) := by
+    have heq : ↑(C2_0_5 a) * volume (ball (x1 : X) (D ^ 𝔰 p')) *
+      (↑(C_6_2_1 a) / (volume (ball (x1 : X) (D ^ 𝔰 p')) * volume (ball (x2 : X) (D ^ 𝔰 p)))) =
+      ↑(C2_0_5 a) * (↑(C_6_2_1 a) / volume (ball (x2 : X) (D ^ 𝔰 p))) := by
       simp only [mul_assoc]
       congr 1
       rw [ENNReal.div_eq_inv_mul, ENNReal.mul_inv (Or.inr measure_ball_ne_top)
@@ -627,13 +560,13 @@ lemma exp_ineq' (ha : 1 < a) : 0 ≤ 1 + ((8 * a  : ℕ) : ℝ) * -(2 * (a : ℝ
   nlinarith
 
 /-- Inequality 6.2.29. -/ -- TODO: add ‖g ↑x1‖₊ * ‖g ↑x2‖₊ in blueprint's RHS
-lemma I12_nnreal_le (ha : 1 < a) (p p' : 𝔓 X) (hle : 𝔰 p' ≤ 𝔰 p) (g : X → ℂ)
-    (hinter : (ball (𝔠 p') (5 * D^𝔰 p') ∩ ball (𝔠 p) (5 * D^𝔰 p)).Nonempty)
+lemma I12_nnreal_le (ha : 1 < a) {p p' : 𝔓 X} (hle : 𝔰 p' ≤ 𝔰 p) (g : X → ℂ)
+    (hinter : (ball (𝔠 p') (5 * D ^ 𝔰 p') ∩ ball (𝔠 p) (5 * D ^ 𝔰 p)).Nonempty)
     (x1 : E p') (x2 : E p) :
     (I12 p p' g x1 x2).toNNReal ≤
     (2^(254 * a^3 + 8 * a + 1) * ((1 + dist_(p') (𝒬 p') (𝒬 p))^(-(2 * a^2 + a^3 : ℝ)⁻¹))) /
-      (volume (ball (x2 : X) (↑D ^𝔰 p))).toNNReal * ‖g ↑x1‖₊ * ‖g ↑x2‖₊ := by
-  apply le_trans (NNReal.coe_le_coe.mpr (I12_nnreal_le' ha p p' hle g x1 x2))
+      (volume (ball (x2 : X) (D ^𝔰 p))).toNNReal * ‖g ↑x1‖₊ * ‖g ↑x2‖₊ := by
+  apply le_trans (NNReal.coe_le_coe.mpr (I12_nnreal_le' p p' hle g x1 x2))
   simp only [Nat.cast_pow, Nat.cast_ofNat, NNReal.coe_mul, NNReal.coe_div, NNReal.coe_pow,
     NNReal.coe_ofNat, NNReal.coe_rpow, NNReal.coe_add, NNReal.coe_one, coe_nndist, coe_nnnorm]
   gcongr ?_ *  ‖g ↑x1‖ * ‖g ↑x2‖
@@ -666,21 +599,21 @@ lemma I12_nnreal_le (ha : 1 < a) (p p' : 𝔓 X) (hle : 𝔰 p' ≤ 𝔰 p) (g :
 
 /-- Inequality 6.2.32 -/
 lemma volume_nnreal_coeGrid_le (p : 𝔓 X) (x2 : E p) :
-    (volume (coeGrid (𝓘 p))).toNNReal ≤ 2 ^ (3*a) * (volume (ball (x2 : X) (↑D ^𝔰 p))).toNNReal := by
+    (volume (coeGrid (𝓘 p))).toNNReal ≤ 2 ^ (3*a) * (volume (ball (x2 : X) (D ^𝔰 p))).toNNReal := by
   -- Inequality 6.2.30
-  have hdist : dist (𝔠 p) (x2 : X) < 4 * ↑D ^𝔰 p := by --TODO: < in blueprint
+  have hdist : dist (𝔠 p) (x2 : X) < 4 * D ^𝔰 p := by --TODO: < in blueprint
     rw [dist_comm]
     exact Grid_subset_ball (mem_of_subset_of_mem (fun _ ha ↦ ha.1) x2.prop)
   -- Inclusion 6.2.31
-  have hsub : (coeGrid (𝓘 p)) ⊆ (ball (x2 : X) (8 * ↑D ^𝔰 p)) := by
+  have hsub : (coeGrid (𝓘 p)) ⊆ (ball (x2 : X) (8 * D ^𝔰 p)) := by
     apply le_trans Grid_subset_ball
     intro x hx
     calc dist x x2
       _ ≤ dist x (𝔠 p) + dist (𝔠 p) x2 := dist_triangle _ _ _
-      _ < 4 * ↑D ^ 𝔰 p + 4 * ↑D ^ 𝔰 p := by
+      _ < 4 * D ^ 𝔰 p + 4 * D ^ 𝔰 p := by
         apply add_lt_add hx hdist
-      _ = 8 * ↑D ^ 𝔰 p := by ring
-  have h : (volume (coeGrid (𝓘 p))).toNNReal ≤ (volume (ball (x2 : X) (8 * ↑D ^𝔰 p))).toNNReal := by
+      _ = 8 * D ^ 𝔰 p := by ring
+  have h : (volume (coeGrid (𝓘 p))).toNNReal ≤ (volume (ball (x2 : X) (8 * D ^𝔰 p))).toNNReal := by
     gcongr; finiteness
   have h8 : (8 : ℝ) = 2 ^ 3 := by norm_num
   have h23a : (2 : ℝ≥0) ^ (3 * a) = ((2 : ℝ≥0∞) ^ (3 * a)).toNNReal := by
@@ -689,51 +622,51 @@ lemma volume_nnreal_coeGrid_le (p : 𝔓 X) (x2 : E p) :
   simp only [h23a, h8]
   rw [← ENNReal.toNNReal_mul]
   rw [ENNReal.toNNReal_le_toNNReal (by finiteness)]
-  · convert DoublingMeasure.volume_ball_two_le_same_repeat (x2 : X) (↑D ^𝔰 p) 3 using 1
+  · convert DoublingMeasure.volume_ball_two_le_same_repeat (x2 : X) (D ^𝔰 p) 3 using 1
     rw [mul_comm 3, pow_mul]
     simp only [NNReal.coe_pow, NNReal.coe_ofNat, Nat.cast_pow, Nat.cast_ofNat]
   · exact ENNReal.mul_ne_top (by exact Ne.symm (not_eq_of_beq_eq_false rfl)) (by finiteness)
 
 /-- Inequality 6.2.32 -/
 lemma volume_coeGrid_le (p : 𝔓 X) (x2 : E p) :
-    volume (coeGrid (𝓘 p)) ≤ 2 ^ (3*a) * (volume (ball (x2 : X) (↑D ^𝔰 p))) := by
+    volume (coeGrid (𝓘 p)) ≤ 2 ^ (3*a) * (volume (ball (x2 : X) (D ^𝔰 p))) := by
   -- Inequality 6.2.30
-  have hdist : dist (𝔠 p) (x2 : X) < 4 * ↑D ^𝔰 p := --TODO: < in blueprint
+  have hdist : dist (𝔠 p) (x2 : X) < 4 * D ^𝔰 p := --TODO: < in blueprint
     dist_comm (𝔠 p) (x2 : X) ▸ Grid_subset_ball (mem_of_subset_of_mem (fun _ ha ↦ ha.1) x2.prop)
   -- Inclusion 6.2.31
-  have hsub : (coeGrid (𝓘 p)) ⊆ (ball (x2 : X) (8 * ↑D ^𝔰 p)) := by
+  have hsub : (coeGrid (𝓘 p)) ⊆ (ball (x2 : X) (8 * D ^𝔰 p)) := by
     apply le_trans Grid_subset_ball
     intro x hx
     calc dist x x2
       _ ≤ dist x (𝔠 p) + dist (𝔠 p) x2 := dist_triangle _ _ _
-      _ < 4 * ↑D ^ 𝔰 p + 4 * ↑D ^ 𝔰 p := add_lt_add hx hdist
-      _ = 8 * ↑D ^ 𝔰 p := by ring
-  have h : volume (coeGrid (𝓘 p)) ≤ volume (ball (x2 : X) (8 * ↑D ^𝔰 p)) :=
+      _ < 4 * D ^ 𝔰 p + 4 * D ^ 𝔰 p := add_lt_add hx hdist
+      _ = 8 * D ^ 𝔰 p := by ring
+  have h : volume (coeGrid (𝓘 p)) ≤ volume (ball (x2 : X) (8 * D ^𝔰 p)) :=
     measure_mono hsub
   have h8 : (8 : ℝ) = 2 ^ 3 := by norm_num
   apply le_trans h
   simp only [NNReal.coe_mul, ← NNReal.coe_le_coe, h8]
-  convert DoublingMeasure.volume_ball_two_le_same_repeat (x2 : X) (↑D ^𝔰 p) 3 using 1
+  convert DoublingMeasure.volume_ball_two_le_same_repeat (x2 : X) (D ^𝔰 p) 3 using 1
   rw [mul_comm 3, pow_mul]
   simp [NNReal.coe_pow, NNReal.coe_ofNat, Nat.cast_pow, Nat.cast_ofNat]
 
 -- Bound 6.2.29 using 6.2.32 and `4 ≤ a`.
 lemma bound_6_2_29 (ha : 4 ≤ a) (p p' : 𝔓 X) (x2 : E p) : 2 ^ (254 * a^3 + 8 * a + 1) *
       ((1 + nndist_(p') (𝒬 p') (𝒬 p))^(-(2 * a^2 + a^3 : ℝ)⁻¹)) /
-        (volume (ball (x2 : X) (↑D ^𝔰 p))) ≤ (C_6_1_5 a) *
+        (volume (ball (x2 : X) (D ^𝔰 p))) ≤ (C_6_1_5 a) *
           ((1 + nndist_(p') (𝒬 p') (𝒬 p))^(-(2 * a^2 + a^3 : ℝ)⁻¹)) /
             (volume (coeGrid (𝓘 p))).toNNReal := by
   have h4 : (2 : ℝ≥0∞) ^ (254 * a ^ 3 + 1) * 2 ^ (11 * a) ≤ C_6_1_5 a :=
     ENNReal.coe_le_coe.mpr (C_6_1_5_bound ha)
   -- Inequality 6.2.32
   have hvol : ∀ (x2 : E p), volume (coeGrid (𝓘 p)) ≤
-      2 ^ (3*a) * (volume (ball (x2 : X) (↑D ^𝔰 p))) := volume_coeGrid_le p
+      2 ^ (3*a) * (volume (ball (x2 : X) (D ^𝔰 p))) := volume_coeGrid_le p
   calc 2 ^ (254 * a^3 + 8 * a + 1) *
     ((1 + nndist_(p') (𝒬 p') (𝒬 p))^(-(2 * a^2 + a^3 : ℝ)⁻¹)) /
-      (volume (ball (x2 : X) (↑D ^𝔰 p)))
+      (volume (ball (x2 : X) (D ^𝔰 p)))
     _ = 2^ (254 * a^3 + 1) * 2 ^ (11 * a) * 2 ^ (- (3 : ℤ) * a) *
         ((1 + nndist_(p') (𝒬 p') (𝒬 p))^(-(2 * a^2 + a^3 : ℝ)⁻¹)) /
-          (volume (ball (x2 : X) (↑D ^𝔰 p))) := by
+          (volume (ball (x2 : X) (D ^𝔰 p))) := by
       simp only [← zpow_natCast, ← ENNReal.zpow_add two_ne_zero
         ENNReal.ofNat_ne_top]
       congr
@@ -741,7 +674,7 @@ lemma bound_6_2_29 (ha : 4 ≤ a) (p p' : 𝔓 X) (x2 : E p) : 2 ^ (254 * a^3 + 
       ring_nf
     _ = 2 ^ (254 * a^3 + 1) * 2 ^ (11 * a) *
         ((1 + nndist_(p') (𝒬 p') (𝒬 p))^(-(2 * a^2 + a^3 : ℝ)⁻¹)) /
-          (2 ^ (3 * a) * volume (ball (x2 : X) (↑D ^𝔰 p))) := by
+          (2 ^ (3 * a) * volume (ball (x2 : X) (D ^𝔰 p))) := by
       simp only [Int.reduceNeg, neg_mul,  Nat.cast_pow, Nat.cast_ofNat, ENNReal.div_eq_inv_mul]
       rw [ENNReal.mul_inv (by right; finiteness) (by left; simp)]
       simp only [← mul_assoc]
@@ -750,7 +683,7 @@ lemma bound_6_2_29 (ha : 4 ≤ a) (p p' : 𝔓 X) (x2 : E p) : 2 ^ (254 * a^3 + 
       rw [ENNReal.zpow_neg two_ne_zero ENNReal.ofNat_ne_top]
       norm_cast
     _ ≤ (C_6_1_5 a) * ((1 + nndist_(p') (𝒬 p') (𝒬 p))^(-(2 * a^2 + a^3 : ℝ)⁻¹)) /
-          (2 ^ (3 * a) * volume (ball (x2 : X) (↑D ^𝔰 p))) := by gcongr
+          (2 ^ (3 * a) * volume (ball (x2 : X) (D ^𝔰 p))) := by gcongr
     _ ≤ (C_6_1_5 a) * ((1 + nndist_(p') (𝒬 p') (𝒬 p))^(-(2 * a^2 + a^3 : ℝ)⁻¹)) /
           (volume (coeGrid (𝓘 p))).toNNReal := by
         gcongr;
@@ -760,7 +693,7 @@ lemma bound_6_2_29 (ha : 4 ≤ a) (p p' : 𝔓 X) (x2 : E p) : 2 ^ (254 * a^3 + 
 -- Bound 6.2.29 using 6.2.32 and `4 ≤ a`.
 lemma bound_6_2_29' (ha : 4 ≤ a) (p p' : 𝔓 X) (x2 : E p) : 2 ^ (254 * a^3 + 8 * a + 1) *
       ((1 + dist_(p') (𝒬 p') (𝒬 p))^(-(2 * a^2 + a^3 : ℝ)⁻¹)) /
-        (volume (ball (x2 : X) (↑D ^𝔰 p))).toNNReal ≤ (C_6_1_5 a) *
+        (volume (ball (x2 : X) (D ^𝔰 p))).toNNReal ≤ (C_6_1_5 a) *
           ((1 + dist_(p') (𝒬 p') (𝒬 p))^(-(2 * a^2 + a^3 : ℝ)⁻¹)) /
             (volume (coeGrid (𝓘 p))).toNNReal := by
   have h1 : 0 < (volume (𝓘 p : Set X)).toNNReal :=
@@ -769,22 +702,22 @@ lemma bound_6_2_29' (ha : 4 ≤ a) (p p' : 𝔓 X) (x2 : E p) : 2 ^ (254 * a^3 +
   have h4 : 2 ^ (254 * a ^ 3 + 1) * 2 ^ (11 * a) ≤ C_6_1_5 a := C_6_1_5_bound ha
   -- Inequality 6.2.32
   have hvol : ∀ (x2 : E p), (volume (coeGrid (𝓘 p))).toNNReal ≤
-      2 ^ (3*a) * (volume (ball (x2 : X) (↑D ^𝔰 p))).toNNReal := by
+      2 ^ (3*a) * (volume (ball (x2 : X) (D ^𝔰 p))).toNNReal := by
     intro x2
     apply volume_nnreal_coeGrid_le
   calc 2 ^ (254 * a^3 + 8 * a + 1) *
     ((1 + dist_(p') (𝒬 p') (𝒬 p))^(-(2 * a^2 + a^3 : ℝ)⁻¹)) /
-      (volume (ball (x2 : X) (↑D ^𝔰 p))).toNNReal
+      (volume (ball (x2 : X) (D ^𝔰 p))).toNNReal
     _ = 2^ (254 * a^3 + 1) * 2 ^ (11 * a) * 2 ^ (- (3 : ℤ) * a) *
         ((1 + dist_(p') (𝒬 p') (𝒬 p))^(-(2 * a^2 + a^3 : ℝ)⁻¹)) /
-          (volume (ball (x2 : X) (↑D ^𝔰 p))).toNNReal := by
+          (volume (ball (x2 : X) (D ^𝔰 p))).toNNReal := by
       simp only [← zpow_natCast, ← zpow_add₀ h2]
       congr
       push_cast
       ring
     _ = 2 ^ (254 * a^3 + 1) * 2 ^ (11 * a) *
         ((1 + dist_(p') (𝒬 p') (𝒬 p))^(-(2 * a^2 + a^3 : ℝ)⁻¹)) /
-          (2 ^ (3 * a) * (volume (ball (x2 : X) (↑D ^𝔰 p)))).toNNReal := by
+          (2 ^ (3 * a) * (volume (ball (x2 : X) (D ^𝔰 p)))).toNNReal := by
       simp only [mul_div_assoc, mul_assoc, neg_mul, zpow_neg]
       rw [inv_mul_eq_div, div_div, mul_comm (2 ^ (3 * a))]
       simp only [mul_div]
@@ -792,7 +725,7 @@ lemma bound_6_2_29' (ha : 4 ≤ a) (p p' : 𝔓 X) (x2 : E p) : 2 ^ (254 * a^3 +
       rw [ENNReal.toNNReal_mul, NNReal.coe_mul]
       rfl
     _ ≤ (C_6_1_5 a) * ((1 + dist_(p') (𝒬 p') (𝒬 p))^(-(2 * a^2 + a^3 : ℝ)⁻¹)) /
-          (2 ^ (3 * a) * (volume (ball (x2 : X) (↑D ^𝔰 p))).toNNReal) := by
+          (2 ^ (3 * a) * (volume (ball (x2 : X) (D ^𝔰 p))).toNNReal) := by
           gcongr
           · simp only [Nat.cast_pow, Nat.cast_ofNat, Nat.ofNat_pos, pow_pos,
               mul_pos_iff_of_pos_left, NNReal.coe_pos]
@@ -875,7 +808,7 @@ lemma boundedCompactSupport_star_Ks_mul_g (p' : 𝔓 X) {g : X → ℂ} (hg : Me
         _ ≤ dist x.2 x.1 + dist x.1 y.1 + dist y.1 y.2 := by
           gcongr
           exact dist_triangle x.2 x.1 y.1
-        _ ≤ (↑D ^ 𝔰 p' / 2) + C + (↑D ^ 𝔰 p' / 2) := by
+        _ ≤ (D ^ 𝔰 p' / 2) + C + (D ^ 𝔰 p' / 2) := by
           gcongr
           · rw [dist_comm]
             have hx' : x ∈ tsupport fun x ↦ (Ks (𝔰 p') x.1 x.2) := by
@@ -893,7 +826,7 @@ lemma boundedCompactSupport_star_Ks_mul_g (p' : 𝔓 X) {g : X → ℂ} (hg : Me
               ext z
               simp only [mem_support, ne_eq, map_eq_zero]
             exact (dist_mem_Icc_of_mem_tsupport_Ks hy').2
-        _ = ↑D ^ 𝔰 p' + C := by ring
+        _ = D ^ 𝔰 p' + C := by ring
   · intros A hA
     rw [isBounded_image_iff]
     obtain ⟨C, hC0, hC⟩ := Bornology.IsBounded.exists_bound_of_norm_Ks hA (𝔰 p')
@@ -933,13 +866,13 @@ lemma boundedCompactSupport_Ks_mul_star_g (p : 𝔓 X)  {g : X → ℂ}
         _ ≤ dist x.2 x.1 + dist x.1 y.1 + dist y.1 y.2 := by
           gcongr
           exact dist_triangle x.2 x.1 y.1
-        _ ≤ (↑D ^ 𝔰 p / 2) + C + (↑D ^ 𝔰 p / 2) := by
+        _ ≤ (D ^ 𝔰 p / 2) + C + (D ^ 𝔰 p / 2) := by
           gcongr
           · rw [dist_comm]
             exact (dist_mem_Icc_of_mem_tsupport_Ks hx.2).2
           · exact hC hx.1 hy.1
           · exact (dist_mem_Icc_of_mem_tsupport_Ks hy.2).2
-        _ = ↑D ^ 𝔰 p + C := by ring
+        _ = D ^ 𝔰 p + C := by ring
   · intros A hA
     rw [isBounded_image_iff]
     obtain ⟨C, hC0, hC⟩ := Bornology.IsBounded.exists_bound_of_norm_Ks hA (𝔰 p)
@@ -1153,7 +1086,7 @@ lemma integrableOn_I12 (ha : 4 ≤ a) {p p' : 𝔓 X} (hle : 𝔰 p' ≤ 𝔰 p)
       by_cases hz : z ∈ (E p') ×ˢ (E p)
       · have ha1 : 1 < a := by omega
         simp only [f, if_pos hz, Real.norm_eq_abs, NNReal.abs_eq]
-        apply le_trans (I12_nnreal_le ha1 p p' hle g hinter ⟨z.1, hz.1⟩ ⟨z.2, hz.2⟩)
+        apply le_trans (I12_nnreal_le ha1 hle g hinter ⟨z.1, hz.1⟩ ⟨z.2, hz.2⟩)
         simp only [coe_nnnorm]
         gcongr ?_ *  ‖g ↑_‖ * ‖g ↑_‖
         convert (bound_6_2_29' ha p p' ⟨z.2, hz.2⟩)
@@ -1178,7 +1111,7 @@ lemma integrableOn_I12' (ha : 4 ≤ a) {p p' : 𝔓 X} (hle : 𝔰 p' ≤ 𝔰 p
     IntegrableOn (fun x ↦ ((I12 p p' g x.1 x.2).toReal : ℂ)) (E p' ×ˢ E p) volume :=
   ContinuousLinearMap.integrable_comp (Complex.ofRealCLM) (integrableOn_I12 ha hle hg hg1 hinter)
 
-lemma bound_6_2_26_aux (p p' : 𝔓 X)  (g : X → ℂ) :
+lemma bound_6_2_26_aux (p p' : 𝔓 X) (g : X → ℂ) :
     let f := fun (x, z1, z2) ↦ (starRingEnd ℂ) (Ks (𝔰 p') z1 x) *
       exp (I * (((Q z1) z1) - ((Q z1) x))) * g z1 * (Ks (𝔰 p) z2 x *
         exp (I * (-((Q z2) z2) + ((Q z2) x))) * (starRingEnd ℂ) (g z2))
@@ -1263,12 +1196,12 @@ lemma correlation_le_of_nonempty_inter (ha : 4 ≤ a) {p p' : 𝔓 X} (hle : �
   -- Inequality 6.2.29
   have hI12 : ∀ (x1 : E p') (x2 : E p), I12 x1 x2 ≤
       (2^(254 * a^3 + 8 * a + 1) * ((1 + edist_(p') (𝒬 p') (𝒬 p))^(-(2 * a^2 + a^3 : ℝ)⁻¹))) /
-      (volume (ball (x2 : X) (↑D ^𝔰 p))) * ‖g ↑x1‖ₑ * ‖g ↑x2‖ₑ :=
+      (volume (ball (x2 : X) (D ^𝔰 p))) * ‖g ↑x1‖ₑ * ‖g ↑x2‖ₑ :=
     I12_le (by omega) p p' hle g hinter
   -- Bound 6.2.29 using 6.2.32 and `4 ≤ a`.
   have hle' : ∀ (x2 : E p), 2 ^ (254 * a^3 + 8 * a + 1) *
       ((1 + nndist_(p') (𝒬 p') (𝒬 p))^(-(2 * a^2 + a^3 : ℝ)⁻¹)) /
-        (volume (ball (x2 : X) (↑D ^𝔰 p))) ≤ (C_6_1_5 a) *
+        (volume (ball (x2 : X) (D ^𝔰 p))) ≤ (C_6_1_5 a) *
           ((1 + nndist_(p') (𝒬 p') (𝒬 p))^(-(2 * a^2 + a^3 : ℝ)⁻¹)) /
             (volume (coeGrid (𝓘 p))).toNNReal := bound_6_2_29 ha p p'
   -- Estimate 6.2.24 -- 6.2.25 by 6.2.26
@@ -1372,7 +1305,7 @@ lemma correlation_le (ha : 4 ≤ a) {p p' : 𝔓 X} (hle : 𝔰 p' ≤ 𝔰 p) {
 
 -- Lemma 6.1.5 (part II)
 lemma correlation_zero_of_ne_subset (p p' : 𝔓 X) (g : X → ℂ)
-    (hp : ¬ coeGrid (𝓘 p) ⊆ ball (𝔠 p) (15 * ↑D ^𝔰 p)) :
+    (hp : ¬ coeGrid (𝓘 p) ⊆ ball (𝔠 p) (15 * D ^𝔰 p)) :
     ‖∫ y, (adjointCarleson p' g y) * conj (adjointCarleson p g y)‖ₑ = 0 := by
   simp only [enorm_eq_nnnorm, ENNReal.coe_eq_zero]
   have hD : 1 ≤ (D : ℝ) := one_le_defaultD _

--- a/Carleson/Defs.lean
+++ b/Carleson/Defs.lean
@@ -668,6 +668,8 @@ lemma a_pos : 0 < a := by linarith [four_le_a X]
 lemma cast_a_pos : 0 < (a : ℝ) := by norm_cast; exact a_pos X
 lemma τ_pos : 0 < defaultτ a := inv_pos.mpr (cast_a_pos X)
 lemma τ_nonneg : 0 ≤ defaultτ a := (τ_pos X).le
+lemma τ_le_one : defaultτ a ≤ 1 := by
+  rw [defaultτ, inv_le_one_iff₀]; right; norm_cast; linarith [four_le_a X]
 
 /-- `τ` as an element of `ℝ≥0`. -/
 def nnτ : ℝ≥0 := ⟨defaultτ a, τ_nonneg X⟩

--- a/Carleson/ForestOperator/Forests.lean
+++ b/Carleson/ForestOperator/Forests.lean
@@ -42,7 +42,7 @@ lemma estimate_C7_4_6 {a : ℕ} (n : ℕ) (ha : 4 ≤ a) :
   simp_rw [C7_4_6, C7_2_1, C7_6_2, C2_1_3, ← mul_assoc]
   conv_lhs => enter [1, 1, 1, 2]; norm_cast
   conv_lhs => enter [1, 1, 2, 2]; norm_cast
-  rw [NNReal.rpow_natCast, NNReal.rpow_natCast, ← pow_add, ← pow_add,
+  rw [NNReal.rpow_natCast, ← pow_add, ← pow_add,
     show 152 * a ^ 3 + 102 * a ^ 3 + (21 * a + 5) = 254 * a ^ 3 + 21 * a + 5 by ring]
   simp_rw [NNReal.rpow_neg, ← div_eq_mul_inv]
   gcongr 2 ^ ?_ / 2 ^ ?_

--- a/Carleson/ForestOperator/L2Estimate.lean
+++ b/Carleson/ForestOperator/L2Estimate.lean
@@ -751,11 +751,12 @@ private lemma aeMeasurable_cS_bound : AEMeasurable (cS_bound t u f) := by
 -- The natural constant for Lemma 7.2.1 is ≤ the simpler constant `C7_2_1` we use instead.
 private lemma le_C7_2_1 {a : ℕ} (ha : 4 ≤ a) :
     C7_1_3 a * CMB (defaultA a) 2 + C7_1_3 a * C7_2_3 a + C7_2_2 a ≤ (C7_2_1 a : ℝ≥0∞) := calc
-  _ ≤ (3 : ℕ) • (2 : ℝ≥0∞) ^ (151 * (a : ℝ) ^ 3 + 12 * a) := by
+  _ ≤ (3 : ℕ) • (2 : ℝ≥0∞) ^ (151 * a ^ 3 + 12 * a) := by
     rw [three'_nsmul]
     gcongr
-    · rw [C7_1_3_eq_C7_1_6 ha, C7_1_6_def, CMB_defaultA_two_eq, ← ENNReal.coe_mul,
-        ← NNReal.rpow_add two_ne_zero, ENNReal.coe_rpow_of_ne_zero two_ne_zero, ENNReal.coe_ofNat]
+    · rw [C7_1_3_eq_C7_1_6 ha, C7_1_6_def, CMB_defaultA_two_eq, pow_add]
+      simp_rw [ENNReal.coe_pow, ENNReal.coe_rpow_of_ne_zero two_ne_zero, ENNReal.coe_ofNat]
+      gcongr; rw [← ENNReal.rpow_natCast, Nat.cast_mul]
       apply ENNReal.rpow_le_rpow_of_exponent_le one_le_two ?_
       linarith [show 4 ≤ (a : ℝ) by exact_mod_cast ha]
     · rw [C7_1_3_eq_C7_1_6 ha, C7_2_3_def, C7_1_6_def]
@@ -764,12 +765,10 @@ private lemma le_C7_2_1 {a : ℕ} (ha : 4 ≤ a) :
     · rw [C7_2_2_def]
       norm_cast
       exact pow_right_mono₀ one_le_two <| (Nat.mul_le_mul_right _ (by norm_num)).trans le_self_add
-  _ = 3 * 2 ^ (12 * (a : ℝ)) * (2 : ℝ≥0∞) ^ (151 * (a : ℝ) ^ 3) := by
-    rw [add_comm, ENNReal.rpow_add _ _ two_ne_zero ENNReal.ofNat_ne_top]; ring
-  _ ≤ (2 : ℝ≥0∞) ^ ((a : ℝ) ^ 3) * (2 : ℝ≥0∞) ^ (151 * (a : ℝ) ^ 3) := by
-    apply mul_right_mono
-    norm_cast
-    calc 3 * 2 ^ (12 * a)
+  _ = 3 * 2 ^ (12 * a) * 2 ^ (151 * a ^ 3) := by rw [add_comm, pow_add]; ring
+  _ ≤ 2 ^ (a ^ 3) * 2 ^ (151 * a ^ 3) := by
+    apply mul_right_mono; norm_cast
+    calc
       _ ≤ 2 ^ 2 * 2 ^ (12 * a) := by gcongr; norm_num
       _ = 2 ^ (2 + 12 * a)     := by rw [pow_add]
       _ ≤ 2 ^ (a ^ 3)          := pow_le_pow_right₀ one_le_two <| calc 2 + 12 * a
@@ -777,10 +776,7 @@ private lemma le_C7_2_1 {a : ℕ} (ha : 4 ≤ a) :
         _ = 13 * a     := by ring
         _ ≤ a ^ 2 * a  := by rw [mul_le_mul_right] <;> nlinarith
         _ = a ^ 3      := rfl
-  _ = _ := by
-    rw [C7_2_1_def, ← ENNReal.rpow_add _ _ two_ne_zero ENNReal.ofNat_ne_top]
-    norm_cast
-    ring
+  _ = _ := by rw [C7_2_1_def, ← pow_add]; norm_cast; ring
 
 -- Main estimate used in the proof of `tree_projection_estimate`
 private lemma eLpNorm_two_cS_bound_le : eLpNorm (cS_bound t u f) 2 volume ≤

--- a/Carleson/ForestOperator/LargeSeparation.lean
+++ b/Carleson/ForestOperator/LargeSeparation.lean
@@ -553,8 +553,7 @@ lemma holder_correlation_tile_one
         ENNReal.mul_comm_div, ← mul_div_assoc, ← mul_assoc, mul_comm (2 ^ (3 * a))]
     _ ≤ _ := by
       gcongr; rw [C2_1_3, C7_5_5]; norm_cast
-      simp_rw [Nat.cast_pow, NNReal.rpow_natCast, Nat.cast_ofNat,
-        show (4 : ℝ≥0) = 2 ^ 2 by norm_num, ← pow_add]
+      simp_rw [show 4 = 2 ^ 2 by norm_num, ← pow_add]
       apply pow_le_pow_right' one_le_two
       calc
         _ = 102 * a ^ 3 + 3 * a * 1 * 1 + 2 * 1 * 1 * 1 := by norm_num
@@ -803,18 +802,17 @@ lemma holder_correlation_tile_two (hu : u ∈ t) (hp : p ∈ t u) (hf : BoundedC
       exact coe_nnreal_ennreal_nndist ..
     _ ≤ _ := by
       gcongr; rw [C2_1_3, D2_1_3, C7_5_5, Q7_5_5]; norm_cast
-      simp_rw [NNReal.rpow_natCast, Nat.cast_mul, Nat.cast_pow, Nat.cast_ofNat]
       calc
-        _ ≤ (2 : ℝ≥0) ^ (3 * a) *
+        _ ≤ 2 ^ (3 * a) *
             (2 ^ (102 * a ^ 3) * (2 ^ 4 * 2 ^ (6 * a)) + 2 ^ (150 * a ^ 3)) := by gcongr; norm_num
-        _ ≤ (2 : ℝ≥0) ^ (3 * a) * (2 ^ (150 * a ^ 3) + 2 ^ (150 * a ^ 3)) := by
+        _ ≤ 2 ^ (3 * a) * (2 ^ (150 * a ^ 3) + 2 ^ (150 * a ^ 3)) := by
           gcongr; rw [← pow_add, ← pow_add]; apply pow_le_pow_right' one_le_two
           calc
             _ = 102 * a ^ 3 + 4 * 1 * 1 * 1 + 6 * a * 1 * 1 := by ring
             _ ≤ 102 * a ^ 3 + 4 * a * a * a + 6 * a * a * a := by gcongr <;> linarith [four_le_a X]
             _ = 112 * a ^ 3 := by ring
             _ ≤ _ := by gcongr; norm_num
-        _ = (2 : ℝ≥0) ^ (150 * a ^ 3 + (3 * a + 1)) := by
+        _ = 2 ^ (150 * a ^ 3 + (3 * a + 1)) := by
           rw [← two_mul, ← pow_succ', ← pow_add]; ring
         _ ≤ _ := by
           apply pow_le_pow_right' one_le_two
@@ -1059,7 +1057,7 @@ lemma local_tree_control_sup_bound {k : ℤ} (mk : k ∈ Finset.Icc (s J) (s J +
       rw [ENNReal.div_eq_inv_mul, ENNReal.inv_div (by left; norm_num) (by left; positivity),
         ← ENNReal.mul_div_right_comm, mp.1, ENNReal.div_eq_inv_mul, mul_comm]
       gcongr; unfold C2_1_3; norm_cast
-      simp_rw [NNReal.rpow_natCast, Nat.cast_pow, Nat.cast_ofNat, ← pow_add]
+      simp_rw [← pow_add]
       refine pow_le_pow_right' one_le_two ?_
       rw [show 103 * a ^ 3 = a * a * a + 102 * a ^ 3 by ring]; gcongr; nlinarith [four_le_a X]
 

--- a/Carleson/ForestOperator/PointwiseEstimate.lean
+++ b/Carleson/ForestOperator/PointwiseEstimate.lean
@@ -336,7 +336,7 @@ lemma pairwiseDisjoint_𝓛 : (𝓛 𝔖).PairwiseDisjoint (fun I ↦ (I : Set X
 /-- The constant used in `first_tree_pointwise`.
 Has value `10 * 2 ^ (104 * a ^ 3)` in the blueprint. -/
 -- Todo: define this recursively in terms of previous constants
-irreducible_def C7_1_4 (a : ℕ) : ℝ≥0 := 10 * 2 ^ (104 * (a : ℝ) ^ 3)
+irreducible_def C7_1_4 (a : ℕ) : ℝ≥0 := 10 * 2 ^ (104 * a ^ 3)
 
 -- Used in the proof of `exp_sub_one_le`, which is used to prove Lemma 7.1.4
 private lemma exp_Lipschitz : LipschitzWith 1 (fun (t : ℝ) ↦ exp (.I * t)) := by
@@ -601,9 +601,7 @@ lemma first_tree_pointwise (hu : u ∈ t) (hL : L ∈ 𝓛 (t u)) (hx : x ∈ L)
     rw [← Finset.mul_sum]
     apply le_trans <| mul_le_mul_left' (L7_1_4_sum hσ) _
     rw [mul_comm _ 2, ← mul_assoc, ← mul_assoc, C7_1_4]
-    gcongr
-    · norm_num
-    · exact_mod_cast pow_le_pow_right₀ one_le_two (le_refl _)
+    gcongr; norm_num
   intro s hs
   have eq1 : ∫ (y : X), ‖(cexp (I * (q y)) - 1) * Ks s x y * f y‖ =
       ∫ y in ball x (D ^ s / 2), ‖(cexp (I * (q y)) - 1) * Ks s x y * f y‖ := by
@@ -737,7 +735,7 @@ lemma second_tree_pointwise (hu : u ∈ t) (hL : L ∈ 𝓛 (t u)) (hx : x ∈ L
 /-- The constant used in `third_tree_pointwise`.
 Has value `2 ^ (151 * a ^ 3)` in the blueprint. -/
 -- Todo: define this recursively in terms of previous constants
-irreducible_def C7_1_6 (a : ℕ) : ℝ≥0 := 2 ^ (151 * (a : ℝ) ^ 3)
+irreducible_def C7_1_6 (a : ℕ) : ℝ≥0 := 2 ^ (151 * a ^ 3)
 
 -- Used in the proof of Lemmas 7.1.3 and 7.1.6 to translate between `∑ p` into `∑ s`
 open scoped Classical in
@@ -945,7 +943,7 @@ lemma third_tree_pointwise (hu : u ∈ t) (hL : L ∈ 𝓛 (t u)) (hx : x ∈ L)
           Real.toNNReal ((D2_1_3 a) / (volume.real (ball x (D ^ s I))) * 2 ^ (3 / (a : ℝ)) *
           ∑ J ∈ 𝓙' t u (c I) (s I), D ^ ((s J - s I) / (a : ℝ)) * ∫ y in J, ‖f y‖)) := by
       let summand := fun (y : X) (i : ℤ) ↦
-          ((D2_1_3 (a : ℝ≥0)) / volume.real (ball x (D ^ i)) * 2 ^ (3 / (a : ℝ)) *
+          ((D2_1_3 a) / volume.real (ball x (D ^ i)) * 2 ^ (3 / (a : ℝ)) *
           ∑ J ∈ 𝓙' t u y i, D ^ (((s J) - (i : ℝ)) / a) * ∫ y in J, ‖f y‖).toNNReal
       exact congrArg ENNReal.ofNNReal <| sum_p_eq_sum_I_sum_p t u x summand
     _ ≤ ENNReal.ofNNReal (∑ I : Grid X, ∑ p ∈ ps I, (E p).indicator 1 x *
@@ -1011,8 +1009,6 @@ lemma third_tree_pointwise (hu : u ∈ t) (hL : L ∈ 𝓛 (t u)) (hx : x ∈ L)
       _ = (2 : ℝ) ^ (150 * a ^ 3 + 5 * a + 3 / a : ℝ) := by
         rw [Real.rpow_add two_pos, Real.rpow_add two_pos, mul_comm 5, Real.rpow_mul two_pos.le a 5]
         norm_cast
-        congr
-        norm_cast
       _ ≤ (2 : ℝ) ^ (151 * a ^ 3) := by
         have : ((151 * a ^ 3 : ℕ) : ℝ) = (151 : ℝ) * (a : ℝ) ^ 3 := by norm_cast
         rw [← Real.rpow_natCast 2, Real.rpow_le_rpow_left_iff one_lt_two, this]
@@ -1036,26 +1032,24 @@ lemma third_tree_pointwise (hu : u ∈ t) (hL : L ∈ 𝓛 (t u)) (hx : x ∈ L)
         ← Real.toNNReal_pow two_pos.le, ← Real.toNNReal_mul (by positivity), ← mul_assoc,
         div_eq_mul_one_div]
     _ = _ := by
+      rw [C7_1_6]; congr
+      simp_rw [← indicator_mul_const, Pi.one_apply, one_mul, ENNReal.coe_finset_sum,
+        ENNReal.coe_indicator]
+      apply Finset.sum_congr rfl (fun I _ ↦ ?_)
       congr
-      · rw [C7_1_6_def]; norm_cast
-      · simp_rw [← indicator_mul_const, Pi.one_apply, one_mul, ENNReal.coe_finset_sum,
-          ENNReal.coe_indicator]
-        apply Finset.sum_congr rfl (fun I _ ↦ ?_)
-        congr
-        ext
-        rw [Finset.mul_sum, ENNReal.ofNNReal_toNNReal]
-        rw [ENNReal.ofReal_sum_of_nonneg (fun _ _ ↦ by positivity)]
-        refine Finset.sum_congr rfl (fun J hJ ↦ ?_)
-        repeat rw [ENNReal.ofReal_mul (by positivity)]
-        rw [ENNReal.ofReal_div_of_pos, ENNReal.ofReal_one, ← mul_assoc]; swap
-        · exact measure_real_ball_pos (c I) <| mul_pos (by norm_num) (defaultD_pow_pos a (s I))
-        rw [← ENNReal.mul_div_right_comm, one_mul]
-        congr
-        · rw [← ENNReal.ofReal_rpow_of_pos (defaultD_pos a)]
-          norm_cast
-        · rw [Measure.real, ENNReal.ofReal_toReal measure_ball_ne_top]
-        · exact integral_eq_lintegral_approxOnCube pairwiseDisjoint_𝓙 (mem_𝓙_of_mem_𝓙' hJ) hf
-
+      ext
+      rw [Finset.mul_sum, ENNReal.ofNNReal_toNNReal]
+      rw [ENNReal.ofReal_sum_of_nonneg (fun _ _ ↦ by positivity)]
+      refine Finset.sum_congr rfl (fun J hJ ↦ ?_)
+      repeat rw [ENNReal.ofReal_mul (by positivity)]
+      rw [ENNReal.ofReal_div_of_pos, ENNReal.ofReal_one, ← mul_assoc]; swap
+      · exact measure_real_ball_pos (c I) <| mul_pos (by norm_num) (defaultD_pow_pos a (s I))
+      rw [← ENNReal.mul_div_right_comm, one_mul]
+      congr
+      · rw [← ENNReal.ofReal_rpow_of_pos (defaultD_pos a)]
+        norm_cast
+      · rw [Measure.real, ENNReal.ofReal_toReal measure_ball_ne_top]
+      · exact integral_eq_lintegral_approxOnCube pairwiseDisjoint_𝓙 (mem_𝓙_of_mem_𝓙' hJ) hf
 
 /-- The constant used in `pointwise_tree_estimate`.
 Has value `2 ^ (151 * a ^ 3)` in the blueprint. -/
@@ -1063,16 +1057,16 @@ irreducible_def C7_1_3 (a : ℕ) : ℝ≥0 := max (C7_1_4 a) (C7_1_6 a) --2 ^ (1
 
 lemma C7_1_3_eq_C7_1_6 {a : ℕ} (ha : 4 ≤ a) : C7_1_3 a = C7_1_6 a := by
   rw [C7_1_3_def, C7_1_6_def, sup_eq_right]
-  have : C7_1_4 a ≤ 2 ^ (4 : ℝ) * 2 ^ (104 * (a : ℝ) ^ 3) := by rw [C7_1_4_def]; gcongr; norm_num
+  have : C7_1_4 a ≤ 2 ^ 4 * 2 ^ (104 * a ^ 3) := by rw [C7_1_4_def]; gcongr; norm_num
   apply this.trans
-  rw [← NNReal.rpow_add two_ne_zero]
+  rw [← pow_add]
   gcongr
   · exact one_le_two
   · calc
-      4 + 104 * (a : ℝ) ^ 3 ≤ 4 ^ 3 + 104 * (a : ℝ) ^ 3 := by gcongr; norm_num
-      _                     ≤ a ^ 3 + 104 * (a : ℝ) ^ 3 := by gcongr; exact_mod_cast ha
-      _                     = 105 * (a : ℝ) ^ 3         := by ring
-      _                     ≤ _                         := by gcongr; norm_num
+      _ ≤ 4 ^ 3 + 104 * a ^ 3 := by gcongr; norm_num
+      _ ≤ a ^ 3 + 104 * a ^ 3 := by gcongr
+      _ = 105 * a ^ 3 := by ring
+      _ ≤ _ := by gcongr; norm_num
 
 /-- Lemma 7.1.3. -/
 lemma pointwise_tree_estimate (hu : u ∈ t) (hL : L ∈ 𝓛 (t u)) (hx : x ∈ L) (hx' : x' ∈ L)


### PR DESCRIPTION
The first commit fills in the last sorry in Lemma 6.1.5's proof. To facilitate the cleanup, in the second commit I changed some exponents appearing in constants to be `ℕ`-valued rather than `ℝ`- or `ℝ≥0`-valued, where such a change was possible:
```lean
/-- The constant appearing in part 3 of Lemma 2.1.3. -/
def D2_1_3 (a : ℕ) : ℝ≥0 := 2 ^ (150 * a ^ 3)
```
Overall this leads to fewer extra assumptions that need to be proven and fewer type conversion steps.