### PR TITLE
Fix definition of GeneralCase (partial progress on Lemma 10.2.5)

### DIFF
--- a/Carleson/TwoSidedCarleson/WeakCalderonZygmund.lean
+++ b/Carleson/TwoSidedCarleson/WeakCalderonZygmund.lean
@@ -215,6 +215,7 @@ lemma iUnion_czPartition (ha : 4 ≤ a) {hX : GeneralCase f α} :
     simp_all
 
 open scoped Classical in
+variable (f) in
 /-- The function `g` in Lemma 10.2.5. (both cases) -/
 def czApproximation (ha : 4 ≤ a) (α : ℝ≥0∞) (x : X) : ℂ :=
   if hX : GeneralCase f α then
@@ -223,60 +224,61 @@ def czApproximation (ha : 4 ≤ a) (α : ℝ≥0∞) (x : X) : ℂ :=
 
 lemma czApproximation_def_of_mem (ha : 4 ≤ a) {hX : GeneralCase f α} {x : X}
     {i : ℕ} (hx : x ∈ czPartition ha hX i) :
-    czApproximation (f := f) ha α x = ⨍ y in czPartition ha hX i, f y := by
+    czApproximation f ha α x = ⨍ y in czPartition ha hX i, f y := by
   have : ∃ i, x ∈ czPartition ha hX i := ⟨i, hx⟩
   simp [czApproximation, hX, this, czPartition_pairwiseDisjoint' ha this.choose_spec hx]
 
 lemma czApproximation_def_of_notMem (ha : 4 ≤ a) {x : X} (hX : GeneralCase f α)
     (hx : x ∉ globalMaximalFunction volume 1 f ⁻¹' Ioi α) :
-    czApproximation (f := f) ha α x = f x := by
+    czApproximation f ha α x = f x := by
   rw [← iUnion_czPartition ha (hX := hX), mem_iUnion, not_exists] at hx
   simp only [czApproximation, hX, ↓reduceDIte, hx, exists_const]
 
 lemma czApproximation_def_of_volume_lt (ha : 4 ≤ a) {x : X}
-    (hX : ¬ GeneralCase f α) : czApproximation (f := f) ha α x = ⨍ y, f y := by
+    (hX : ¬ GeneralCase f α) : czApproximation f ha α x = ⨍ y, f y := by
   simp [czApproximation, hX]
 
 /-- The function `b_i` in Lemma 10.2.5 (general case). -/
 def czRemainder' (ha : 4 ≤ a) (hX : GeneralCase f α) (i : ℕ) (x : X) : ℂ :=
-  (czPartition ha hX i).indicator (f - czApproximation (f := f) ha α) x
+  (czPartition ha hX i).indicator (f - czApproximation f ha α) x
 
+variable (f) in
 /-- The function `b = ∑ⱼ bⱼ` introduced below Lemma 10.2.5.
 In the finite case, we also use this as the function `b = b₁` in Lemma 10.2.5.
 We choose a more convenient definition, but prove in `tsum_czRemainder'` that this is the same. -/
 def czRemainder (ha : 4 ≤ a) (α : ℝ≥0∞) (x : X) : ℂ :=
-  f x - czApproximation (f := f) ha α x
+  f x - czApproximation f ha α x
 
 /-- Part of Lemma 10.2.5, this is essentially (10.2.16) (both cases). -/
 def tsum_czRemainder' (ha : 4 ≤ a) (hf : BoundedFiniteSupport f) (hX : GeneralCase f α) (x : X) :
-    ∑ᶠ i, czRemainder' ha hX i x = czRemainder (f := f) ha α x := by
+    ∑ᶠ i, czRemainder' ha hX i x = czRemainder f ha α x := by
   sorry
 
 /-- Part of Lemma 10.2.5 (both cases). -/
 lemma measurable_czApproximation (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} :
-    Measurable (czApproximation (f := f) ha α) := by
+    Measurable (czApproximation f ha α) := by
   sorry
 
 /-- Part of Lemma 10.2.5, equation (10.2.16) (both cases).
 This is true by definition, the work lies in `tsum_czRemainder'` -/
 lemma czApproximation_add_czRemainder (ha : 4 ≤ a) {x : X} :
-    czApproximation (f := f) ha α x + czRemainder (f := f) ha α x = f x := by
+    czApproximation f ha α x + czRemainder f ha α x = f x := by
   simp [czApproximation, czRemainder]
 
 /-- Part of Lemma 10.2.5, equation (10.2.17) (both cases). -/
 lemma norm_czApproximation_le (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} (hα : ⨍⁻ x, ‖f x‖ₑ < α) :
-    ∀ᵐ x, ‖czApproximation (f := f) ha α x‖ₑ ≤ 2 ^ (3 * a) * α := by
+    ∀ᵐ x, ‖czApproximation f ha α x‖ₑ ≤ 2 ^ (3 * a) * α := by
   sorry
 
 /-- Equation (10.2.17) specialized to the general case. -/
 lemma norm_czApproximation_le_infinite (ha : 4 ≤ a) {hf : BoundedFiniteSupport f}
     (hX : GeneralCase f α) (hα : 0 < α) :
-    ∀ᵐ x, ‖czApproximation (f := f) ha α x‖ₑ ≤ 2 ^ (3 * a) * α := by
+    ∀ᵐ x, ‖czApproximation f ha α x‖ₑ ≤ 2 ^ (3 * a) * α := by
   sorry
 
 /-- Part of Lemma 10.2.5, equation (10.2.18) (both cases). -/
 lemma eLpNorm_czApproximation_le (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} (hα : 0 < α) :
-    eLpNorm (czApproximation (f := f) ha α) 1 volume ≤ eLpNorm f 1 volume := by
+    eLpNorm (czApproximation f ha α) 1 volume ≤ eLpNorm f 1 volume := by
   sorry
 
 /-- Part of Lemma 10.2.5, equation (10.2.19) (general case). -/
@@ -293,7 +295,7 @@ lemma integral_czRemainder' (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} {hX : G
 
 /-- Part of Lemma 10.2.5, equation (10.2.20) (finite case). -/
 lemma integral_czRemainder (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} (hX : ¬ GeneralCase f α) (hα : 0 < α) :
-    ∫ x, czRemainder (f := f) ha α x = 0 := by
+    ∫ x, czRemainder f ha α x = 0 := by
   sorry
 
 /-- Part of Lemma 10.2.5, equation (10.2.21) (general case). -/
@@ -305,7 +307,7 @@ lemma eLpNorm_czRemainder'_le (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} {hX :
 /-- Part of Lemma 10.2.5, equation (10.2.21) (finite case). -/
 lemma eLpNorm_czRemainder_le (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} (hX : ¬ GeneralCase f α)
     (hα : 0 < α) :
-    eLpNorm (czRemainder (f := f) ha α) 1 volume ≤ 2 ^ (2 * a + 1) * α * volume (univ : Set X) := by
+    eLpNorm (czRemainder f ha α) 1 volume ≤ 2 ^ (2 * a + 1) * α * volume (univ : Set X) := by
   sorry
 
 /-- Part of Lemma 10.2.5, equation (10.2.22) (general case). -/
@@ -329,7 +331,7 @@ lemma tsum_eLpNorm_czRemainder'_le (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} 
 /-- Part of Lemma 10.2.5, equation (10.2.23) (finite case). -/
 lemma tsum_eLpNorm_czRemainder_le (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} (hX : ¬ GeneralCase f α)
     (hα : 0 < α) :
-    eLpNorm (czRemainder (f := f) ha α) 1 volume ≤ 2 * eLpNorm f 1 volume := by
+    eLpNorm (czRemainder f ha α) 1 volume ≤ 2 * eLpNorm f 1 volume := by
   sorry
 
 /- ### Lemmas 10.2.6 - 10.2.9 -/
@@ -338,6 +340,7 @@ lemma tsum_eLpNorm_czRemainder_le (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} (
 irreducible_def c10_0_3 (a : ℕ) : ℝ≥0 := (2 ^ (a ^ 3 + 12 * a + 4))⁻¹
 
 open scoped Classical in
+variable (f) in
 /-- The set `Ω` introduced below Lemma 10.2.5. -/
 def Ω (ha : 4 ≤ a) (α : ℝ≥0∞) : Set X :=
   if hX : GeneralCase f α then ⋃ i, czBall2 ha hX i else univ
@@ -347,7 +350,7 @@ irreducible_def C10_2_6 (a : ℕ) : ℝ≥0 := 2 ^ (2 * a ^ 3 + 3 * a + 2) * c10
 
 /-- Lemma 10.2.6 -/
 lemma estimate_good (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} (hα : ⨍⁻ x, ‖f x‖ₑ / c10_0_3 a < α) :
-    distribution (czOperator K r (czApproximation (f := f) ha α)) (α / 2) volume ≤
+    distribution (czOperator K r (czApproximation f ha α)) (α / 2) volume ≤
     C10_2_6 a / α * eLpNorm f 1 volume := by
   sorry
 
@@ -363,8 +366,8 @@ def czOperatorBound (ha : 4 ≤ a) (hX : GeneralCase f α) (x : X) : ℝ≥0∞ 
 Note that `hx` implies `hX`, but we keep the superfluous hypothesis to shorten the statement. -/
 lemma estimate_bad_partial (ha : 4 ≤ a) {hf : BoundedFiniteSupport f}
     (hα : ⨍⁻ x, ‖f x‖ₑ / c10_0_3 a < α)
-    (hx : x ∈ (Ω (f := f) ha α)ᶜ) (hX : GeneralCase f α) :
-    ‖czOperator K r (czRemainder (f := f) ha α) x‖ₑ ≤ 3 * czOperatorBound ha hX x + α / 8 := by
+    (hx : x ∈ (Ω f ha α)ᶜ) (hX : GeneralCase f α) :
+    ‖czOperator K r (czRemainder f ha α) x‖ₑ ≤ 3 * czOperatorBound ha hX x + α / 8 := by
   sorry
 
 /-- The constant used in `distribution_czOperatorBound`. -/
@@ -373,7 +376,7 @@ irreducible_def C10_2_8 (a : ℕ) : ℝ≥0 := 2 ^ (a ^ 3 + 9 * a + 4)
 /-- Lemma 10.2.8 -/
 lemma distribution_czOperatorBound (ha : 4 ≤ a) {hf : BoundedFiniteSupport f}
     (hα : ⨍⁻ x, ‖f x‖ₑ / c10_0_3 a < α) (hX : GeneralCase f α) :
-    volume ((Ω (f := f) ha α)ᶜ ∩ czOperatorBound ha hX ⁻¹' Ioi (α / 8)) ≤
+    volume ((Ω f ha α)ᶜ ∩ czOperatorBound ha hX ⁻¹' Ioi (α / 8)) ≤
     C10_2_8 a / α * eLpNorm f 1 volume := by
   sorry
 
@@ -384,7 +387,7 @@ irreducible_def C10_2_9 (a : ℕ) : ℝ≥0 := 2 ^ (5 * a) / c10_0_3 a + 2 ^ (a 
 -- In the proof, case on `GeneralCase f α`, noting in the finite case that `Ω = univ`
 lemma estimate_bad (ha : 4 ≤ a) {hf : BoundedFiniteSupport f}
     (hα : ⨍⁻ x, ‖f x‖ₑ / c10_0_3 a < α) (hX : GeneralCase f α) :
-    distribution (czOperator K r (czRemainder (f := f) ha α)) (α / 2) volume ≤
+    distribution (czOperator K r (czRemainder f ha α)) (α / 2) volume ≤
     C10_2_9 a / α * eLpNorm f 1 volume := by
   sorry
 

--- a/Carleson/TwoSidedCarleson/WeakCalderonZygmund.lean
+++ b/Carleson/TwoSidedCarleson/WeakCalderonZygmund.lean
@@ -355,7 +355,7 @@ lemma estimate_good (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} (hα : ⨍⁻ x
 irreducible_def C10_2_7 (a : ℕ) : ℝ≥0 := 2 ^ (a ^ 3 + 2 * a + 1) * c10_0_3 a
 
 /-- The function `F` defined in Lemma 10.2.7. -/
-def czOperatorBound (ha : 4 ≤ a) (hf : BoundedFiniteSupport f) (hX : GeneralCase f α) (x : X) : ℝ≥0∞ :=
+def czOperatorBound (ha : 4 ≤ a) (hX : GeneralCase f α) (x : X) : ℝ≥0∞ :=
   C10_2_7 a * α * ∑' i, ((czRadius ha hX i).toNNReal / nndist x (czCenter ha hX i)) ^ (a : ℝ)⁻¹ *
     volume (czBall3 ha hX i) / volume (ball x (dist x (czCenter ha hX i)))
 
@@ -364,7 +364,7 @@ Note that `hx` implies `hX`, but we keep the superfluous hypothesis to shorten t
 lemma estimate_bad_partial (ha : 4 ≤ a) {hf : BoundedFiniteSupport f}
     (hα : ⨍⁻ x, ‖f x‖ₑ / c10_0_3 a < α)
     (hx : x ∈ (Ω (f := f) ha α)ᶜ) (hX : GeneralCase f α) :
-    ‖czOperator K r (czRemainder (f := f) ha α) x‖ₑ ≤ 3 * czOperatorBound ha hf hX x + α / 8 := by
+    ‖czOperator K r (czRemainder (f := f) ha α) x‖ₑ ≤ 3 * czOperatorBound ha hX x + α / 8 := by
   sorry
 
 /-- The constant used in `distribution_czOperatorBound`. -/
@@ -373,7 +373,7 @@ irreducible_def C10_2_8 (a : ℕ) : ℝ≥0 := 2 ^ (a ^ 3 + 9 * a + 4)
 /-- Lemma 10.2.8 -/
 lemma distribution_czOperatorBound (ha : 4 ≤ a) {hf : BoundedFiniteSupport f}
     (hα : ⨍⁻ x, ‖f x‖ₑ / c10_0_3 a < α) (hX : GeneralCase f α) :
-    volume ((Ω (f := f) ha α)ᶜ ∩ czOperatorBound ha hf hX ⁻¹' Ioi (α / 8)) ≤
+    volume ((Ω (f := f) ha α)ᶜ ∩ czOperatorBound ha hX ⁻¹' Ioi (α / 8)) ≤
     C10_2_8 a / α * eLpNorm f 1 volume := by
   sorry
 

--- a/Carleson/TwoSidedCarleson/WeakCalderonZygmund.lean
+++ b/Carleson/TwoSidedCarleson/WeakCalderonZygmund.lean
@@ -74,76 +74,88 @@ We could have tried harder to uniformize the cases, but in the finite case there
 
 /-- The property specifying whether we are in the "general case". -/
 def GeneralCase (f : X → ℂ) (α : ℝ≥0∞) : Prop :=
-  ∃ x, α < globalMaximalFunction (X := X) volume 1 f x
+  ∃ x, α ≥ globalMaximalFunction (X := X) volume 1 f x
 
+omit [IsCancellative X (defaultτ a)] in
 /-- In the finite case, the volume of `X` is finite. -/
-lemma volume_lt_of_not_GeneralCase (h : ¬ GeneralCase f α) : volume (univ : Set X) < ∞ :=
-  sorry -- Use Lemma 10.2.1
+lemma volume_lt_of_not_GeneralCase (hf : BoundedFiniteSupport f) (h : ¬ GeneralCase f α)
+    (hα : 0 < α) : volume (univ : Set X) < ∞ := by
+  simp only [GeneralCase, not_exists, not_le] at h
+  have ne_top : α ≠ ⊤ := have ⟨x⟩ : Nonempty X := inferInstance; (h x).ne_top
+  have ineq := (maximal_theorem f hf).2
+  simp only [wnorm, one_ne_top, reduceIte, wnorm', distribution, toReal_one, inv_one, rpow_one,
+    iSup_le_iff] at ineq
+  rw [← eq_univ_iff_forall.mpr fun x ↦ (coe_toNNReal ne_top) ▸ h x]
+  refine lt_top_of_mul_ne_top_right ?_ (coe_ne_zero.mpr (toNNReal_ne_zero.mpr ⟨hα.ne.symm, ne_top⟩))
+  refine (lt_of_le_of_lt (ineq α.toNNReal) ?_).ne
+  exact mul_lt_top (by norm_num) <| (BoundedFiniteSupport.memLp hf 1).eLpNorm_lt_top
 
-/- Use `lowerSemiContinuous_globalMaximalFunction` for part 1. -/
-lemma isOpen_MB_preimage_Ioi (hf : BoundedFiniteSupport f) (hX : GeneralCase f α) :
+omit [CompatibleFunctions ℝ X (defaultA a)] [IsCancellative X (defaultτ a)] in
+lemma isOpen_MB_preimage_Ioi (hX : GeneralCase f α) :
     IsOpen (globalMaximalFunction (X := X) volume 1 f ⁻¹' Ioi α) ∧
-    globalMaximalFunction (X := X) volume 1 f ⁻¹' Ioi α ≠ univ := by
-  sorry
+    globalMaximalFunction (X := X) volume 1 f ⁻¹' Ioi α ≠ univ :=
+  have ⟨x, hx⟩ := hX
+  ⟨lowerSemiContinuous_globalMaximalFunction.isOpen_preimage _,
+    (Set.ne_univ_iff_exists_notMem _).mpr ⟨x, by simpa using hx⟩⟩
 
 /-- The center of B_j in the proof of Lemma 10.2.5 (general case). -/
-def czCenter (ha : 4 ≤ a) (hf : BoundedFiniteSupport f) (hX : GeneralCase f α) (i : ℕ) : X :=
-  ball_covering ha (isOpen_MB_preimage_Ioi hf hX) |>.choose i
+def czCenter (ha : 4 ≤ a) (hX : GeneralCase f α) (i : ℕ) : X :=
+  ball_covering ha (isOpen_MB_preimage_Ioi hX) |>.choose i
 
 /-- The radius of B_j in the proof of Lemma 10.2.5 (general case). -/
-def czRadius (ha : 4 ≤ a) (hf : BoundedFiniteSupport f) (hX : GeneralCase f α) (i : ℕ) : ℝ :=
-  ball_covering ha (isOpen_MB_preimage_Ioi hf hX) |>.choose_spec.choose i
+def czRadius (ha : 4 ≤ a) (hX : GeneralCase f α) (i : ℕ) : ℝ :=
+  ball_covering ha (isOpen_MB_preimage_Ioi hX) |>.choose_spec.choose i
 
 /-- The ball B_j in the proof of Lemma 10.2.5 (general case). -/
-abbrev czBall (ha : 4 ≤ a) (hf : BoundedFiniteSupport f) (hX : GeneralCase f α) (i : ℕ) : Set X :=
-  ball (czCenter ha hf hX i) (czRadius ha hf hX i)
+abbrev czBall (ha : 4 ≤ a) (hX : GeneralCase f α) (i : ℕ) : Set X :=
+  ball (czCenter ha hX i) (czRadius ha hX i)
 
 /-- The ball B_j' introduced below Lemma 10.2.5 (general case). -/
-abbrev czBall2 (ha : 4 ≤ a) (hf : BoundedFiniteSupport f) (hX : GeneralCase f α) (i : ℕ) : Set X :=
-  ball (czCenter ha hf hX i) (2 * czRadius ha hf hX i)
+abbrev czBall2 (ha : 4 ≤ a) (hX : GeneralCase f α) (i : ℕ) : Set X :=
+  ball (czCenter ha hX i) (2 * czRadius ha hX i)
 
 /-- The ball B_j* in Lemma 10.2.5 (general case). -/
-abbrev czBall3 (ha : 4 ≤ a) (hf : BoundedFiniteSupport f) (hX : GeneralCase f α) (i : ℕ) : Set X :=
-  ball (czCenter ha hf hX i) (3 * czRadius ha hf hX i)
+abbrev czBall3 (ha : 4 ≤ a) (hX : GeneralCase f α) (i : ℕ) : Set X :=
+  ball (czCenter ha hX i) (3 * czRadius ha hX i)
 
 /-- The ball B_j** in the proof of Lemma 10.2.5 (general case). -/
-abbrev czBall7 (ha : 4 ≤ a) (hf : BoundedFiniteSupport f) (hX : GeneralCase f α) (i : ℕ) : Set X :=
-  ball (czCenter ha hf hX i) (7 * czRadius ha hf hX i)
+abbrev czBall7 (ha : 4 ≤ a) (hX : GeneralCase f α) (i : ℕ) : Set X :=
+  ball (czCenter ha hX i) (7 * czRadius ha hX i)
 
-lemma czBall_pairwiseDisjoint (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} {hX : GeneralCase f α} :
-    univ.PairwiseDisjoint fun i ↦ closedBall (czCenter ha hf hX i) (czRadius ha hf hX i) :=
-  ball_covering ha (isOpen_MB_preimage_Ioi hf hX) |>.choose_spec.choose_spec.1
+lemma czBall_pairwiseDisjoint (ha : 4 ≤ a) {hX : GeneralCase f α} :
+    univ.PairwiseDisjoint fun i ↦ closedBall (czCenter ha hX i) (czRadius ha hX i) :=
+  ball_covering ha (isOpen_MB_preimage_Ioi hX) |>.choose_spec.choose_spec.1
 
-lemma iUnion_czBall3 (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} {hX : GeneralCase f α} :
-    ⋃ i, czBall3 ha hf hX i = globalMaximalFunction volume 1 f ⁻¹' Ioi α :=
-  ball_covering ha (isOpen_MB_preimage_Ioi hf hX) |>.choose_spec.choose_spec.2.1
+lemma iUnion_czBall3 (ha : 4 ≤ a) {hX : GeneralCase f α} :
+    ⋃ i, czBall3 ha hX i = globalMaximalFunction volume 1 f ⁻¹' Ioi α :=
+  ball_covering ha (isOpen_MB_preimage_Ioi hX) |>.choose_spec.choose_spec.2.1
 
-lemma not_disjoint_czBall7 (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} {hX : GeneralCase f α} {i : ℕ} :
-    ¬ Disjoint (czBall7 ha hf hX i) (globalMaximalFunction volume 1 f ⁻¹' Ioi α)ᶜ :=
-  ball_covering ha (isOpen_MB_preimage_Ioi hf hX) |>.choose_spec.choose_spec.2.2.1 i
+lemma not_disjoint_czBall7 (ha : 4 ≤ a) {hX : GeneralCase f α} {i : ℕ} :
+    ¬ Disjoint (czBall7 ha hX i) (globalMaximalFunction volume 1 f ⁻¹' Ioi α)ᶜ :=
+  ball_covering ha (isOpen_MB_preimage_Ioi hX) |>.choose_spec.choose_spec.2.2.1 i
 
 /-- Part of Lemma 10.2.5 (general case). -/
-lemma cardinalMk_czBall3_le (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} {hX : GeneralCase f α}
+lemma cardinalMk_czBall3_le (ha : 4 ≤ a) {hX : GeneralCase f α}
     {y : X} (hy : α < globalMaximalFunction volume 1 f y) :
-    Cardinal.mk { i | y ∈ czBall3 ha hf hX i} ≤ (2 ^ (6 * a) : ℕ) :=
-  ball_covering ha (isOpen_MB_preimage_Ioi hf hX) |>.choose_spec.choose_spec.2.2.2 y hy
+    Cardinal.mk { i | y ∈ czBall3 ha hX i} ≤ (2 ^ (6 * a) : ℕ) :=
+  ball_covering ha (isOpen_MB_preimage_Ioi hX) |>.choose_spec.choose_spec.2.2.2 y hy
 
-lemma mem_czBall3_finite (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} {hX : GeneralCase f α} {y : X}
+lemma mem_czBall3_finite (ha : 4 ≤ a) {hX : GeneralCase f α} {y : X}
     (hy : α < globalMaximalFunction volume 1 f y) :
-    { i | y ∈ czBall3 ha hf hX i}.Finite := by
+    { i | y ∈ czBall3 ha hX i}.Finite := by
   rw [← Cardinal.lt_aleph0_iff_set_finite]
   exact lt_of_le_of_lt (cardinalMk_czBall3_le ha hy) (Cardinal.nat_lt_aleph0 _)
 
 /-- `Q_i` in the proof of Lemma 10.2.5 (general case). -/
-def czPartition (ha : 4 ≤ a) (hf : BoundedFiniteSupport f) (hX : GeneralCase f α) (i : ℕ) : Set X :=
-  czBall3 ha hf hX i \ ((⋃ j < i, czPartition ha hf hX j) ∪ ⋃ j > i, czBall ha hf hX j)
+def czPartition (ha : 4 ≤ a) (hX : GeneralCase f α) (i : ℕ) : Set X :=
+  czBall3 ha hX i \ ((⋃ j < i, czPartition ha hX j) ∪ ⋃ j > i, czBall ha hX j)
 
-lemma czBall_subset_czPartition (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} {hX : GeneralCase f α} {i : ℕ} :
-    czBall ha hf hX i ⊆ czPartition ha hf hX i := by
+lemma czBall_subset_czPartition (ha : 4 ≤ a) {hX : GeneralCase f α} {i : ℕ} :
+    czBall ha hX i ⊆ czPartition ha hX i := by
   intro r hr
   rw [czPartition]
   refine mem_diff_of_mem ?_ ?_
-  · have : dist r (czCenter ha hf hX i) ≥ 0 := dist_nonneg
+  · have : dist r (czCenter ha hX i) ≥ 0 := dist_nonneg
     simp_all only [mem_ball]
     linarith
   · rw [mem_ball] at hr
@@ -153,153 +165,153 @@ lemma czBall_subset_czPartition (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} {hX
       simp only [mem_diff, mem_ball, mem_union, mem_iUnion, not_or, not_and, not_forall, not_not]
       exact fun _ _ _ _ ↦ by use i
     · intro x hx
-      have := pairwiseDisjoint_iff.mp <| czBall_pairwiseDisjoint ha (hf := hf) (hX := hX)
+      have := pairwiseDisjoint_iff.mp <| czBall_pairwiseDisjoint ha (hX := hX)
       simp only [mem_univ, forall_const] at this
       have := (disjoint_or_nonempty_inter _ _).resolve_right <| (@this i x).mt (by omega)
       exact le_of_not_ge <| mem_closedBall.mpr.mt <| disjoint_left.mp this hr.le
 
-lemma czPartition_subset_czBall3 (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} {hX : GeneralCase f α} {i : ℕ} :
-    czPartition ha hf hX i ⊆ czBall3 ha hf hX i := by
+lemma czPartition_subset_czBall3 (ha : 4 ≤ a) {hX : GeneralCase f α} {i : ℕ} :
+    czPartition ha hX i ⊆ czBall3 ha hX i := by
   rw [czPartition]; exact diff_subset
 
-lemma czPartition_pairwiseDisjoint (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} {hX : GeneralCase f α} :
-    univ.PairwiseDisjoint fun i ↦ czPartition ha hf hX i := by
+lemma czPartition_pairwiseDisjoint (ha : 4 ≤ a) {hX : GeneralCase f α} :
+    univ.PairwiseDisjoint fun i ↦ czPartition ha hX i := by
   simp only [pairwiseDisjoint_iff, mem_univ, forall_const]
   intro i k hik
   have ⟨x, hxi, hxk⟩ := inter_nonempty.mp hik
-  have (t d) (hx : x ∈ czPartition ha hf hX t) (hd : t < d) : x ∉ czPartition ha hf hX d := by
-    have : czPartition ha hf hX t ⊆ ⋃ j < d, czPartition ha hf hX j := subset_biUnion_of_mem hd
+  have (t d) (hx : x ∈ czPartition ha hX t) (hd : t < d) : x ∉ czPartition ha hX d := by
+    have : czPartition ha hX t ⊆ ⋃ j < d, czPartition ha hX j := subset_biUnion_of_mem hd
     rw [czPartition]
     exact notMem_diff_of_mem <| mem_union_left _ (this hx)
   have : _ ∧ _ := ⟨this i k hxi |>.mt (· hxk), this k i hxk |>.mt (· hxi)⟩
   omega
 
-lemma czPartition_pairwiseDisjoint' (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} {hX : GeneralCase f α}
-    {x : X} {i j : ℕ} (hi : x ∈ czPartition ha hf hX i) (hj : x ∈ czPartition ha hf hX j) :
+lemma czPartition_pairwiseDisjoint' (ha : 4 ≤ a) {hX : GeneralCase f α}
+    {x : X} {i j : ℕ} (hi : x ∈ czPartition ha hX i) (hj : x ∈ czPartition ha hX j) :
     i = j := by
-  have := czPartition_pairwiseDisjoint ha (hf := hf) (hX := hX)
+  have := czPartition_pairwiseDisjoint ha (hX := hX)
   apply pairwiseDisjoint_iff.mp this (mem_univ i) (mem_univ j)
   exact inter_nonempty.mp <| .intro x ⟨hi, hj⟩
 
-lemma iUnion_czPartition (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} {hX : GeneralCase f α} :
-    ⋃ i, czPartition ha hf hX i = globalMaximalFunction volume 1 f ⁻¹' Ioi α := by
-  rw [← iUnion_czBall3 ha (hf := hf) (hX := hX)]
+lemma iUnion_czPartition (ha : 4 ≤ a) {hX : GeneralCase f α} :
+    ⋃ i, czPartition ha hX i = globalMaximalFunction volume 1 f ⁻¹' Ioi α := by
+  rw [← iUnion_czBall3 ha (hX := hX)]
   refine ext fun x ↦ ⟨fun hx ↦ ?_, fun hx ↦ ?_⟩
-  · have : ⋃ i, czPartition ha hf hX i ⊆ ⋃ i, czBall3 ha hf hX i := fun y hy ↦
+  · have : ⋃ i, czPartition ha hX i ⊆ ⋃ i, czBall3 ha hX i := fun y hy ↦
       have ⟨r, hr⟩ := mem_iUnion.mp hy
       mem_iUnion_of_mem r (czPartition_subset_czBall3 ha hr)
     exact this hx
   · rw [mem_iUnion] at hx ⊢
     by_contra! hp
     obtain ⟨g, hg⟩ := hx
-    have ⟨t, ht⟩ : ∃ i, x ∈ (⋃ j < i, czPartition ha hf hX j) ∪ ⋃ j > i, czBall ha hf hX j := by
+    have ⟨t, ht⟩ : ∃ i, x ∈ (⋃ j < i, czPartition ha hX j) ∪ ⋃ j > i, czBall ha hX j := by
       by_contra! hb
       absurd hp g
       rw [czPartition, mem_diff]
       exact ⟨hg, hb g⟩
-    have : ⋃ j > t, czBall ha hf hX j ⊆ ⋃ j > t, czPartition ha hf hX j :=
+    have : ⋃ j > t, czBall ha hX j ⊆ ⋃ j > t, czPartition ha hX j :=
       iUnion₂_mono fun i j ↦ czBall_subset_czPartition ha (i := i)
     have := (mem_or_mem_of_mem_union ht).imp_right (this ·)
     simp_all
 
 open scoped Classical in
 /-- The function `g` in Lemma 10.2.5. (both cases) -/
-def czApproximation (ha : 4 ≤ a) (hf : BoundedFiniteSupport f) (α : ℝ≥0∞) (x : X) : ℂ :=
+def czApproximation (ha : 4 ≤ a) (α : ℝ≥0∞) (x : X) : ℂ :=
   if hX : GeneralCase f α then
-    if hx : ∃ j, x ∈ czPartition ha hf hX j then ⨍ y in czPartition ha hf hX hx.choose, f y else f x
+    if hx : ∃ j, x ∈ czPartition ha hX j then ⨍ y in czPartition ha hX hx.choose, f y else f x
   else ⨍ y, f y
 
-lemma czApproximation_def_of_mem (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} {hX : GeneralCase f α} {x : X}
-    {i : ℕ} (hx : x ∈ czPartition ha hf hX i) :
-    czApproximation ha hf α x = ⨍ y in czPartition ha hf hX i, f y := by
-  have : ∃ i, x ∈ czPartition ha hf hX i := ⟨i, hx⟩
+lemma czApproximation_def_of_mem (ha : 4 ≤ a) {hX : GeneralCase f α} {x : X}
+    {i : ℕ} (hx : x ∈ czPartition ha hX i) :
+    czApproximation (f := f) ha α x = ⨍ y in czPartition ha hX i, f y := by
+  have : ∃ i, x ∈ czPartition ha hX i := ⟨i, hx⟩
   simp [czApproximation, hX, this, czPartition_pairwiseDisjoint' ha this.choose_spec hx]
 
-lemma czApproximation_def_of_notMem (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} {x : X} (hX : GeneralCase f α)
+lemma czApproximation_def_of_notMem (ha : 4 ≤ a) {x : X} (hX : GeneralCase f α)
     (hx : x ∉ globalMaximalFunction volume 1 f ⁻¹' Ioi α) :
-    czApproximation ha hf α x = f x := by
-  rw [← iUnion_czPartition ha (hf := hf) (hX := hX), mem_iUnion, not_exists] at hx
+    czApproximation (f := f) ha α x = f x := by
+  rw [← iUnion_czPartition ha (hX := hX), mem_iUnion, not_exists] at hx
   simp only [czApproximation, hX, ↓reduceDIte, hx, exists_const]
 
-lemma czApproximation_def_of_volume_lt (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} {x : X}
-    (hX : ¬ GeneralCase f α) : czApproximation ha hf α x = ⨍ y, f y := by
+lemma czApproximation_def_of_volume_lt (ha : 4 ≤ a) {x : X}
+    (hX : ¬ GeneralCase f α) : czApproximation (f := f) ha α x = ⨍ y, f y := by
   simp [czApproximation, hX]
 
 /-- The function `b_i` in Lemma 10.2.5 (general case). -/
-def czRemainder' (ha : 4 ≤ a)(hf : BoundedFiniteSupport f) (hX : GeneralCase f α) (i : ℕ) (x : X) : ℂ :=
-  (czPartition ha hf hX i).indicator (f - czApproximation ha hf α) x
+def czRemainder' (ha : 4 ≤ a) (hX : GeneralCase f α) (i : ℕ) (x : X) : ℂ :=
+  (czPartition ha hX i).indicator (f - czApproximation (f := f) ha α) x
 
 /-- The function `b = ∑ⱼ bⱼ` introduced below Lemma 10.2.5.
 In the finite case, we also use this as the function `b = b₁` in Lemma 10.2.5.
 We choose a more convenient definition, but prove in `tsum_czRemainder'` that this is the same. -/
-def czRemainder (ha : 4 ≤ a) (hf : BoundedFiniteSupport f) (α : ℝ≥0∞) (x : X) : ℂ :=
-  f x - czApproximation ha hf α x
+def czRemainder (ha : 4 ≤ a) (α : ℝ≥0∞) (x : X) : ℂ :=
+  f x - czApproximation (f := f) ha α x
 
 /-- Part of Lemma 10.2.5, this is essentially (10.2.16) (both cases). -/
 def tsum_czRemainder' (ha : 4 ≤ a) (hf : BoundedFiniteSupport f) (hX : GeneralCase f α) (x : X) :
-    ∑ᶠ i, czRemainder' ha hf hX i x = czRemainder ha hf α x := by
+    ∑ᶠ i, czRemainder' ha hX i x = czRemainder (f := f) ha α x := by
   sorry
 
 /-- Part of Lemma 10.2.5 (both cases). -/
 lemma measurable_czApproximation (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} :
-    Measurable (czApproximation ha hf α) := by
+    Measurable (czApproximation (f := f) ha α) := by
   sorry
 
 /-- Part of Lemma 10.2.5, equation (10.2.16) (both cases).
 This is true by definition, the work lies in `tsum_czRemainder'` -/
-lemma czApproximation_add_czRemainder (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} {x : X} :
-    czApproximation ha hf α x + czRemainder ha hf α x = f x := by
+lemma czApproximation_add_czRemainder (ha : 4 ≤ a) {x : X} :
+    czApproximation (f := f) ha α x + czRemainder (f := f) ha α x = f x := by
   simp [czApproximation, czRemainder]
 
 /-- Part of Lemma 10.2.5, equation (10.2.17) (both cases). -/
 lemma norm_czApproximation_le (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} (hα : ⨍⁻ x, ‖f x‖ₑ < α) :
-    ∀ᵐ x, ‖czApproximation ha hf α x‖ₑ ≤ 2 ^ (3 * a) * α := by
+    ∀ᵐ x, ‖czApproximation (f := f) ha α x‖ₑ ≤ 2 ^ (3 * a) * α := by
   sorry
 
 /-- Equation (10.2.17) specialized to the general case. -/
 lemma norm_czApproximation_le_infinite (ha : 4 ≤ a) {hf : BoundedFiniteSupport f}
     (hX : GeneralCase f α) (hα : 0 < α) :
-    ∀ᵐ x, ‖czApproximation ha hf α x‖ₑ ≤ 2 ^ (3 * a) * α := by
+    ∀ᵐ x, ‖czApproximation (f := f) ha α x‖ₑ ≤ 2 ^ (3 * a) * α := by
   sorry
 
 /-- Part of Lemma 10.2.5, equation (10.2.18) (both cases). -/
 lemma eLpNorm_czApproximation_le (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} (hα : 0 < α) :
-    eLpNorm (czApproximation ha hf α) 1 volume ≤ eLpNorm f 1 volume := by
+    eLpNorm (czApproximation (f := f) ha α) 1 volume ≤ eLpNorm f 1 volume := by
   sorry
 
 /-- Part of Lemma 10.2.5, equation (10.2.19) (general case). -/
 lemma support_czRemainder'_subset (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} {hX : GeneralCase f α} (hα : 0 < α)
     {i : ℕ} :
-    support (czRemainder' ha hf hX i) ⊆ czBall3 ha hf hX i := by
+    support (czRemainder' ha hX i) ⊆ czBall3 ha hX i := by
   sorry
 
 /-- Part of Lemma 10.2.5, equation (10.2.20) (general case). -/
 lemma integral_czRemainder' (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} {hX : GeneralCase f α} (hα : 0 < α)
     {i : ℕ} :
-    ∫ x, czRemainder' ha hf hX i x = 0 := by
+    ∫ x, czRemainder' ha hX i x = 0 := by
   sorry
 
 /-- Part of Lemma 10.2.5, equation (10.2.20) (finite case). -/
 lemma integral_czRemainder (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} (hX : ¬ GeneralCase f α) (hα : 0 < α) :
-    ∫ x, czRemainder ha hf α x = 0 := by
+    ∫ x, czRemainder (f := f) ha α x = 0 := by
   sorry
 
 /-- Part of Lemma 10.2.5, equation (10.2.21) (general case). -/
 lemma eLpNorm_czRemainder'_le (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} {hX : GeneralCase f α}
     (hα : 0 < α) {i : ℕ} :
-    eLpNorm (czRemainder' ha hf hX i) 1 volume ≤ 2 ^ (2 * a + 1) * α * volume (czBall3 ha hf hX i) := by
+    eLpNorm (czRemainder' ha hX i) 1 volume ≤ 2 ^ (2 * a + 1) * α * volume (czBall3 ha hX i) := by
   sorry
 
 /-- Part of Lemma 10.2.5, equation (10.2.21) (finite case). -/
 lemma eLpNorm_czRemainder_le (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} (hX : ¬ GeneralCase f α)
     (hα : 0 < α) :
-    eLpNorm (czRemainder ha hf α) 1 volume ≤ 2 ^ (2 * a + 1) * α * volume (univ : Set X) := by
+    eLpNorm (czRemainder (f := f) ha α) 1 volume ≤ 2 ^ (2 * a + 1) * α * volume (univ : Set X) := by
   sorry
 
 /-- Part of Lemma 10.2.5, equation (10.2.22) (general case). -/
 lemma tsum_volume_czBall3_le (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} (hX : GeneralCase f α)
     (hα : 0 < α) :
-    ∑' i, volume (czBall3 ha hf hX i) ≤ 2 ^ (4 * a) / α * eLpNorm f 1 volume := by
+    ∑' i, volume (czBall3 ha hX i) ≤ 2 ^ (4 * a) / α * eLpNorm f 1 volume := by
   sorry
 
 /-- Part of Lemma 10.2.5, equation (10.2.22) (finite case). -/
@@ -311,13 +323,13 @@ lemma volume_univ_le (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} (hX : ¬ Gener
 /-- Part of Lemma 10.2.5, equation (10.2.23) (general case). -/
 lemma tsum_eLpNorm_czRemainder'_le (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} (hX : GeneralCase f α)
     (hα : 0 < α) :
-    ∑' i, eLpNorm (czRemainder' ha hf hX i) 1 volume ≤ 2 * eLpNorm f 1 volume := by
+    ∑' i, eLpNorm (czRemainder' ha hX i) 1 volume ≤ 2 * eLpNorm f 1 volume := by
   sorry
 
 /-- Part of Lemma 10.2.5, equation (10.2.23) (finite case). -/
 lemma tsum_eLpNorm_czRemainder_le (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} (hX : ¬ GeneralCase f α)
     (hα : 0 < α) :
-    eLpNorm (czRemainder ha hf α) 1 volume ≤ 2 * eLpNorm f 1 volume := by
+    eLpNorm (czRemainder (f := f) ha α) 1 volume ≤ 2 * eLpNorm f 1 volume := by
   sorry
 
 /- ### Lemmas 10.2.6 - 10.2.9 -/
@@ -328,14 +340,14 @@ irreducible_def c10_0_3 (a : ℕ) : ℝ≥0 := (2 ^ (a ^ 3 + 12 * a + 4))⁻¹
 open scoped Classical in
 /-- The set `Ω` introduced below Lemma 10.2.5. -/
 def Ω (ha : 4 ≤ a) (hf : BoundedFiniteSupport f) (α : ℝ≥0∞) : Set X :=
-  if hX : GeneralCase f α then ⋃ i, czBall2 ha hf hX i else univ
+  if hX : GeneralCase f α then ⋃ i, czBall2 ha hX i else univ
 
 /-- The constant used in `estimate_good`. -/
 irreducible_def C10_2_6 (a : ℕ) : ℝ≥0 := 2 ^ (2 * a ^ 3 + 3 * a + 2) * c10_0_3 a
 
 /-- Lemma 10.2.6 -/
 lemma estimate_good (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} (hα : ⨍⁻ x, ‖f x‖ₑ / c10_0_3 a < α) :
-    distribution (czOperator K r (czApproximation ha hf α)) (α / 2) volume ≤
+    distribution (czOperator K r (czApproximation (f := f) ha α)) (α / 2) volume ≤
     C10_2_6 a / α * eLpNorm f 1 volume := by
   sorry
 
@@ -344,15 +356,15 @@ irreducible_def C10_2_7 (a : ℕ) : ℝ≥0 := 2 ^ (a ^ 3 + 2 * a + 1) * c10_0_3
 
 /-- The function `F` defined in Lemma 10.2.7. -/
 def czOperatorBound (ha : 4 ≤ a) (hf : BoundedFiniteSupport f) (hX : GeneralCase f α) (x : X) : ℝ≥0∞ :=
-  C10_2_7 a * α * ∑' i, ((czRadius ha hf hX i).toNNReal / nndist x (czCenter ha hf hX i)) ^ (a : ℝ)⁻¹ *
-    volume (czBall3 ha hf hX i) / volume (ball x (dist x (czCenter ha hf hX i)))
+  C10_2_7 a * α * ∑' i, ((czRadius ha hX i).toNNReal / nndist x (czCenter ha hX i)) ^ (a : ℝ)⁻¹ *
+    volume (czBall3 ha hX i) / volume (ball x (dist x (czCenter ha hX i)))
 
 /-- Lemma 10.2.7.
 Note that `hx` implies `hX`, but we keep the superfluous hypothesis to shorten the statement. -/
 lemma estimate_bad_partial (ha : 4 ≤ a) {hf : BoundedFiniteSupport f}
     (hα : ⨍⁻ x, ‖f x‖ₑ / c10_0_3 a < α)
     (hx : x ∈ (Ω ha hf α)ᶜ) (hX : GeneralCase f α) :
-    ‖czOperator K r (czRemainder ha hf α) x‖ₑ ≤ 3 * czOperatorBound ha hf hX x + α / 8 := by
+    ‖czOperator K r (czRemainder (f := f) ha α) x‖ₑ ≤ 3 * czOperatorBound ha hf hX x + α / 8 := by
   sorry
 
 /-- The constant used in `distribution_czOperatorBound`. -/
@@ -372,7 +384,7 @@ irreducible_def C10_2_9 (a : ℕ) : ℝ≥0 := 2 ^ (5 * a) / c10_0_3 a + 2 ^ (a 
 -- In the proof, case on `GeneralCase f α`, noting in the finite case that `Ω = univ`
 lemma estimate_bad (ha : 4 ≤ a) {hf : BoundedFiniteSupport f}
     (hα : ⨍⁻ x, ‖f x‖ₑ / c10_0_3 a < α) (hX : GeneralCase f α) :
-    distribution (czOperator K r (czRemainder ha hf α)) (α / 2) volume ≤
+    distribution (czOperator K r (czRemainder (f := f) ha α)) (α / 2) volume ≤
     C10_2_9 a / α * eLpNorm f 1 volume := by
   sorry
 

--- a/Carleson/TwoSidedCarleson/WeakCalderonZygmund.lean
+++ b/Carleson/TwoSidedCarleson/WeakCalderonZygmund.lean
@@ -339,7 +339,7 @@ irreducible_def c10_0_3 (a : ℕ) : ℝ≥0 := (2 ^ (a ^ 3 + 12 * a + 4))⁻¹
 
 open scoped Classical in
 /-- The set `Ω` introduced below Lemma 10.2.5. -/
-def Ω (ha : 4 ≤ a) (hf : BoundedFiniteSupport f) (α : ℝ≥0∞) : Set X :=
+def Ω (ha : 4 ≤ a) (α : ℝ≥0∞) : Set X :=
   if hX : GeneralCase f α then ⋃ i, czBall2 ha hX i else univ
 
 /-- The constant used in `estimate_good`. -/
@@ -363,7 +363,7 @@ def czOperatorBound (ha : 4 ≤ a) (hf : BoundedFiniteSupport f) (hX : GeneralCa
 Note that `hx` implies `hX`, but we keep the superfluous hypothesis to shorten the statement. -/
 lemma estimate_bad_partial (ha : 4 ≤ a) {hf : BoundedFiniteSupport f}
     (hα : ⨍⁻ x, ‖f x‖ₑ / c10_0_3 a < α)
-    (hx : x ∈ (Ω ha hf α)ᶜ) (hX : GeneralCase f α) :
+    (hx : x ∈ (Ω (f := f) ha α)ᶜ) (hX : GeneralCase f α) :
     ‖czOperator K r (czRemainder (f := f) ha α) x‖ₑ ≤ 3 * czOperatorBound ha hf hX x + α / 8 := by
   sorry
 
@@ -373,7 +373,7 @@ irreducible_def C10_2_8 (a : ℕ) : ℝ≥0 := 2 ^ (a ^ 3 + 9 * a + 4)
 /-- Lemma 10.2.8 -/
 lemma distribution_czOperatorBound (ha : 4 ≤ a) {hf : BoundedFiniteSupport f}
     (hα : ⨍⁻ x, ‖f x‖ₑ / c10_0_3 a < α) (hX : GeneralCase f α) :
-    volume ((Ω ha hf α)ᶜ ∩ czOperatorBound ha hf hX ⁻¹' Ioi (α / 8)) ≤
+    volume ((Ω (f := f) ha α)ᶜ ∩ czOperatorBound ha hf hX ⁻¹' Ioi (α / 8)) ≤
     C10_2_8 a / α * eLpNorm f 1 volume := by
   sorry
 


### PR DESCRIPTION
- The definition of `GeneralCase` had the wrong inequality. This is now fixed.
- The following two lemmas about `GeneralCase` are proven using the correct definition. 
- The assumption `(hf : BoundedFiniteSupport f)` turned out to be unnecessary for the proof of `isOpen_MB_preimage_Ioi`, and thus unnecessary for a lot of subsequent work. I removed the assumption from any definitions/lemmas that were already completed without using it, but left it as an assumption for any lemma that doesn't have a proof yet.