### PR TITLE
Proofs of tsum_czRemainder' and measurable_czApproximation (Lemma 10.2.5)

### DIFF
--- a/Carleson/TwoSidedCarleson/WeakCalderonZygmund.lean
+++ b/Carleson/TwoSidedCarleson/WeakCalderonZygmund.lean
@@ -291,12 +291,9 @@ lemma aemeasurable_czApproximation (ha : 4 ≤ a) {hf : AEMeasurable f} :
                  have hx : ∃ j, x ∈ czPartition ha hX j := ⟨i, hxi⟩
                  simpa [czA, hx, czPartition_pairwiseDisjoint' ha hx.choose_spec hxi] using hi
   rw [this]
-  apply MeasurableSet.union
-  · have := Measurable.exists (MeasurableSet.czPartition ha hX · |>.mem)
-    measurability
-  · refine MeasurableSet.sUnion ((to_countable _).image _) ?_
-    rintro _ ⟨i, ⟨_, rfl⟩⟩
-    exact MeasurableSet.czPartition ha hX i
+  have := Measurable.exists (MeasurableSet.czPartition ha hX · |>.mem)
+  apply MeasurableSet.union (by measurability) ∘ MeasurableSet.sUnion ((to_countable _).image _)
+  simp [MeasurableSet.czPartition ha hX]
 
 /-- Part of Lemma 10.2.5, equation (10.2.16) (both cases).
 This is true by definition, the work lies in `tsum_czRemainder'` -/

--- a/Carleson/TwoSidedCarleson/WeakCalderonZygmund.lean
+++ b/Carleson/TwoSidedCarleson/WeakCalderonZygmund.lean
@@ -289,12 +289,12 @@ lemma measurable_czApproximation (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} :
       | inl hx => simpa [czApproximation, hX, mem_setOf_eq ▸ mem_setOf_eq ▸ hx.1] using hx.2
       | inr hx => obtain ⟨b, ⟨⟨i, ⟨hiM, rfl⟩⟩, hxb⟩⟩ := hx; simpa [czApproximation_def_of_mem ha hxb]
   rw [this]
-  refine MeasurableSet.union ?_ ?_
+  apply MeasurableSet.union
   · have : Measurable f := by sorry
     have := Measurable.exists (MeasurableSet.czPartition ha hX · |>.mem)
     measurability
   · refine MeasurableSet.sUnion ((to_countable M).image _) ?_
-    rintro t ⟨i, ⟨hi, rfl⟩⟩
+    rintro _ ⟨i, ⟨_, rfl⟩⟩
     exact MeasurableSet.czPartition ha hX i
 
 /-- Part of Lemma 10.2.5, equation (10.2.16) (both cases).

--- a/Carleson/TwoSidedCarleson/WeakCalderonZygmund.lean
+++ b/Carleson/TwoSidedCarleson/WeakCalderonZygmund.lean
@@ -269,7 +269,6 @@ def tsum_czRemainder' (ha : 4 ≤ a) (hX : GeneralCase f α) (x : X) :
   · simp only [czApproximation, hX, reduceDIte, hx, sub_self]
     exact finsum_eq_zero_of_forall_eq_zero fun i ↦ indicator_of_notMem (fun hi ↦ hx ⟨i, hi⟩) _
 
-open Classical in
 /-- Part of Lemma 10.2.5 (both cases). -/
 lemma measurable_czApproximation (ha : 4 ≤ a) {hf : BoundedFiniteSupport f} :
     Measurable (czApproximation f ha α) := by

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -7550,9 +7550,9 @@ Most of the next lemma and its proof is taken from Theorem 4.2 in \cite{stein-bo
 \begin{lemma}[Calderon Zygmund decomposition]
     \label{Calderon-Zygmund-decomposition}
     \leanok
-    \lean{cardinalMk_czBall3_le, tsum_czRemainder', measurable_czApproximation, czApproximation_add_czRemainder, norm_czApproximation_le, norm_czApproximation_le_infinite, eLpNorm_czApproximation_le, support_czRemainder'_subset, integral_czRemainder', integral_czRemainder, eLpNorm_czRemainder'_le, eLpNorm_czRemainder_le, tsum_volume_czBall3_le, volume_univ_le, tsum_eLpNorm_czRemainder'_le, tsum_eLpNorm_czRemainder_le}
+    \lean{cardinalMk_czBall3_le, tsum_czRemainder', aemeasurable_czApproximation, czApproximation_add_czRemainder, norm_czApproximation_le, norm_czApproximation_le_infinite, eLpNorm_czApproximation_le, support_czRemainder'_subset, integral_czRemainder', integral_czRemainder, eLpNorm_czRemainder'_le, eLpNorm_czRemainder_le, tsum_volume_czBall3_le, volume_univ_le, tsum_eLpNorm_czRemainder'_le, tsum_eLpNorm_czRemainder_le}
     \uses{ball-covering,Lebesgue-differentiation,maximal-theorem}
-    Let $f$ be a bounded, measurable function supported on a set of finite measure and let $\alpha>\frac{1}{\mu(X)}\int |f|\,d\mu$.
+    Let $f$ be a bounded, a.e. measurable function supported on a set of finite measure and let $\alpha>\frac{1}{\mu(X)}\int |f|\,d\mu$.
     Then there exists a measurable function $g$, a countable family of balls $B_j^*$ (where we allow $B_1^* = X$ in the special case that $\mu(X)<\infty$)
     % Do we actually need this parenthetical?
     such that each $x\in X$ is contained in at most $2^{6a}$ of the $B_j^*$, and a countable family of measurable functions $\{b_j\}_{j\in J}$ such that for all $x \in X$

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -7553,9 +7553,9 @@ Most of the next lemma and its proof is taken from Theorem 4.2 in \cite{stein-bo
     \lean{cardinalMk_czBall3_le, tsum_czRemainder', aemeasurable_czApproximation, czApproximation_add_czRemainder, norm_czApproximation_le, norm_czApproximation_le_infinite, eLpNorm_czApproximation_le, support_czRemainder'_subset, integral_czRemainder', integral_czRemainder, eLpNorm_czRemainder'_le, eLpNorm_czRemainder_le, tsum_volume_czBall3_le, volume_univ_le, tsum_eLpNorm_czRemainder'_le, tsum_eLpNorm_czRemainder_le}
     \uses{ball-covering,Lebesgue-differentiation,maximal-theorem}
     Let $f$ be a bounded, a.e. measurable function supported on a set of finite measure and let $\alpha>\frac{1}{\mu(X)}\int |f|\,d\mu$.
-    Then there exists a measurable function $g$, a countable family of balls $B_j^*$ (where we allow $B_1^* = X$ in the special case that $\mu(X)<\infty$)
+    Then there exists an a.e. measurable function $g$, a countable family of balls $B_j^*$ (where we allow $B_1^* = X$ in the special case that $\mu(X)<\infty$)
     % Do we actually need this parenthetical?
-    such that each $x\in X$ is contained in at most $2^{6a}$ of the $B_j^*$, and a countable family of measurable functions $\{b_j\}_{j\in J}$ such that for all $x \in X$
+    such that each $x\in X$ is contained in at most $2^{6a}$ of the $B_j^*$, and a countable family of a.e. measurable functions $\{b_j\}_{j\in J}$ such that for all $x \in X$
     \begin{equation}
        \label{eq-gb-dec}
        f(x)= g(x) + \sum_{j} b_j(x)


### PR DESCRIPTION
The proofs are complete, aside from one sorry in `measurable_czApproximation` for the measurability of `f` (which is supposed to be an assumption, according to the blueprint). The comment on `BoundedFiniteSupport` says that it should include measurability, but I figured I would check in before changing that, in case some other change was intended.