### PR TITLE
Lemma 10.1.7

### DIFF
--- a/Carleson/TwoSidedCarleson/Basic.lean
+++ b/Carleson/TwoSidedCarleson/Basic.lean
@@ -26,6 +26,43 @@ lemma memLp_top_K_on_ball_complement (hr : 0 < r) {x : X}:
       · intro y hy
         apply enorm_K_le_ball_complement' hr hy
 
+lemma czoperator_bound {g : X → ℂ} (hg : BoundedFiniteSupport g) (hr : 0 < r) (x : X) :
+    ∃ (M : ℝ≥0), ∀ᵐ y ∂(volume.restrict (ball x r)ᶜ), ‖K x y * g y‖ ≤ M := by
+  let M0 := (C_K a / volume (ball x r) * eLpNorm g ∞).toNNReal
+  use M0
+  rw [ae_iff, Measure.restrict_apply₀']
+  · let M1 := (C_K a / volume (ball x r)).toNNReal
+    let M2 := (eLpNorm g ∞).toNNReal
+    have : { y | ¬‖K x y * g y‖ ≤ M0} ⊆ { y | ¬‖K x y‖ ≤ M1 ∨ ¬‖g y‖ ≤ M2} := by
+      rw [setOf_subset_setOf]
+      intro y
+      contrapose!
+      intro hy
+      rw [norm_mul]
+      trans M1 * M2
+      · apply mul_le_mul hy.left hy.right
+        case b0 | c0 => simp only [norm_nonneg, NNReal.zero_le_coe]
+
+      apply le_of_eq
+      norm_cast
+      rw [← toNNReal_mul]
+    rw [← Measure.restrict_apply₀']
+    · apply measure_mono_null_ae this.eventuallyLE
+      rw [setOf_or]
+      apply measure_union_null
+      · rw [← ae_iff]
+        apply ae_restrict_of_forall_mem measurableSet_ball.compl
+        intro y hy
+        simp_rw [M1, ← ENNReal.toReal.eq_1, ← toReal_enorm]
+        apply (ENNReal.toReal_le_toReal enorm_lt_top.ne ?_).mpr
+        · apply enorm_K_le_ball_complement hy
+        · exact (div_lt_top coe_ne_top ((measure_ball_pos volume x hr).ne.symm)).ne
+      · simp_rw [← ae_iff, M2, ← ENNReal.toReal.eq_1, ← toReal_enorm,
+          (ENNReal.toReal_le_toReal enorm_lt_top.ne (hg.eLpNorm_lt_top).ne), eLpNorm_exponent_top]
+        apply ae_restrict_of_ae ae_le_eLpNormEssSup
+    · exact measurableSet_ball.compl.nullMeasurableSet
+  · exact measurableSet_ball.compl.nullMeasurableSet
+
 @[fun_prop]
 lemma czOperator_aestronglyMeasurable {g : X → ℂ} (hg : BoundedFiniteSupport g) :
     AEStronglyMeasurable (fun x ↦ czOperator K r g x) := by
@@ -57,8 +94,8 @@ lemma czoperator_welldefined {g : X → ℂ} (hg : BoundedFiniteSupport g) (hr :
     simp only [NNReal.zero_le_coe]
 
   have bdd_Kxg : ∃ (M : ℝ), ∀ᵐ y ∂(volume.restrict ((ball x r)ᶜ ∩ support Kxg)), ‖Kxg y‖ ≤ M := by
-    let M0 := (C_K a / volume (ball x r) * eLpNorm g ∞).toNNReal
-    use M0
+    obtain ⟨M, hM⟩ := czoperator_bound (K := K) hg hr x
+    use M
     rw [ae_iff, Measure.restrict_apply₀']
     · conv =>
         arg 1; arg 2;
@@ -67,37 +104,8 @@ lemma czoperator_welldefined {g : X → ℂ} (hg : BoundedFiniteSupport g) (hr :
         · apply inter_subset_left.trans
           apply setOf_subset.mpr
           apply tmp_Kxg
-
-      let M1 := (C_K a / volume (ball x r)).toNNReal
-      let M2 := (eLpNorm g ∞).toNNReal
-      have : { y | ¬‖Kxg y‖ ≤ M0} ⊆ { y | ¬‖K x y‖ ≤ M1 ∨ ¬‖g y‖ ≤ M2} := by
-        rw [setOf_subset_setOf]
-        intro y
-        contrapose!
-        intro hy
-        rw [norm_mul]
-        trans M1 * M2
-        · apply mul_le_mul hy.left hy.right
-          case b0 | c0 => simp only [norm_nonneg, NNReal.zero_le_coe]
-
-        apply le_of_eq
-        norm_cast
-        rw [← toNNReal_mul]
-      rw [← Measure.restrict_apply₀']
-      · apply measure_mono_null_ae this.eventuallyLE
-        rw [setOf_or]
-        apply measure_union_null
-        · rw [← ae_iff]
-          apply ae_restrict_of_forall_mem measurableSet_ball.compl
-          intro y hy
-          simp_rw [M1, ← ENNReal.toReal.eq_1, ← toReal_enorm]
-          apply (ENNReal.toReal_le_toReal enorm_lt_top.ne ?_).mpr
-          · apply enorm_K_le_ball_complement hy
-          · exact (div_lt_top coe_ne_top ((measure_ball_pos volume x hr).ne.symm)).ne
-        · simp_rw [← ae_iff, M2, ← ENNReal.toReal.eq_1, ← toReal_enorm,
-            (ENNReal.toReal_le_toReal enorm_lt_top.ne (hg.eLpNorm_lt_top).ne), eLpNorm_exponent_top]
-          apply ae_restrict_of_ae ae_le_eLpNormEssSup
-      · exact measurableSet_ball.compl.nullMeasurableSet
+      rw [← Measure.restrict_apply₀' (by measurability), ← ae_iff]
+      exact hM
     · apply NullMeasurableSet.inter
       · exact measurableSet_ball.compl.nullMeasurableSet
       · exact mKxg.nullMeasurableSet_support

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -978,8 +978,7 @@ theorem small_annulus_right {g : X → ℂ} (hg : BoundedFiniteSupport g) {R₁ 
   · -- This is painful because we have to show continuity of the indicator
     -- which is needed to apply `dominated` because `R` is variable in the domain of the integral.
     -- This in turn meant proving continuity at `R₁`, which actually aligns with the blueprint.
-    filter_upwards
-    intro y
+    filter_upwards with y
     unfold ContinuousWithinAt
     have : nhdsWithin R₁ (Ioo R₁ R₂) |>.Eventually (fun r ↦ y ∉ Annulus.oo x R₁ r) := by
       by_cases hy : R₁ < dist x y
@@ -1037,8 +1036,7 @@ theorem small_annulus_left {g : X → ℂ} (hg : BoundedFiniteSupport g) {R₁ R
   · -- This is painful because we have to show continuity of the indicator
     -- which is needed to apply `dominated` because `R` is variable in the domain of the integral.
     -- This in turn meant proving continuity at `R₂`, which actually aligns with the blueprint.
-    filter_upwards
-    intro y
+    filter_upwards with y
     unfold ContinuousWithinAt
     have : nhdsWithin R₂ (Ioo R₁ R₂) |>.Eventually (fun r ↦ y ∉ Annulus.oo x r R₂) := by
       by_cases hy : dist x y < R₂

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -941,19 +941,96 @@ theorem simple_nontangential_operator_le (ha : 4 ≤ a)
     HasBoundedStrongType (simpleNontangentialOperator K r) 2 2 volume volume (C10_1_6 a) := by
   sorry
 
+-- right ContinuousWithinAt (fun x ↦ ‖∫ (y : X) in Annulus.oo x' R₁ x, K x' y * f y‖ₑ) (Ioo R₁ R₂) R₁
+-- left  ContinuousWithinAt (fun x ↦ ‖∫ (y : X) in Annulus.oo x' x R₁, K x' y * f y‖ₑ) (Ioo (dist x x') R₁) R₁
+
 /-- Part of Lemma 10.1.7, reformulated. -/
 theorem small_annulus_right (ha : 4 ≤ a)
     (hT : ∀ r > 0, HasBoundedStrongType (czOperator K r) 2 2 volume volume (C_Ts a))
-    {f : X → ℂ} (hf : BoundedFiniteSupport f) {R₁ : ℝ} :
-    Continuous (fun R₂ ↦ ∫ y in {y | dist x' y ∈ Ioo R₁ R₂}, K x' y * f y) := by
+    {f : X → ℂ} (hf : BoundedFiniteSupport f) {R₁ : ℝ} (hR₁ : R₁ > 0):
+    Continuous (fun R₂ ↦ ∫ y in Annulus.oo x R₁ R₂, K x y * f y) := by
   sorry
 
 /-- Part of Lemma 10.1.7, reformulated -/
 theorem small_annulus_left (ha : 4 ≤ a)
     (hT : ∀ r > 0, HasBoundedStrongType (czOperator K r) 2 2 volume volume (C_Ts a))
-    {f : X → ℂ} (hf : BoundedFiniteSupport f) {R₂ : ℝ} :
-    Continuous (fun R₁ ↦ ∫ y in {y | dist x' y ∈ Ioo R₁ R₂}, K x' y * f y) := by
+    {g : X → ℂ} (hg : BoundedFiniteSupport g) {R₂ : ℝ} :
+    ContinuousOn (fun R₁ ↦ ∫ y in Annulus.oo x R₁ R₂, K x y * g y) {R | 0 < R} := by
+  conv => arg 1; intro R1; rw [← integral_indicator (by measurability)]
+  apply continuousOn_of_dominated (s := {R | 0 < R})
+  · intro R hR
+    have : Measurable (K x) := measurable_K_right x
+    fun_prop (disch := measurability)
+  · sorry
+  · sorry
+  · apply Filter.Eventually.of_forall
+    intro y
+    apply continuousOn_of_forall_continuousAt
+    intro R hR
+    apply ContinuousOn.continuousAt_indicator
+    · sorry
+    sorry
   sorry
+  -- by_cases hR₂ : R₂ ≤ 0
+  -- · have : ∀ R₁, Annulus.oo x R₁ R₂ = ∅ := by
+  --     intro R₁; unfold Annulus.oo; ext y; simp [hR₂.trans dist_nonneg]
+  --   simp_rw [this, setIntegral_empty]
+  --   exact continuousOn_const
+  -- rw [not_le] at hR₂
+  -- simp_rw [Metric.continuousOn_iff]
+  -- intro R h2R ε hε
+  -- by_cases hR : R₂ < R
+  -- · use R - R₂; refine ⟨(by simp [hR]), ?_⟩
+  --   intro R' h2R' hR'
+  --   have : R₂ < R' := by
+  --     by_cases h : R < R'
+  --     · exact hR.trans h
+  --     rw [Real.dist_eq, abs_of_nonpos (by linarith [not_lt.mp h])] at hR'
+  --     linarith
+  --   rw [Annulus.oo_eq_empty this.le, Annulus.oo_eq_empty hR.le, setIntegral_empty]
+  --   simp [hε]
+  -- rw [not_lt] at hR
+  -- use 1; constructor
+  -- · sorry
+  -- intro R' h2R' hR'
+  -- wlog hle : R ≤ R'
+  -- · rw [dist_comm] at hR'; rw [not_le] at hle
+  --   simpa [dist_comm] using this ha hT hg hR₂ R' h2R' ε hε (hle.le.trans hR) R h2R hR' (hle.le)
+
+  -- have : True := by
+  --   sorry
+  --   --MeasureTheory.continuousOn_of_dominated
+
+  -- by_cases h2R' : R₂ ≤ R'
+  -- · rw [Annulus.oo_eq_empty h2R', setIntegral_empty, dist_zero,
+  --     ← integral_indicator (by measurability)]
+  --   rw [← Real.coe_toNNReal ε hε.le, --pass to ENNReal for lintegral
+  --     ← Real.coe_toNNReal _ (norm_nonneg _), NNReal.coe_lt_coe, norm_toNNReal, ← enorm_lt_coe]
+  --   apply lt_of_le_of_lt <| enorm_integral_le_lintegral_enorm _
+  --   simp_rw [enorm_indicator_eq_indicator_enorm]
+  --   apply lt_of_le_of_lt <| lintegral_mono <|
+  --     indicator_le_indicator_of_subset (Annulus.oo_subset_oo (by rfl) h2R') (by simp)
+  --   sorry
+  -- · rw [not_le] at h2R'
+  --   simp_rw [dist_eq_norm_sub, ← Annulus.oc_union_oo hle h2R']
+  --   rw [setIntegral_union_2 ?dj (by measurability) ?int, sub_add_cancel_right, norm_neg,
+  --       ← integral_indicator (by measurability)]
+  --   case dj =>
+  --     rw [Annulus.oo, Annulus.oc, Set.disjoint_iff]; intro y
+  --     simp_rw [mem_empty_iff_false, mem_inter_iff, mem_setOf, mem_Ioc, mem_Ioo]
+  --     exact fun h ↦ (not_lt.mpr h.1.2) h.2.1
+  --   case int =>
+  --     simp_rw [Annulus.oc_union_oo hle h2R']
+  --     apply IntegrableOn.mono_set <| czoperator_welldefined hg (r := R / 2) ?hr x
+  --     case hr => linarith [mem_setOf.mp h2R]
+  --     rw [← Annulus.ci_eq]
+  --     apply Annulus.oo_subset_ci
+  --     linarith [mem_setOf.mp h2R]
+  --   rw [← Real.coe_toNNReal ε hε.le, --pass to ENNReal for lintegral
+  --       ← Real.coe_toNNReal _ (norm_nonneg _), NNReal.coe_lt_coe, norm_toNNReal, ← enorm_lt_coe]
+  --   apply lt_of_le_of_lt <| enorm_integral_le_lintegral_enorm _
+  --   simp_rw [enorm_indicator_eq_indicator_enorm]
+  --   sorry
 
 /-- Lemma 10.1.8. -/
 theorem nontangential_operator_boundary (ha : 4 ≤ a) {f : X → ℂ} (hf : BoundedFiniteSupport f) :

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -7294,6 +7294,7 @@ In order to pass from the one-sided truncation in $T_r$ and $T_{*}^r$ to the two
     \end{equation}
 \end{lemma}
 \begin{proof}
+\leanok
 We only prove the second inequality, the first one is analogous.
 Note that the integrand is bounded in $X\setminus B(x,\frac{R}{2})$. So for $0<\delta\le\frac{R}{2}$,
 \begin{align*}
@@ -7316,6 +7317,7 @@ By continuity from above of $\mu$, the right factor becomes arbitrarily small as
     \end{equation}
 \end{lemma}
 \begin{proof}
+\leanok
 We show two inequalities. Let $\epsilon>0$.
 Let $R_1<R_2$ and $x'\in B(x,R_1)$. Then for small enough $\delta>0$,
 \begin{alignat}{3}


### PR DESCRIPTION
With the correct statement in place in 10.1.8, it was feasible to prove both estimates without resorting to epsilon-delta intricacies.
Instead `continuousWithinAt_of_dominated` was used.

This led to intricacies because continuity of an indicator had to be proved. This was feasible but only at the boundary. Therefore no `ContinuousOn` or `Continuous` statement was shown.
In fact if you look precisely the formalised statement aligns with the blueprint in the sense that they show the same thing.

In terms of the formalisation, I struggled to play nicely with `nhdsWithin` on the reals, so it might be that some statements can be optimised. Also the proofs look similar, but in critical parts the left-or-rightness is being used so I'm afraid it cannot be easily unified.