### PR TITLE
fix interpolated_exponents

### DIFF
--- a/Carleson/ToMathlib/RealInterpolation/InterpolatedExponents.lean
+++ b/Carleson/ToMathlib/RealInterpolation/InterpolatedExponents.lean
@@ -23,12 +23,17 @@ theorem mem_sub_Ioo {q r : ℝ≥0∞} (hr : r ≠ ⊤) (hq : q ∈ Ioo 0 r) : r
   · apply False.elim (by simp at hq)
   exact ⟨tsub_pos_of_lt hq.2, (ENNReal.sub_lt_self_iff hr).mpr ⟨hr', hq.1⟩⟩
 
-lemma sub_toReal_of_le {t : ℝ≥0∞} (ht : t ≤ 1) : 1 - t.toReal = (1 - t).toReal := sorry
+lemma sub_toReal_of_le {t : ℝ≥0∞} (ht : t ≤ 1) : 1 - t.toReal = (1 - t).toReal := by
+  rw [ENNReal.toReal_sub_of_le ht, ENNReal.toReal_one]
+  exact ENNReal.one_ne_top
 
 lemma sub_sub_toReal_of_le {t : ℝ≥0∞} (ht : t ≤ 1) : t.toReal = 1 - (1 - t).toReal := by
   rw [← sub_toReal_of_le ht, _root_.sub_sub_cancel]
 
-lemma bar {t : ℝ≥0∞} (ht : t ∈ Ioo 0 1) : 1 - (1 - t) = t := sorry
+lemma bar {t : ℝ≥0∞} (ht : t ∈ Ioo 0 1) : 1 - (1 - t) = t := by
+  apply ENNReal.sub_sub_cancel
+  · exact one_ne_top
+  · exact ht.2.le
 
 lemma one_le_toReal {a : ℝ≥0∞} (ha₁ : 1 ≤ a) (ha₂ : a < ⊤) : 1 ≤ a.toReal :=
   toReal_mono ha₂.ne_top ha₁
@@ -56,6 +61,10 @@ lemma lt_top_of_Ico {p q r : ℝ≥0∞} (hq : q ∈ Ico p r) : q < ⊤ := by fi
 lemma ne_top_of_Ioo {p q r : ℝ≥0∞} (hq : q ∈ Ioo p r) : q ≠ ⊤ := hq.2.ne_top
 
 lemma lt_top_of_Ioo {p q r : ℝ≥0∞} (hq : q ∈ Ioo p r) : q < ⊤ := (ne_top_of_Ioo hq).lt_top
+
+-- check why Ioo.one_sub_mem doesn't work here
+theorem Ioo_one_sum_mem {t : ℝ≥0∞} (ht : t ∈ Ioo 0 1) : 1 - t ∈ Ioo 0 1 := by
+  exact mem_sub_Ioo top_ne_one.symm ht
 
 -- XXX: generalise interval bounds!
 lemma toReal_mem_Ioo {t : ℝ≥0∞} (ht : t ∈ Ioo 0 1) : t.toReal ∈ Ioo 0 1 :=
@@ -182,18 +191,16 @@ lemma one_le_interp_exp_aux (hp₀ : 1 ≤ p₀) (hp₁ : 1 ≤ p₁) (hp₀p₁
 
 lemma switch_exponents (ht : t ∈ Ioo 0 1)
     (hp : p⁻¹ = (1 - t) * p₀⁻¹ + t * p₁⁻¹) :
-    p⁻¹ = (1 - t) * p₁⁻¹ + t * p₀⁻¹ := by
-  rw [add_comm]
-  sorry /- proof was: rw [← ofReal_one, ← ofReal_sub, _root_.sub_sub_cancel, ofReal_sub _ ht.1.le, ofReal_one]
-  · exact hp
-  · exact (Ioo.one_sub_mem ht).1.le -/
+    p⁻¹ = (1 - (1 - t)) * p₁⁻¹ + (1 - t) * p₀⁻¹ := by
+  rw [ENNReal.sub_sub_cancel one_ne_top ht.2.le, hp, add_comm]
 
 lemma one_le_interp (hp₀ : 1 ≤ p₀) (hp₁ : 1 ≤ p₁)
     (hp₀p₁ : p₀ ≠ p₁) (ht : t ∈ Ioo 0 1)
     (hp : p⁻¹ = (1 - t) * p₀⁻¹ + t * p₁⁻¹) : 1 ≤ p := by
   rcases (lt_or_gt_of_ne hp₀p₁) with p₀lt_p₁ | p₁lt_p₀
   · exact one_le_interp_exp_aux hp₀ hp₁ p₀lt_p₁ ht hp
-  · exact one_le_interp_exp_aux hp₁ hp₀ p₁lt_p₀ ht (switch_exponents ht hp)
+  · exact one_le_interp_exp_aux hp₁ hp₀ p₁lt_p₀ (Ioo_one_sum_mem ht) <| switch_exponents  ht hp
+
 
 lemma one_le_interp_toReal (hp₀ : 1 ≤ p₀) (hp₁ : 1 ≤ p₁)
     (hp₀p₁ : p₀ ≠ p₁) (ht : t ∈ Ioo 0 1)
@@ -311,7 +318,9 @@ lemma ne_toReal_exp_interp_exp (ht : t ∈ Ioo 0 1) (hp₀ : 0 < p₀) (hp₁ : 
 lemma ne_toReal_exp_interp_exp₁ (ht : t ∈ Ioo 0 1) (hp₀ : 0 < p₀) (hp₁ : 0 < p₁) (hp₀p₁ : p₀ ≠ p₁)
     (hp : p⁻¹ = (1 - t) * p₀⁻¹ + t * p₁⁻¹) :
     p.toReal ≠ p₁.toReal :=
-  (ne_toReal_exp_interp_exp ht hp₁ hp₀ (Ne.symm hp₀p₁) (switch_exponents ht hp)).symm
+    (ne_toReal_exp_interp_exp (Ioo_one_sum_mem ht) hp₁ hp₀ (Ne.symm hp₀p₁)
+    (switch_exponents ht hp)).symm
+
 
 lemma ofReal_inv_interp_sub_exp_pos₁ (ht : t ∈ Ioo 0 1) (hq₀ : 0 < q₀) (hq₁ : 0 < q₁)
     (hq₀q₁ : q₀ ≠ q₁)
@@ -332,7 +341,7 @@ lemma exp_lt_iff (ht : t ∈ Ioo 0 1) (hp₀ : 0 < p₀) (hp₁ : 0 < p₁) (hp�
   · exact ⟨fun h ↦ (not_le_of_gt h (le_of_lt (interp_exp_between hp₀ hp₁ p₀lt_p₁ ht hp).1)).elim,
       fun h ↦ (not_le_of_gt h p₀lt_p₁.le).elim⟩
   · exact ⟨fun _ ↦ p₁lt_p₀,
-      fun _ ↦ (interp_exp_between hp₁ hp₀ p₁lt_p₀ ht (switch_exponents ht hp)).2⟩
+      fun _ ↦ (interp_exp_between hp₁ hp₀ p₁lt_p₀ (Ioo_one_sum_mem ht) (switch_exponents ht hp)).2⟩
 
 lemma exp_gt_iff (ht : t ∈ Ioo 0 1) (hp₀ : 0 < p₀) (hp₁ : 0 < p₁) (hp₀p₁ : p₀ ≠ p₁)
     (hp : p⁻¹ = (1 - t) * p₀⁻¹ + t * p₁⁻¹) :
@@ -340,19 +349,19 @@ lemma exp_gt_iff (ht : t ∈ Ioo 0 1) (hp₀ : 0 < p₀) (hp₁ : 0 < p₁) (hp�
   rcases lt_or_gt_of_ne hp₀p₁ with p₀lt_p₁ | p₁lt_p₀
   · exact ⟨fun _ ↦ p₀lt_p₁, fun _ ↦ (interp_exp_between hp₀ hp₁ p₀lt_p₁ ht hp).1⟩
   · exact ⟨fun h ↦ (not_le_of_gt h (interp_exp_between hp₁ hp₀ p₁lt_p₀
-      ht (switch_exponents ht hp)).2.le).elim,
+      (Ioo_one_sum_mem ht) (switch_exponents ht hp)).2.le).elim,
       fun h ↦ (not_le_of_gt h p₁lt_p₀.le).elim⟩
 
 lemma exp_lt_exp_gt_iff (ht : t ∈ Ioo 0 1) (hp₀ : 0 < p₀) (hp₁ : 0 < p₁) (hp₀p₁ : p₀ ≠ p₁)
     (hp : p⁻¹ = (1 - t) * p₀⁻¹ + t * p₁⁻¹) :
     p < p₀ ↔ p₁ < p := by
-  rw [exp_lt_iff ht hp₀ hp₁ hp₀p₁ hp, ← exp_gt_iff ht hp₁ hp₀ (Ne.symm hp₀p₁)
+  rw [exp_lt_iff ht hp₀ hp₁ hp₀p₁ hp, ← exp_gt_iff (Ioo_one_sum_mem ht) hp₁ hp₀ (Ne.symm hp₀p₁)
     (switch_exponents ht hp)]
 
 lemma exp_gt_exp_lt_iff (ht : t ∈ Ioo 0 1) (hp₀ : 0 < p₀) (hp₁ : 0 < p₁) (hp₀p₁ : p₀ ≠ p₁)
     (hp : p⁻¹ = (1 - t) * p₀⁻¹ + t * p₁⁻¹) :
     p₀ < p ↔ p < p₁ := by
-  rw [exp_gt_iff ht hp₀ hp₁ hp₀p₁ hp, ← exp_lt_iff ht hp₁ hp₀ (Ne.symm hp₀p₁)
+  rw [exp_gt_iff ht hp₀ hp₁ hp₀p₁ hp, ← exp_lt_iff (Ioo_one_sum_mem ht) hp₁ hp₀ (Ne.symm hp₀p₁)
     (switch_exponents ht hp)]
 
 lemma exp_lt_iff₁ (ht : t ∈ Ioo 0 1) (hp₀ : 0 < p₀) (hp₁ : 0 < p₁) (hp₀p₁ : p₀ ≠ p₁)
@@ -399,7 +408,7 @@ lemma ζ_equality₁ (ht : t ∈ Ioo 0 1) :
   unfold ζ
   have aux : t.toReal ≠ 0 := toReal_ne_zero_of_Ioo ht
   rw [← mul_div_mul_right _ _ aux, mul_assoc _ _ t.toReal, mul_assoc _ _ t.toReal]
-  congr <;> sorry -- proof was just `ring`
+  congr <;>  rw [ENNReal.toReal_sub_of_le ht.2.le ENNReal.one_ne_top, ENNReal.toReal_one] <;> ring
 
 lemma ζ_equality₂ (ht : t ∈ Ioo 0 1) :
     ζ p₀ q₀ p₁ q₁ t.toReal =
@@ -408,10 +417,10 @@ lemma ζ_equality₂ (ht : t ∈ Ioo 0 1) :
     (((1 - t).toReal * q₀⁻¹.toReal + t.toReal * q₁⁻¹.toReal) *
     ((1 - t).toReal * p₀⁻¹.toReal + t.toReal * p₁⁻¹.toReal - p₁⁻¹.toReal)) := by
   unfold ζ
-  sorry /- proof was
-  have : - (1 - t) < 0 := neg_neg_iff_pos.mpr (sub_pos.mpr ht.2)
-  rw [← mul_div_mul_right _ _ this.ne, mul_assoc _ _ (-(1 - t)), mul_assoc _ _ (-(1 - t))]
-  congr <;> ring -/
+  rw [ENNReal.toReal_sub_of_le ht.2.le]
+  · rw [ENNReal.toReal_one, ← mul_div_mul_right _ _ (sub_ne_zero.mpr (ENNReal.toReal_ne_one.mpr ht.2.ne))]
+    ring
+  · exact one_ne_top
 
 lemma ζ_symm (ht : t ∈ Ioo 0 1) : ζ p₀ q₀ p₁ q₁ t.toReal = ζ p₁ q₁ p₀ q₀ (1 - t).toReal := by
   unfold ζ
@@ -910,16 +919,15 @@ lemma eq_exponents₅ (ht : t ∈ Ioo 0 1) (hq₀ : 0 < q₀) (hq₁ : 0 < q₁)
     (hq : q⁻¹ = (1 - t) * q₀⁻¹ + t * q₁⁻¹) (hq₁' : q₁ ≠ ⊤) :
     (q₁.toReal + -(q₀⁻¹.toReal / (q₁⁻¹.toReal - q₀⁻¹.toReal) * (q.toReal - q₁.toReal)))
       = t.toReal * q.toReal := by
-  rw [eq_exponents₄, neg_mul, neg_neg, eq_exponents₀ ht hq₁ hq₀ (Ne.symm hq₀q₁)
-    (switch_exponents ht hq) hq₁']
-  sorry -- proof was just `ring`
+  rw [eq_exponents₄, neg_mul, neg_neg, eq_exponents₀ (Ioo_one_sum_mem ht) hq₁ hq₀ (Ne.symm hq₀q₁)
+    (switch_exponents ht hq) hq₁', ENNReal.sub_sub_cancel one_ne_top ht.2.le]
 
 lemma eq_exponents₆ (ht : t ∈ Ioo 0 1) (hq₀ : 0 < q₀) (hq₁ : 0 < q₁) (hq₀q₁ : q₀ ≠ q₁)
     (hq : q⁻¹ = (1 - t) * q₀⁻¹ + t * q₁⁻¹) (hq₁' : q₁ ≠ ⊤) :
     q₁⁻¹.toReal / (q₁⁻¹.toReal - q₀⁻¹.toReal) * (q.toReal - q₁.toReal) = (1 - t).toReal * q.toReal := by
   rw [← neg_neg (a := q₁⁻¹.toReal / (q₁⁻¹.toReal - q₀⁻¹.toReal)), ← eq_exponents₄, neg_mul,
-    eq_exponents₁ ht hq₁ hq₀ (Ne.symm hq₀q₁) (switch_exponents ht hq) hq₁']
-  sorry -- proof was just `ring`
+    eq_exponents₁ (Ioo_one_sum_mem ht) hq₁ hq₀ (Ne.symm hq₀q₁) (switch_exponents ht hq) hq₁']
+  ring
 
 lemma eq_exponents₇ (ht : t ∈ Ioo 0 1) (hq₀ : 0 < q₀) (hq₁ : 0 < q₁) (hq₀q₁ : q₀ ≠ q₁)
     (hq : q⁻¹ = (1 - t) * q₀⁻¹ + t * q₁⁻¹) (hq₁' : q₁ ≠ ⊤) :


### PR DESCRIPTION
There was a mistake in `switch_exponents`, which lead to it being impossible to prove and more failures below.

