### PR TITLE
Clean up variables in `MetricCarleson`

### DIFF
--- a/Carleson/Defs.lean
+++ b/Carleson/Defs.lean
@@ -271,12 +271,14 @@ lemma le_upperRadius [FunctionDistances ℝ X] {Q : X → Θ X} {θ : Θ X} {x :
     (hr : dist_{x, r} θ (Q x) < 1) : ENNReal.ofReal r ≤ upperRadius Q θ x := by
   apply le_iSup₂ (f := fun r _ ↦ ENNReal.ofReal r) r hr
 
+/-
 /-- The linearized maximally truncated nontangential Calderon Zygmund operator `T_Q^θ` -/
 def linearizedNontangentialOperator [FunctionDistances ℝ X] (Q : X → Θ X) (θ : Θ X)
     (K : X → X → ℂ) (f : X → ℂ) (x : X) : ℝ≥0∞ :=
   ⨆ (R₁ : ℝ) (x' : X) (_ : dist x x' ≤ R₁),
   ‖∫ y in {y | ENNReal.ofReal (dist x' y) ∈ Ioo (ENNReal.ofReal R₁) (upperRadius Q θ x')},
     K x' y * f y‖₊
+-/
 
 /-- The maximally truncated nontangential Calderon Zygmund operator `T_*` -/
 def nontangentialOperator (K : X → X → ℂ) (f : X → ℂ) (x : X) : ℝ≥0∞ :=

--- a/Carleson/MetricCarleson/Basic.lean
+++ b/Carleson/MetricCarleson/Basic.lean
@@ -6,17 +6,12 @@ open MeasureTheory Set ENNReal Filter Topology ShortVariables Metric Complex
 
 noncomputable section
 
-variable {X : Type*} {a : ℕ} [MetricSpace X]
-variable {C : ℝ}
-variable {F G : Set X}
-variable {K : X → X → ℂ}
-variable {f : X → ℂ}
-
-variable [CompatibleFunctions ℝ X (defaultA a)]
-  (ha : 4 ≤ a)
-  {x : X} {θ : Θ X} {R₁ R₂ : ℝ}
+variable {X : Type*} {a : ℕ} [MetricSpace X] {K : X → X → ℂ}
 
 namespace MetricΘ
+
+variable [CompatibleFunctions ℝ X (defaultA a)]
+
 /-- We choose as metric space instance on `Θ` one given by an arbitrary ball.
 The metric given by all other balls are equivalent. -/
 scoped instance : PseudoMetricSpace (Θ X) :=
@@ -44,34 +39,30 @@ end MetricΘ
 
 open MetricΘ
 
-variable
-  [DoublingMeasure X (defaultA a : ℕ)]
+variable [KernelProofData a K] {θ : Θ X} {R₁ R₂ : ℝ} {f : X → ℂ} {x : X}
   [IsCancellative X (defaultτ a)]
-  [IsOneSidedKernel a K]
 
-
-lemma continuous_carlesonOperatorIntegrand (hf : ∀ x, ‖f x‖ₑ ≤ 1) :
+lemma continuous_carlesonOperatorIntegrand (nf : (‖f ·‖) ≤ 1) :
     Continuous (carlesonOperatorIntegrand K · R₁ R₂ f x) := by
   sorry
 
-lemma rightContinuous_carlesonOperatorIntegrand (hf : ∀ x, ‖f x‖ₑ ≤ 1) :
+lemma rightContinuous_carlesonOperatorIntegrand (nf : (‖f ·‖) ≤ 1) :
     ContinuousWithinAt (carlesonOperatorIntegrand K θ · R₂ f x) (Ici R₁) R₁ := by
   sorry
 
-lemma leftContinuous_carlesonOperatorIntegrand (hf : ∀ x, ‖f x‖ₑ ≤ 1) :
+lemma leftContinuous_carlesonOperatorIntegrand (nf : (‖f ·‖) ≤ 1) :
     ContinuousWithinAt (carlesonOperatorIntegrand K θ R₁ · f x) (Iic R₂) R₂ := by
   sorry
 
-lemma measurable_carlesonOperatorIntegrand (hf : ∀ x, ‖f x‖ₑ ≤ 1) :
+lemma measurable_carlesonOperatorIntegrand (nf : (‖f ·‖) ≤ 1) :
     Measurable (carlesonOperatorIntegrand K θ R₁ R₂ f) := by
   sorry
 
 /-- The constant used in the proof of `int-continuous`. -/
 irreducible_def C3_0_1 (a : ℕ) (R₁ R₂ : ℝ≥0) : ℝ≥0 :=
-  2 ^ ((a : ℝ) ^ 3) * (2 * R₂ / R₁) ^ a
+  2 ^ (a ^ 3) * (2 * R₂ / R₁) ^ a
 
 -- not sure if this is the best phrasing
-lemma isBounded_carlesonOperatorIntegrand {R₁ R₂ : ℝ≥0}
-    (hf : ∀ x, ‖f x‖ₑ ≤ 1) :
+lemma isBounded_carlesonOperatorIntegrand {R₁ R₂ : ℝ≥0} (nf : (‖f ·‖) ≤ 1) :
     ‖carlesonOperatorIntegrand K θ R₁ R₂ f x‖ₑ ≤ C3_0_1 a R₁ R₂ := by
   sorry

--- a/Carleson/MetricCarleson/Linearized.lean
+++ b/Carleson/MetricCarleson/Linearized.lean
@@ -1,3 +1,4 @@
+import Carleson.MetricCarleson.Basic
 import Carleson.MetricCarleson.Truncation
 
 open scoped NNReal
@@ -5,28 +6,15 @@ open MeasureTheory Set ENNReal
 
 noncomputable section
 
-/-- The constant used in `linearized_metric_carleson`.
-Has value `2 ^ (450 * a ^ 3) / (q - 1) ^ 6` in the blueprint. -/
--- Todo: define this recursively in terms of previous constants
-def C1_0_3 (a : ℕ) (q : ℝ≥0) : ℝ≥0 := 2 ^ (450 * a ^ 3) / (q - 1) ^ 6
+variable {X : Type*} {a : ℕ} [MetricSpace X] {q q' : ℝ≥0} {F G : Set X} {K : X → X → ℂ}
+variable [KernelProofData a K] {Q : SimpleFunc X (Θ X)} {f : X → ℂ} [IsCancellative X (defaultτ a)]
 
-variable {X : Type*} {a : ℕ} [MetricSpace X] [DoublingMeasure X (defaultA a : ℕ)]
-variable {τ C : ℝ} {q q' : ℝ≥0}
-variable {F G : Set X}
-variable {K : X → X → ℂ}
-
-
-/- Theorem 1.0.3 -/
-theorem linearized_metric_carleson [CompatibleFunctions ℝ X (defaultA a)]
-  [IsCancellative X (defaultτ a)] [IsOneSidedKernel a K]
-    (ha : 4 ≤ a) (hq : q ∈ Ioc 1 2) (hqq' : q.HolderConjugate q')
-    (Q : SimpleFunc X (Θ X)) {θ : Θ X}
-    (hF : MeasurableSet F) (hG : MeasurableSet G)
-    (hT : HasBoundedStrongType (linearizedNontangentialOperator Q θ K · ·)
-      2 2 volume volume (C_Ts a))
-    (f : X → ℂ) (hmf : Measurable f) (hf : ∀ x, ‖f x‖ ≤ F.indicator 1 x) :
+/-- Theorem 1.0.3 -/
+theorem linearized_metric_carleson
+    (hq : q ∈ Ioc 1 2) (hqq' : q.HolderConjugate q') (mF : MeasurableSet F) (mG : MeasurableSet G)
+    (mf : Measurable f) (nf : (‖f ·‖) ≤ F.indicator 1) :
     ∫⁻ x in G, linearizedCarlesonOperator Q K f x ≤
-    C1_0_3 a q * (volume G) ^ (q' : ℝ)⁻¹ * (volume F) ^ (q : ℝ)⁻¹ := by
+    C1_0_2 a q * volume G ^ (q' : ℝ)⁻¹ * volume F ^ (q : ℝ)⁻¹ := by
   sorry
 
 end

--- a/Carleson/MetricCarleson/Main.lean
+++ b/Carleson/MetricCarleson/Main.lean
@@ -5,20 +5,15 @@ open scoped NNReal
 
 noncomputable section
 
-variable {X : Type*} {a : ℕ} [MetricSpace X] [DoublingMeasure X (defaultA a : ℕ)]
-variable {τ : ℝ} {q q' : ℝ≥0} {C : ℝ}
-variable {F G : Set X}
-variable {K : X → X → ℂ}
+variable {X : Type*} {a : ℕ} [MetricSpace X] {q q' : ℝ≥0} {F G : Set X} {K : X → X → ℂ}
+variable [KernelProofData a K] {f : X → ℂ} [IsCancellative X (defaultτ a)]
 
-/- Theorem 1.0.2 -/
-theorem metric_carleson [CompatibleFunctions ℝ X (defaultA a)]
-  [IsCancellative X (defaultτ a)] [IsOneSidedKernel a K]
-    (ha : 4 ≤ a) (hq : q ∈ Ioc 1 2) (hqq' : q.HolderConjugate q')
-    (hF : MeasurableSet F) (hG : MeasurableSet G)
-    (hT : HasBoundedStrongType (nontangentialOperator K · ·) 2 2 volume volume (C_Ts a))
-    (f : X → ℂ) (hmf : Measurable f) (hf : ∀ x, ‖f x‖ ≤ F.indicator 1 x) :
+/-- Theorem 1.0.2 -/
+theorem metric_carleson
+    (hq : q ∈ Ioc 1 2) (hqq' : q.HolderConjugate q') (mF : MeasurableSet F) (mG : MeasurableSet G)
+    (mf : Measurable f) (nf : (‖f ·‖) ≤ F.indicator 1) :
     ∫⁻ x in G, carlesonOperator K f x ≤
-    C1_0_2 a q * (volume G) ^ (q' : ℝ)⁻¹ * (volume F) ^ (q : ℝ)⁻¹ := by
+    C1_0_2 a q * volume G ^ (q' : ℝ)⁻¹ * volume F ^ (q : ℝ)⁻¹ := by
   sorry
 
 end


### PR DESCRIPTION
This PR tidies the assumptions of Lemmas 3.0.1, 1.0.3 and 1.0.2 according to [this Zulip thread](https://leanprover.zulipchat.com/#narrow/channel/442935-Carleson/topic/Assumptions.20needed.20for.20Lemma.203.2E0.2E4/near/526001243). It does not constitute a claim on any of these lemmas.