### PR TITLE
feat: integrableOn_K_mul

### DIFF
--- a/Carleson/Defs.lean
+++ b/Carleson/Defs.lean
@@ -408,6 +408,20 @@ lemma enorm_K_sub_le [ProperSpace X] [IsFiniteMeasureOnCompacts (volume : Measur
         apply ofReal_div_le (by positivity)
       · exact ofReal_div_le measureReal_nonneg
 
+lemma integrableOn_K_mul [IsOpenPosMeasure (volume : Measure X)]
+    [IsFiniteMeasureOnCompacts (volume : Measure X)] [ProperSpace X]
+    [IsOneSidedKernel a K] {f : X → ℂ} (hf : Integrable f) (x : X) {r : ℝ} (hr : 0 < r) :
+    IntegrableOn (K x * f) (ball x r)ᶜ := by
+  use (measurable_K_right x).aestronglyMeasurable.mul hf.aestronglyMeasurable |>.restrict
+  exact (hasFiniteIntegral_def _ _).mpr <| calc
+    _ = ∫⁻ y in (ball x r)ᶜ, ‖K x y‖ₑ * ‖f y‖ₑ := by simp
+    _ ≤ ∫⁻ y in (ball x r)ᶜ, C_K a / volume (ball x r) * ‖f y‖ₑ := by
+      exact setLIntegral_mono_ae (hf.aemeasurable.enorm.const_mul _).restrict <|
+        Filter.Eventually.of_forall fun y hy ↦ mul_le_mul_right' (enorm_K_le_ball_complement hy) _
+    _ = _ * ∫⁻ y in (ball x r)ᶜ, ‖f y‖ₑ := lintegral_const_mul'' _ hf.aemeasurable.enorm.restrict
+    _ ≤ _ * ∫⁻ y, ‖f y‖ₑ := mul_le_mul_left' (setLIntegral_le_lintegral _ _) _
+    _ < ∞ := ENNReal.mul_lt_top (ENNReal.div_lt_top coe_ne_top (measure_ball_pos _ x hr).ne') hf.2
+
 lemma integrableOn_K_Icc [IsOpenPosMeasure (volume : Measure X)]
     [IsFiniteMeasureOnCompacts (volume : Measure X)] [ProperSpace X]
     [IsOneSidedKernel a K] {x : X} {r R : ℝ} (hr : r > 0) :

--- a/Carleson/Defs.lean
+++ b/Carleson/Defs.lean
@@ -425,24 +425,11 @@ lemma integrableOn_K_Icc [IsOpenPosMeasure (volume : Measure X)]
     [IsFiniteMeasureOnCompacts (volume : Measure X)] [ProperSpace X]
     [IsOneSidedKernel a K] {x : X} {r R : ℝ} (hr : r > 0) :
     IntegrableOn (K x) {y | dist x y ∈ Icc r R} volume := by
-  use Measurable.aestronglyMeasurable (measurable_K_right x)
-  rw [hasFiniteIntegral_def]
-  calc ∫⁻ (y : X) in {y | dist x y ∈ Icc r R}, ‖K x y‖ₑ
-    _ ≤ ∫⁻ (y : X) in {y | dist x y ∈ Icc r R}, C_K a / volume (ball x r) := by
-      refine setLIntegral_mono measurable_const (fun y hy ↦ ?_)
-      refine (enorm_K_le_vol_inv x y).trans ?_
-      rw [vol]
-      gcongr
-      exact hy.1
-    _ < _ := by
-      rw [setLIntegral_const]
-      apply ENNReal.mul_lt_top (ENNReal.div_lt_top ENNReal.coe_ne_top _); swap
-      · simp_rw [← pos_iff_ne_zero, measure_ball_pos _ _ hr]
-      refine (Ne.lt_top fun h ↦ ?_)
-      have : {y | dist x y ∈ Icc r R} ⊆ closedBall x R := by
-        intro y ⟨_, hy⟩
-        exact mem_closedBall_comm.mp hy
-      exact measure_closedBall_lt_top.ne (measure_mono_top this h)
+  rw [← mul_one (K x)]
+  refine integrableOn_K_mul _ ?_ x hr ?_
+  · have : {y | dist x y ∈ Icc r R} ⊆ closedBall x R := by intro y; simp [dist_comm y x]
+    exact integrableOn_const <| lt_of_le_of_lt (measure_mono this) measure_closedBall_lt_top |>.ne
+  · intro y hy; simp [hy.1, dist_comm y x]
 
 /-- `K` is a two-sided Calderon-Zygmund kernel
 In the formalization `K x y` is defined everywhere, even for `x = y`. The assumptions on `K` show

--- a/Carleson/Defs.lean
+++ b/Carleson/Defs.lean
@@ -415,8 +415,8 @@ lemma integrableOn_K_mul [IsOpenPosMeasure (volume : Measure X)]
   use (measurable_K_right x).aestronglyMeasurable.mul hf.aestronglyMeasurable |>.restrict
   exact (hasFiniteIntegral_def _ _).mpr <| calc
     _ = ∫⁻ y in (ball x r)ᶜ, ‖K x y‖ₑ * ‖f y‖ₑ := by simp
-    _ ≤ ∫⁻ y in (ball x r)ᶜ, C_K a / volume (ball x r) * ‖f y‖ₑ := by
-      exact setLIntegral_mono_ae (hf.aemeasurable.enorm.const_mul _).restrict <|
+    _ ≤ ∫⁻ y in (ball x r)ᶜ, C_K a / volume (ball x r) * ‖f y‖ₑ :=
+      setLIntegral_mono_ae (hf.aemeasurable.enorm.const_mul _).restrict <|
         Filter.Eventually.of_forall fun y hy ↦ mul_le_mul_right' (enorm_K_le_ball_complement hy) _
     _ = _ * ∫⁻ y in (ball x r)ᶜ, ‖f y‖ₑ := lintegral_const_mul'' _ hf.aemeasurable.enorm.restrict
     _ ≤ _ * ∫⁻ y, ‖f y‖ₑ := mul_le_mul_left' (setLIntegral_le_lintegral _ _) _

--- a/Carleson/Defs.lean
+++ b/Carleson/Defs.lean
@@ -410,7 +410,7 @@ lemma enorm_K_sub_le [ProperSpace X] [IsFiniteMeasureOnCompacts (volume : Measur
 
 lemma integrableOn_K_mul [IsOpenPosMeasure (volume : Measure X)]
     [IsFiniteMeasureOnCompacts (volume : Measure X)] [ProperSpace X] [IsOneSidedKernel a K]
-    {f : X → ℂ} (s : Set X) (hf : IntegrableOn f s) (x : X) {r : ℝ} (hr : 0 < r)
+    {f : X → ℂ} {s : Set X} (hf : IntegrableOn f s) (x : X) {r : ℝ} (hr : 0 < r)
     (hs : s ⊆ (ball x r)ᶜ) : IntegrableOn (K x * f) s := by
   use (measurable_K_right x).aemeasurable.restrict.mul hf.aemeasurable |>.aestronglyMeasurable
   exact (hasFiniteIntegral_def _ _).mpr <| calc
@@ -426,9 +426,9 @@ lemma integrableOn_K_Icc [IsOpenPosMeasure (volume : Measure X)]
     [IsOneSidedKernel a K] {x : X} {r R : ℝ} (hr : r > 0) :
     IntegrableOn (K x) {y | dist x y ∈ Icc r R} volume := by
   rw [← mul_one (K x)]
-  refine integrableOn_K_mul _ ?_ x hr ?_
+  refine integrableOn_K_mul ?_ x hr ?_
   · have : {y | dist x y ∈ Icc r R} ⊆ closedBall x R := by intro y; simp [dist_comm y x]
-    exact integrableOn_const <| lt_of_le_of_lt (measure_mono this) measure_closedBall_lt_top |>.ne
+    exact integrableOn_const ((measure_mono this).trans_lt measure_closedBall_lt_top).ne
   · intro y hy; simp [hy.1, dist_comm y x]
 
 /-- `K` is a two-sided Calderon-Zygmund kernel

--- a/Carleson/Defs.lean
+++ b/Carleson/Defs.lean
@@ -409,17 +409,16 @@ lemma enorm_K_sub_le [ProperSpace X] [IsFiniteMeasureOnCompacts (volume : Measur
       · exact ofReal_div_le measureReal_nonneg
 
 lemma integrableOn_K_mul [IsOpenPosMeasure (volume : Measure X)]
-    [IsFiniteMeasureOnCompacts (volume : Measure X)] [ProperSpace X]
-    [IsOneSidedKernel a K] {f : X → ℂ} (hf : Integrable f) (x : X) {r : ℝ} (hr : 0 < r) :
-    IntegrableOn (K x * f) (ball x r)ᶜ := by
-  use (measurable_K_right x).aestronglyMeasurable.mul hf.aestronglyMeasurable |>.restrict
+    [IsFiniteMeasureOnCompacts (volume : Measure X)] [ProperSpace X] [IsOneSidedKernel a K]
+    {f : X → ℂ} (s : Set X) (hf : IntegrableOn f s) (x : X) {r : ℝ} (hr : 0 < r)
+    (hs : s ⊆ (ball x r)ᶜ) : IntegrableOn (K x * f) s := by
+  use (measurable_K_right x).aemeasurable.restrict.mul hf.aemeasurable |>.aestronglyMeasurable
   exact (hasFiniteIntegral_def _ _).mpr <| calc
-    _ = ∫⁻ y in (ball x r)ᶜ, ‖K x y‖ₑ * ‖f y‖ₑ := by simp
-    _ ≤ ∫⁻ y in (ball x r)ᶜ, C_K a / volume (ball x r) * ‖f y‖ₑ :=
-      setLIntegral_mono_ae (hf.aemeasurable.enorm.const_mul _).restrict <|
-        Filter.Eventually.of_forall fun y hy ↦ mul_le_mul_right' (enorm_K_le_ball_complement hy) _
-    _ = _ * ∫⁻ y in (ball x r)ᶜ, ‖f y‖ₑ := lintegral_const_mul'' _ hf.aemeasurable.enorm.restrict
-    _ ≤ _ * ∫⁻ y, ‖f y‖ₑ := mul_le_mul_left' (setLIntegral_le_lintegral _ _) _
+    _ = ∫⁻ y in s, ‖K x y‖ₑ * ‖f y‖ₑ := by simp
+    _ ≤ ∫⁻ y in s, C_K a / volume (ball x r) * ‖f y‖ₑ := by
+      exact setLIntegral_mono_ae (hf.aemeasurable.enorm.const_mul _) <| Filter.Eventually.of_forall
+        fun y hy ↦ mul_le_mul_right' (enorm_K_le_ball_complement (hs hy)) _
+    _ = _ * ∫⁻ y in s, ‖f y‖ₑ := by exact lintegral_const_mul'' _ hf.aemeasurable.enorm
     _ < ∞ := ENNReal.mul_lt_top (ENNReal.div_lt_top coe_ne_top (measure_ball_pos _ x hr).ne') hf.2
 
 lemma integrableOn_K_Icc [IsOpenPosMeasure (volume : Measure X)]

--- a/Carleson/Psi.lean
+++ b/Carleson/Psi.lean
@@ -898,7 +898,7 @@ lemma integrable_Ks_x {s : ℤ} {x : X} (hD : 1 < (D : ℝ)) : Integrable (Ks s 
   refine (integrableOn_iff_integrable_of_support_subset ?_).mp (integrableOn_K_mul ?_ x hr)
   · intro y hy
     rw [mem_compl_iff, mem_ball', not_lt]
-    have : «ψ» D (((D : ℝ) ^ s)⁻¹ * dist x y) ≠ 0 := by simp_all [Ks]
+    have : ψ (((D : ℝ) ^ s)⁻¹ * dist x y) ≠ 0 := by simp_all [Ks]
     rw [← Function.mem_support, support_ψ hD, mul_inv_rev] at this
     exact le_inv_mul_iff₀ (defaultD_pow_pos a s) |>.mp this.1.le
   · apply Continuous.integrable_of_hasCompactSupport

--- a/Carleson/Psi.lean
+++ b/Carleson/Psi.lean
@@ -893,19 +893,14 @@ lemma aestronglyMeasurable_Ks {s : ℤ} : AEStronglyMeasurable (fun x : X × X �
 
 /-- The function `y ↦ Ks s x y` is integrable. -/
 lemma integrable_Ks_x {s : ℤ} {x : X} (hD : 1 < (D : ℝ)) : Integrable (Ks s x) := by
-  /- Define a measurable, bounded function `K₀` that is equal to `K x` on the support of
-  `y ↦ ψ (D ^ (-s) * dist x y)`, so that `Ks s x y = K₀ y * ψ (D ^ (-s) * dist x y)`. -/
-  let _ : PosMulReflectLE ℝ := inferInstance -- perf: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/performance.20example.20with.20type-class.20inference
-  let K₀ (y : X) : ℂ := ite (dist x y ≤ D ^ s / (4 * D)) 0 (K x y)
-  have : Ks s x = fun y ↦ K₀ y * (ψ (D ^ (-s) * dist x y) : ℂ) := by
-    ext y
-    by_cases hy : dist x y ≤ D ^ s / (4 * D)
-    · suffices D ^ (-s) * dist x y ≤ 1 / (4 * D) by simp [-defaultD, -zpow_neg, Ks, ψ_formula₀ this]
-      apply le_of_le_of_eq <| (mul_le_mul_left (zpow_pos (one_pos.trans (D1 X)) (-s))).2 hy
-      field_simp
-    · simp [-defaultD, Ks, K₀, hy]
-  rw [this]
-  refine Integrable.bdd_mul ?_ (Measurable.aestronglyMeasurable ?_) ?_
+  let r := D ^ s * ((D : ℝ)⁻¹ * (4 : ℝ)⁻¹)
+  have hr : 0 < r := by positivity
+  refine (integrableOn_iff_integrable_of_support_subset ?_).mp (integrableOn_K_mul ?_ x hr)
+  · intro y hy
+    rw [mem_compl_iff, mem_ball', not_lt]
+    have : «ψ» D (((D : ℝ) ^ s)⁻¹ * dist x y) ≠ 0 := by simp_all [Ks]
+    rw [← Function.mem_support, support_ψ hD, mul_inv_rev] at this
+    exact le_inv_mul_iff₀ (defaultD_pow_pos a s) |>.mp this.1.le
   · apply Continuous.integrable_of_hasCompactSupport
     · exact continuous_ofReal.comp <| continuous_ψ.comp <| (by fun_prop)
     · apply HasCompactSupport.of_support_subset_isCompact (isCompact_closedBall x (D ^ s / 2))
@@ -914,20 +909,6 @@ lemma integrable_Ks_x {s : ℤ} {x : X} (hD : 1 < (D : ℝ)) : Integrable (Ks s 
       replace hy := hy.2.le
       rw [zpow_neg, mul_comm, ← div_eq_mul_inv, div_le_iff₀ (Ds0 X s)] at hy
       rwa [mem_closedBall, dist_comm, div_eq_mul_inv, mul_comm]
-  · refine Measurable.ite ?_ measurable_const measurable_K.of_uncurry_left
-    convert measurableSet_closedBall (x := x) (ε := D ^ s / (4 * D))
-    simp_rw [dist_comm x _, closedBall]
-  · refine ⟨C_K a / volume.real (ball x (D ^ s / (4 * D))), fun y ↦ ?_⟩
-    by_cases hy : dist x y ≤ D ^ s / (4 * D)
-    · simp only [hy, reduceIte, norm_zero, C_K, K₀]
-      positivity
-    · simp only [hy, reduceIte, K₀]
-      apply (norm_K_le_vol_inv x y).trans
-      rw [Real.vol]
-      gcongr
-      · exact measure_ball_pos_real x _ (div_pos (Ds0 X s) (fourD0 hD))
-      · exact measure_ball_ne_top
-      · exact le_of_not_ge hy
 
 end PseudoMetricSpace
 

--- a/Carleson/Psi.lean
+++ b/Carleson/Psi.lean
@@ -895,13 +895,9 @@ lemma aestronglyMeasurable_Ks {s : ℤ} : AEStronglyMeasurable (fun x : X × X �
 lemma integrable_Ks_x {s : ℤ} {x : X} (hD : 1 < (D : ℝ)) : Integrable (Ks s x) := by
   let r := D ^ s * ((D : ℝ)⁻¹ * (4 : ℝ)⁻¹)
   have hr : 0 < r := by positivity
-  refine (integrableOn_iff_integrable_of_support_subset ?_).mp (integrableOn_K_mul ?_ x hr)
-  · intro y hy
-    rw [mem_compl_iff, mem_ball', not_lt]
-    have : ψ (((D : ℝ) ^ s)⁻¹ * dist x y) ≠ 0 := by simp_all [Ks]
-    rw [← Function.mem_support, support_ψ hD, mul_inv_rev] at this
-    exact le_inv_mul_iff₀ (defaultD_pow_pos a s) |>.mp this.1.le
-  · apply Continuous.integrable_of_hasCompactSupport
+  rw [← integrableOn_iff_integrable_of_support_subset (s := (ball x r)ᶜ)]
+  · refine integrableOn_K_mul (ball x r)ᶜ ?_ x hr (subset_refl _)
+    apply Continuous.integrable_of_hasCompactSupport
     · exact continuous_ofReal.comp <| continuous_ψ.comp <| (by fun_prop)
     · apply HasCompactSupport.of_support_subset_isCompact (isCompact_closedBall x (D ^ s / 2))
       intro y hy
@@ -909,6 +905,11 @@ lemma integrable_Ks_x {s : ℤ} {x : X} (hD : 1 < (D : ℝ)) : Integrable (Ks s 
       replace hy := hy.2.le
       rw [zpow_neg, mul_comm, ← div_eq_mul_inv, div_le_iff₀ (Ds0 X s)] at hy
       rwa [mem_closedBall, dist_comm, div_eq_mul_inv, mul_comm]
+  · intro y hy
+    rw [mem_compl_iff, mem_ball', not_lt]
+    have : «ψ» D (((D : ℝ) ^ s)⁻¹ * dist x y) ≠ 0 := by simp_all [Ks]
+    rw [← Function.mem_support, support_ψ hD, mul_inv_rev] at this
+    exact le_inv_mul_iff₀ (defaultD_pow_pos a s) |>.mp this.1.le
 
 end PseudoMetricSpace
 

--- a/Carleson/Psi.lean
+++ b/Carleson/Psi.lean
@@ -896,7 +896,7 @@ lemma integrable_Ks_x {s : ℤ} {x : X} (hD : 1 < (D : ℝ)) : Integrable (Ks s 
   let r := D ^ s * ((D : ℝ)⁻¹ * (4 : ℝ)⁻¹)
   have hr : 0 < r := by positivity
   rw [← integrableOn_iff_integrable_of_support_subset (s := (ball x r)ᶜ)]
-  · refine integrableOn_K_mul (ball x r)ᶜ ?_ x hr (subset_refl _)
+  · refine integrableOn_K_mul ?_ x hr (subset_refl _)
     apply Continuous.integrable_of_hasCompactSupport
     · exact continuous_ofReal.comp <| continuous_ψ.comp <| (by fun_prop)
     · apply HasCompactSupport.of_support_subset_isCompact (isCompact_closedBall x (D ^ s / 2))


### PR DESCRIPTION
Prove `integrableOn_K_mul`, which will be needed for the proof of Lemma 10.2.7.

Use it to simplify the proofs of `integrable_Ks_x` and `integrableOn_K_Icc`.