### PR TITLE
Mark Hardy–Littlewood as finished

### DIFF
--- a/Carleson/Antichain/TileCorrelation.lean
+++ b/Carleson/Antichain/TileCorrelation.lean
@@ -344,13 +344,12 @@ lemma uncertainty' (ha : 1 ≤ a) {p₁ p₂ : 𝔓 X} (hle : 𝔰 p₁ ≤ 𝔰
 section lemma_6_1_5
 
 /-- The constant from lemma 6.1.5. -/
-def C6_1_5 (a : ℕ) : ℝ≥0 := 2^(255 * a^3)
+def C6_1_5 (a : ℕ) : ℝ≥0 := 2 ^ (255 * a ^ 3)
 
 -- TODO : 4 ≤ a in blueprint
-@[nolint unusedHavesSuffices] -- nlinarith does use h255.
 lemma C6_1_5_bound (ha : 4 ≤ a) : 2 ^ (254 * a ^ 3 + 1) * 2 ^ (11 * a) ≤ C6_1_5 a := by
-  have h255 : 255 * a ^ 3 = 254 * a ^ 3  + (a ^ 2 * a) := by
-    have : a ^ 2 * a = a^3 := rfl
+  have h255 : 255 * a ^ 3 = 254 * a ^ 3 + (a ^ 2 * a) := by
+    have : a ^ 2 * a = a ^ 3 := rfl
     rw [← one_mul (a ^ 2 * a), this, ← add_mul]
     rfl
   rw [C6_1_5, ← pow_add]

--- a/Carleson/Psi.lean
+++ b/Carleson/Psi.lean
@@ -350,12 +350,6 @@ lemma sum_Ks {t : Finset ℤ} (hs : nonzeroS D (dist x y) ⊆ t) (hD : 1 < (D : 
   intros
   rwa [psi_eq_zero_iff hD h]
 
--- maybe this version is also useful?
--- lemma sum_Ks' {t : Finset ℤ}
---     (hs : ∀ i : ℤ, (D ^ i * dist x y) ∈ Ioo (4 * D)⁻¹ 2⁻¹ → i ∈ t)
---     (hD : 1 < D) (h : x ≠ y) : ∑ i ∈ t, Ks i x y = K x y := by
---   sorry
-
 lemma dist_mem_Ioo_of_Ks_ne_zero {s : ℤ} {x y : X} (h : Ks s x y ≠ 0) :
     dist x y ∈ Ioo ((D ^ (s - 1) : ℝ) / 4) (D ^ s / 2) := by
   simp only [Ks, zpow_neg, ne_eq, mul_eq_zero, ofReal_eq_zero] at h

--- a/Carleson/TileExistence.lean
+++ b/Carleson/TileExistence.lean
@@ -337,7 +337,6 @@ lemma I1_subset_I3 {k : ℤ} (hk : -S ≤ k) (y:Yk X k) :
   left
   exact hi
 
-@[nolint unusedHavesSuffices]
 lemma I1_subset_I2 {k : ℤ} (hk : -S ≤ k) (y : Yk X k) :
     I1 hk y ⊆ I2 hk y := by
   rw [I1, I2]
@@ -1000,7 +999,6 @@ lemma small_boundary' (k:ℤ) (hk:-S ≤ k) (hk_mK : -S ≤ k - K') (y:Yk X k):
     K' * ∑' (z : ↑(Yk X (k - K'))), volume (⋃ (_ : clProp(hk_mK,z|hk,y)), I3 hk_mK z)
       = ∑ (_:Ioc (k-K') k),
         ∑'(z:Yk X (k-K')),volume (⋃ (_ : clProp(hk_mK,z|hk,y)), I3 hk_mK z) := by
-        -- have : K' = (Ioc (k-K') k).card := by sorry
         rw [Finset.sum_const]
         simp only [Finset.card_univ, Fintype.card_ofFinset, Int.card_Ioc, sub_sub_cancel,
           Int.toNat_natCast, nsmul_eq_mul]

--- a/Carleson/ToMathlib/HardyLittlewood.lean
+++ b/Carleson/ToMathlib/HardyLittlewood.lean
@@ -580,7 +580,6 @@ lemma CMB_defaultA_two_eq {a : ℕ} : CMB (defaultA a) 2 = 2 ^ (a + (3 / 2 : ℝ
 
 /-- Special case of equation (2.0.44). The proof is given between (9.0.12) and (9.0.34).
 Use the real interpolation theorem instead of following the blueprint. -/
-@[nolint unusedHavesSuffices] -- TODO: remove once the sorry is fixed
 lemma hasStrongType_MB [BorelSpace X] [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E]
     [IsFiniteMeasureOnCompacts μ] [ProperSpace X] [Nonempty X] [μ.IsOpenPosMeasure]
     (h𝓑 : 𝓑.Countable) {R : ℝ} (hR : ∀ i ∈ 𝓑, r i ≤ R) {p : ℝ≥0} (hp : 1 < p) :

--- a/Carleson/ToMathlib/WeakType.lean
+++ b/Carleson/ToMathlib/WeakType.lean
@@ -1,5 +1,6 @@
 import Carleson.ToMathlib.BoundedFiniteSupport
 import Carleson.ToMathlib.Misc
+import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
 import Mathlib.Analysis.SpecialFunctions.Pow.Integral
 
 noncomputable section
@@ -838,7 +839,11 @@ lemma lintegral_norm_pow_eq_distribution {f : α → ε} (hf : AEStronglyMeasura
           (∫⁻ (t : ℝ) in Ioi 0, ENNReal.ofReal (t ^ (p - 1))) * μ {x | ‖f x‖ₑ = ∞} := by
         convert (top_mul ae_finite.ne').symm
         convert mul_top (ENNReal.ofReal_pos.mpr hp).ne'
-        sorry -- TODO: this should be some lemma
+        rw [← not_ne_iff, lintegral_ofReal_ne_top_iff_integrable]; rotate_left
+        · exact (measurable_id.pow_const (p - 1)).aestronglyMeasurable.restrict
+        · refine ae_restrict_of_forall_mem measurableSet_Ioi fun x mx ↦ ?_
+          simp_rw [Pi.zero_apply]; rw [mem_Ioi] at mx; positivity
+        exact not_integrableOn_Ioi_rpow (p - 1)
       _ = ∫⁻ (t : ℝ) in Ioi 0, ENNReal.ofReal p * ENNReal.ofReal (t ^ (p - 1))
             * μ {x | ‖f x‖ₑ = ∞} := by
         rw [lintegral_mul_const, lintegral_const_mul] <;> fun_prop

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -6581,6 +6581,7 @@ The following lemma will be used to define $M$ in the proof of \Cref{Hardy-Littl
 
 We turn to the proof of \Cref{Hardy-Littlewood}.
 \begin{proof}[Proof of \Cref{Hardy-Littlewood}]
+\leanok
 \proves{Hardy-Littlewood}
 Let the collection $\mathcal{B}$ be given.
 We first show \eqref{eq-besico}.


### PR DESCRIPTION
After filling in a sorry and tidying up a bit I have checked using `#print axioms` that each of the five Lean statements corresponding to Proposition 2.0.6 – as well as `row_correlation` – depends only on `[propext, Classical.choice, Quot.sound]`.