### PR TITLE
feat: proof of Lemma 11.3.5

### DIFF
--- a/Carleson/Classical/Basic.lean
+++ b/Carleson/Classical/Basic.lean
@@ -128,7 +128,7 @@ lemma fourierCoeffOn_sub {a b : ℝ} {hab : a < b} {f g : ℝ → ℂ} {n : ℤ}
 lemma partialFourierSum_add {f g : ℝ → ℂ} {N : ℕ}
     (hf : IntervalIntegrable f MeasureTheory.volume 0 (2 * π))
     (hg : IntervalIntegrable g MeasureTheory.volume 0 (2 * π)) :
-  S_ N (f + g) = S_ N f + S_ N g := by
+    S_ N (f + g) = S_ N f + S_ N g := by
   ext x
   simp only [partialFourierSum, fourierCoeffOn_add hf hg, fourier_apply, fourier_coe_apply',
     Complex.ofReal_mul, Complex.ofReal_ofNat, add_mul, sum_add_distrib, Pi.add_apply]
@@ -143,8 +143,8 @@ lemma partialFourierSum_sub {f g : ℝ → ℂ} {N : ℕ}
     Complex.ofReal_mul, Complex.ofReal_ofNat, sub_mul, sum_sub_distrib, Pi.sub_apply]
 
 @[simp]
-lemma partialFourierSum_mul {f: ℝ → ℂ} {a : ℂ} {N : ℕ}:
-  S_ N (fun x ↦ a * f x) = fun x ↦ a * S_ N f x := by
+lemma partialFourierSum_mul {f: ℝ → ℂ} {a : ℂ} {N : ℕ} :
+    S_ N (fun x ↦ a * f x) = fun x ↦ a * S_ N f x := by
   ext x
   simp only [partialFourierSum, fourierCoeffOn_mul, fourier_apply, fourier_coe_apply', mul_assoc,
     Complex.ofReal_mul, Complex.ofReal_ofNat, mul_sum]

--- a/Carleson/Classical/Basic.lean
+++ b/Carleson/Classical/Basic.lean
@@ -128,7 +128,7 @@ lemma fourierCoeffOn_sub {a b : ℝ} {hab : a < b} {f g : ℝ → ℂ} {n : ℤ}
 lemma partialFourierSum_add {f g : ℝ → ℂ} {N : ℕ}
     (hf : IntervalIntegrable f MeasureTheory.volume 0 (2 * π))
     (hg : IntervalIntegrable g MeasureTheory.volume 0 (2 * π)) :
-    S_ N (f + g) = S_ N f + S_ N g := by
+  S_ N (f + g) = S_ N f + S_ N g := by
   ext x
   simp only [partialFourierSum, fourierCoeffOn_add hf hg, fourier_apply, fourier_coe_apply',
     Complex.ofReal_mul, Complex.ofReal_ofNat, add_mul, sum_add_distrib, Pi.add_apply]
@@ -143,8 +143,8 @@ lemma partialFourierSum_sub {f g : ℝ → ℂ} {N : ℕ}
     Complex.ofReal_mul, Complex.ofReal_ofNat, sub_mul, sum_sub_distrib, Pi.sub_apply]
 
 @[simp]
-lemma partialFourierSum_mul {f: ℝ → ℂ} {a : ℂ} {N : ℕ} :
-    S_ N (fun x ↦ a * f x) = fun x ↦ a * S_ N f x := by
+lemma partialFourierSum_mul {f: ℝ → ℂ} {a : ℂ} {N : ℕ}:
+  S_ N (fun x ↦ a * f x) = fun x ↦ a * S_ N f x := by
   ext x
   simp only [partialFourierSum, fourierCoeffOn_mul, fourier_apply, fourier_coe_apply', mul_assoc,
     Complex.ofReal_mul, Complex.ofReal_ofNat, mul_sum]

--- a/Carleson/Classical/DirichletKernel.lean
+++ b/Carleson/Classical/DirichletKernel.lean
@@ -14,7 +14,14 @@ def dirichletKernel (N : ℕ) : ℝ → ℂ :=
 def dirichletKernel' (N : ℕ) : ℝ → ℂ :=
   fun x ↦ (exp (I * N * x) / (1 - exp (-I * x)) + exp (-I * N * x) / (1 - exp (I * x)))
 
+
 variable {N : ℕ}
+
+@[fun_prop]
+lemma continuous_dirichletKernel : Continuous (dirichletKernel N) := by
+  change Continuous (fun x ↦ dirichletKernel N x)
+  simp only [dirichletKernel]
+  fun_prop
 
 lemma dirichletKernel_periodic : Function.Periodic (dirichletKernel N) (2 * π) := by
   intro x

--- a/Carleson/Classical/HilbertStrongType.lean
+++ b/Carleson/Classical/HilbertStrongType.lean
@@ -442,7 +442,6 @@ lemma approxHilbertTransform_eq_dirichletApprox {f : ℝ → ℂ} (hf : MemLp f 
     div_eq_inv_mul, ← exp_neg]
   ring
 
-
 /-- The function `L''`, defined in the Proof of Lemma 11.3.5. -/
 def dirichletApproxAux (n : ℕ) (x : ℝ) : ℂ :=
   (n : ℂ)⁻¹ * exp (I * 2 * n * x) / (1 - exp (-I * x)) * ∑ k ∈ .Ico 0 n, exp (I * 2 * k * x)

--- a/Carleson/Classical/HilbertStrongType.lean
+++ b/Carleson/Classical/HilbertStrongType.lean
@@ -179,7 +179,6 @@ def partial_sum_selfadjoint : Prop :=
     ∫ x in (0)..2 * π, conj (partialFourierSum n f x) * g x =
     ∫ x in (0)..2 * π, conj (f x) * partialFourierSum n g x
 
-
 theorem AddCircle.haarAddCircle_eq_smul_volume {T : ℝ} [hT : Fact (0 < T)] :
     (@haarAddCircle T _) = (ENNReal.ofReal T)⁻¹ • (volume : Measure (AddCircle T)) := by
   rw [volume_eq_smul_haarAddCircle, ← smul_assoc, smul_eq_mul,
@@ -189,6 +188,7 @@ open AddCircle in
 /-- Lemma 11.1.10.
 The blueprint states this on `[-π, π]`, but I think we can consistently change this to `(0, 2π]`.
 -/
+-- todo: add lemma that relates `eLpNorm ((Ioc a b).indicator f)` to `∫ x in a..b, _`
 lemma spectral_projection_bound {f : ℝ → ℂ} {n : ℕ} (hmf : Measurable f) :
     eLpNorm ((Ioc 0 (2 * π)).indicator (partialFourierSum n f)) 2 ≤
     eLpNorm ((Ioc 0 (2 * π)).indicator f) 2 := by

--- a/Carleson/Classical/HilbertStrongType.lean
+++ b/Carleson/Classical/HilbertStrongType.lean
@@ -113,7 +113,7 @@ lemma exp_I_mul_eq_one_iff_of_lt_of_lt (x : ℝ) (hx : -(2 * π) < x) (h'x : x <
   rwa [Real.cos_eq_one_iff_of_lt_of_lt hx h'x] at this
 
 lemma niceKernel_upperBound_aux {r x : ℝ} (hr : 0 < r) (hx : r ≤ x ∧ x ≤ π) :
-    1 + r / ‖1 - cexp (I * x)‖ ^ 2 ≤ 1 + 4 * r / x ^ 2 := calc
+    1 + r / ‖1 - exp (I * x)‖ ^ 2 ≤ 1 + 4 * r / x ^ 2 := calc
   _ ≤ 1 + r / (x / 2) ^ 2 := by
     gcongr 1 + ?_
     have : 0 < x := by linarith
@@ -458,7 +458,7 @@ lemma dirichletApprox_eq_add_dirichletApproxAux
   simp only [mul_add, ← mul_assoc]
   rw [inv_mul_cancel₀ (mod_cast hn)]
   simp only [mul_assoc, Finset.mul_sum, one_mul, dirichletApproxAux, neg_mul, div_eq_inv_mul,
-    Nat.Ico_zero_eq_range, ← exp_add, add_comm (1 - cexp (I * ↑x))⁻¹, add_left_inj]
+    Nat.Ico_zero_eq_range, ← exp_add, add_comm (1 - exp (I * ↑x))⁻¹, add_left_inj]
   congr with i
   ring_nf
 
@@ -628,7 +628,7 @@ lemma dist_dirichletApprox_le
     linarith
   rw [dirichletApprox_eq_add_dirichletApproxAux hexpx hnzero, dist_eq_norm, add_sub_right_comm]
   apply (norm_add_le _ _).trans
-  have A : ‖(1 - cexp (I * ↑x))⁻¹ - {y | ‖y‖ ∈ Ioo r 1}.indicator k x‖ ≤ 2 * niceKernel r x := by
+  have A : ‖(1 - exp (I * x))⁻¹ - {y | ‖y‖ ∈ Ioo r 1}.indicator k x‖ ≤ 2 * niceKernel r x := by
     apply norm_sub_indicator_k h'x _ rpos hr.2
     simpa only [Real.norm_eq_abs, abs_le] using hx
   have B : ‖dirichletApproxAux n x‖ ≤ 10 * niceKernel r x := by

--- a/Carleson/Classical/HilbertStrongType.lean
+++ b/Carleson/Classical/HilbertStrongType.lean
@@ -106,12 +106,6 @@ lemma niceKernel_eq_inv' {r x : ℝ} (hr : 0 < r ∧ r < π) (hx : ‖x‖ ≤ r
     simp only [Real.norm_of_nonpos h'x] at hx
     simp [Left.nonneg_neg_iff, h'x, hx]
 
-lemma exp_I_mul_eq_one_iff_of_lt_of_lt (x : ℝ) (hx : -(2 * π) < x) (h'x : x < 2 * π) :
-    exp (I * x) = 1 ↔ x = 0 := by
-  refine ⟨fun h ↦ ?_, fun h ↦ by simp [h]⟩
-  have : Real.cos x = 1 := by simpa [mul_comm I x] using congr(($h).re)
-  rwa [Real.cos_eq_one_iff_of_lt_of_lt hx h'x] at this
-
 lemma niceKernel_upperBound_aux {r x : ℝ} (hr : 0 < r) (hx : r ≤ x ∧ x ≤ π) :
     1 + r / ‖1 - exp (I * x)‖ ^ 2 ≤ 1 + 4 * r / x ^ 2 := calc
   _ ≤ 1 + r / (x / 2) ^ 2 := by
@@ -159,7 +153,7 @@ lemma niceKernel_lowerBound' {r x : ℝ} (hr : 0 < r) (h'r : r < 1) (hx : r ≤ 
 
 /-- Lemma 11.1.8 -/
 lemma mean_zero_oscillation {n : ℤ} (hn : n ≠ 0) :
-    ∫ x in (0)..2 * π, exp (.I * n * x) = 0 := by
+    ∫ x in (0)..2 * π, exp (I * n * x) = 0 := by
   rw [integral_exp_mul_complex (by simp [hn])]
   simp [sub_eq_zero, exp_eq_one_iff, hn, ← mul_assoc, mul_comm I,
     mul_right_comm _ I]

--- a/Carleson/Classical/HilbertStrongType.lean
+++ b/Carleson/Classical/HilbertStrongType.lean
@@ -314,31 +314,60 @@ def dirichletApprox (n : ℕ) (x : ℝ) : ℂ :=
   (n : ℂ)⁻¹ * ∑ k ∈ .Ico n (2 * n), dirichletKernel k x * Complex.exp (- Complex.I * k * x)
 
 /-- Lemma 11.3.5, part 1. -/
-lemma continuous_dirichletApprox {n : ℕ} : Continuous (dirichletApprox n) := by
-  sorry
+@[fun_prop] lemma continuous_dirichletApprox {n : ℕ} : Continuous (dirichletApprox n) := by
+  change Continuous (fun x ↦ dirichletApprox n x)
+  simp only [dirichletApprox]
+  fun_prop
 
 /-- Lemma 11.3.5, part 2. -/
 lemma periodic_dirichletApprox (n : ℕ) : (dirichletApprox n).Periodic (2 * π) := by
-  sorry
+  intro x
+  simp only [dirichletApprox, neg_mul, ofReal_add, ofReal_mul, ofReal_ofNat, mul_eq_mul_left_iff,
+    inv_eq_zero, Nat.cast_eq_zero]
+  left
+  congr with i
+  congr 1
+  · apply dirichletKernel_periodic
+  · simp only [mul_add, neg_add_rev, exp_add, exp_neg, ne_eq, inv_eq_zero, exp_ne_zero,
+      not_false_eq_true, mul_eq_right₀, inv_eq_one]
+    convert Complex.exp_nat_mul_two_pi_mul_I i using 2
+    ring
 
 /-- Lemma 11.3.5, part 3.
 The blueprint states this on `[-π, π]`, but I think we can consistently change this to `(0, 2π]`.
 -/
-lemma approxHilbertTransform_eq_dirichletApprox {f : ℝ → ℂ} {n : ℕ}
-    (hf : MemLp f ∞ volume) (periodic_f : f.Periodic (2 * π))
+lemma approxHilbertTransform_eq_dirichletApprox {f : ℝ → ℂ} (hf : MemLp f ∞ volume)
     {n : ℕ} {x : ℝ} :
     approxHilbertTransform n f x =
-    (2 * π)⁻¹ * ∫ y in (0)..2 * π, f y * dirichletApprox n (x - y) := by
-  sorry
+      (2 * π)⁻¹ * ∫ y in (0)..2 * π, f y * dirichletApprox n (x - y) := by
+  simp only [approxHilbertTransform, Finset.mul_sum, mul_inv_rev, ofReal_mul, ofReal_inv,
+    ofReal_ofNat, dirichletApprox, neg_mul, ofReal_sub]
+  rw [intervalIntegral.integral_finset_sum]; swap
+  · intro i hi
+    apply IntervalIntegrable.mul_continuousOn ?_ (by fun_prop)
+    rw [intervalIntegrable_iff_integrableOn_Ioc_of_le (by simp [Real.pi_nonneg])]
+    exact (hf.restrict _).integrable le_top
+  simp only [Finset.mul_sum]
+  congr with i
+  simp only [modulationOperator, Int.cast_neg, Int.cast_natCast, mul_neg, neg_mul]
+  rw [partialFourierSum_eq_conv_dirichletKernel]; swap
+  · apply IntervalIntegrable.mul_continuousOn ?_ (by fun_prop)
+    rw [intervalIntegrable_iff_integrableOn_Ioc_of_le (by simp [Real.pi_nonneg])]
+    exact (hf.restrict _).integrable le_top
+  simp only [one_div, mul_inv_rev, ← intervalIntegral.integral_const_mul, ←
+    intervalIntegral.integral_mul_const]
+  congr with y
+  simp only [modulationOperator, Int.cast_natCast, mul_sub, neg_sub, exp_sub, div_eq_inv_mul,
+    ← exp_neg]
+  ring
 
 /-- Lemma 11.3.5, part 4.
 The blueprint states this on `[-π, π]`, but I think we can consistently change this to `(0, 2π]`.
 -/
-lemma dist_dirichletApprox_le {f : ℝ → ℂ} {n : ℕ}
-    (hf : MemLp f ∞ volume) (periodic_f : f.Periodic (2 * π))
+lemma dist_dirichletApprox_le {n : ℕ}
     {r : ℝ} (hr : r ∈ Ioo 0 1) {n : ℕ} (hn : n = ⌈r⁻¹⌉₊) {x : ℝ} :
-    dist (dirichletApprox n x) ({y : ℂ | ‖y‖ ∈ Ioo r 1}.indicator 1 x) ≤
-    2 ^ (5 : ℝ) * niceKernel r x := by
+    dist (dirichletApprox n x) ({y : ℝ | ‖y‖ ∈ Ioo r 1}.indicator k x) ≤
+      2 ^ (5 : ℝ) * niceKernel r x := by
   sorry
 
 /- Lemma 11.1.6.

--- a/Carleson/ToMathlib/Misc.lean
+++ b/Carleson/ToMathlib/Misc.lean
@@ -510,6 +510,13 @@ lemma enorm_exp_I_mul_ofReal_sub_one_le {x : ℝ} : ‖exp (I * x) - 1‖ₑ ≤
   iterate 2 rw [← enorm_norm, Real.enorm_of_nonneg (norm_nonneg _)]
   exact ENNReal.ofReal_le_ofReal norm_exp_I_mul_ofReal_sub_one_le
 
+open Real in
+lemma exp_I_mul_eq_one_iff_of_lt_of_lt (x : ℝ) (hx : -(2 * π) < x) (h'x : x < 2 * π) :
+    exp (I * x) = 1 ↔ x = 0 := by
+  refine ⟨fun h ↦ ?_, fun h ↦ by simp [h]⟩
+  have : Real.cos x = 1 := by simpa [mul_comm I x] using congr(($h).re)
+  rwa [Real.cos_eq_one_iff_of_lt_of_lt hx h'x] at this
+
 end Norm
 
 section BddAbove

--- a/Carleson/ToMathlib/Misc.lean
+++ b/Carleson/ToMathlib/Misc.lean
@@ -480,11 +480,10 @@ lemma norm_indicator_one_le {α E}
 lemma norm_exp_I_mul_sub_ofReal (x y: ℝ) : ‖exp (I * (x - y))‖ = 1 := by
   rw [mul_comm, ← ofReal_sub, Complex.norm_exp_ofReal_mul_I]
 
-@[simp] lemma norm_exp_neg_I_mul_ofReal (x : ℝ) : ‖exp (-I * x)‖ = 1 := by
-  rw [neg_mul, exp_neg, norm_inv, norm_exp_I_mul_ofReal, inv_one]
-
-@[simp] lemma norm_exp_neg_I_mul_ofReal' (x : ℝ) : ‖exp (-(I * x))‖ = 1 := by
+@[simp] lemma norm_exp_neg_I_mul_ofReal (x : ℝ) : ‖exp (-(I * x))‖ = 1 := by
   rw [exp_neg, norm_inv, norm_exp_I_mul_ofReal, inv_one]
+
+lemma norm_exp_neg_I_mul_ofReal' (x : ℝ) : ‖exp (-I * x)‖ = 1 := by simp
 
 lemma norm_one_sub_exp_neg_I_mul_ofReal (x : ℝ) : ‖1 - exp (-(I * x))‖ = ‖1 - exp (I * x)‖ := by
   have : 1 - exp (I * x) = - exp (I * x) * (1 - exp (I * (-x))) := by

--- a/Carleson/ToMathlib/Misc.lean
+++ b/Carleson/ToMathlib/Misc.lean
@@ -471,14 +471,25 @@ lemma norm_indicator_one_le {α E}
     ‖s.indicator (1 : α → E) x‖ ≤ 1 :=
   Trans.trans (norm_indicator_le_norm_self 1 x) norm_one
 
-lemma norm_exp_I_mul_ofReal (x : ℝ) : ‖exp (.I * x)‖ = 1 := by
+@[simp] lemma norm_exp_I_mul_ofReal (x : ℝ) : ‖exp (I * x)‖ = 1 := by
   rw [mul_comm, Complex.norm_exp_ofReal_mul_I]
 
-lemma enorm_exp_I_mul_ofReal (x : ℝ) : ‖exp (.I * x)‖ₑ = 1 := by
+@[simp] lemma enorm_exp_I_mul_ofReal (x : ℝ) : ‖exp (I * x)‖ₑ = 1 := by
   rw [← enorm_norm, mul_comm, Complex.norm_exp_ofReal_mul_I, enorm_one]
 
-lemma norm_exp_I_mul_sub_ofReal (x y: ℝ) : ‖exp (.I * (x - y))‖ = 1 := by
+lemma norm_exp_I_mul_sub_ofReal (x y: ℝ) : ‖exp (I * (x - y))‖ = 1 := by
   rw [mul_comm, ← ofReal_sub, Complex.norm_exp_ofReal_mul_I]
+
+@[simp] lemma norm_exp_neg_I_mul_ofReal (x : ℝ) : ‖exp (-I * x)‖ = 1 := by
+  rw [neg_mul, exp_neg, norm_inv, norm_exp_I_mul_ofReal, inv_one]
+
+@[simp] lemma norm_exp_neg_I_mul_ofReal' (x : ℝ) : ‖exp (-(I * x))‖ = 1 := by
+  rw [exp_neg, norm_inv, norm_exp_I_mul_ofReal, inv_one]
+
+lemma norm_one_sub_exp_neg_I_mul_ofReal (x : ℝ) : ‖1 - exp (-(I * x))‖ = ‖1 - exp (I * x)‖ := by
+  have : 1 - exp (I * x) = - exp (I * x) * (1 - exp (I * (-x))) := by
+    simp [mul_sub, ← exp_add]; ring
+  simp [this]
 
 lemma norm_exp_I_mul_ofReal_sub_one {x : ℝ} : ‖exp (I * x) - 1‖ = ‖2 * Real.sin (x / 2)‖ := by
   rw [show ‖2 * Real.sin (x / 2)‖ = ‖2 * sin (x / 2)‖ by norm_cast, two_sin]

--- a/Carleson/ToMathlib/Topology/Instances/AddCircle/Defs.lean
+++ b/Carleson/ToMathlib/Topology/Instances/AddCircle/Defs.lean
@@ -67,7 +67,8 @@ end Periodic
 
 /-- Ioc version of mathlib `coe_eq_coe_iff_of_mem_Ico` -/
 lemma coe_eq_coe_iff_of_mem_Ioc {p : 𝕜} [hp : Fact (0 < p)]
-    {a : 𝕜} [Archimedean 𝕜] {x y : 𝕜} (hx : x ∈ Set.Ioc a (a + p)) (hy : y ∈ Set.Ioc a (a + p)) : (x : AddCircle p) = y ↔ x = y := by
+    {a : 𝕜} [Archimedean 𝕜] {x y : 𝕜} (hx : x ∈ Set.Ioc a (a + p)) (hy : y ∈ Set.Ioc a (a + p)) : 
+    (x : AddCircle p) = y ↔ x = y := by
   refine ⟨fun h => ?_, by tauto⟩
   suffices (⟨x, hx⟩ : Set.Ioc a (a + p)) = ⟨y, hy⟩ by exact Subtype.mk.inj this
   apply_fun equivIoc p a at h

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -8423,7 +8423,7 @@ defined by
 Define the approximate Hilbert transform by
 \begin{equation}
     L_N g=\frac 1N\sum_{n=0}^{N-1}
-       M_{-n-N} S_{N+n}M_{N+n}g\, .
+       M_{n+N} S_{N+n}M_{-N-n}g\, .
 \end{equation}
 
 
@@ -8447,17 +8447,17 @@ We have for every bounded measurable $2\pi$-periodic function $g$
      We have by the triangle inequality, the square root of the identity in \eqref{mnbound}, and \Cref{spectral-projection-bound}
     \begin{equation*}
         \|L_ng\|_{L^2[-\pi, \pi]}=\|\frac 1N\sum_{n=0}^{N-1}
-       M_{-n-N} S_{N+n}M_{N+n}g\|_{L^2[-\pi, \pi]}
+       M_{n+N} S_{N+n}M_{-N-n}g\|_{L^2[-\pi, \pi]}
     \end{equation*}
     \begin{equation*}
         \le \frac 1N\sum_{n=0}^{N-1} \|
-       M_{-n-N} S_{N+n}M_{N+n}g\|_{L^2[-\pi, \pi]}
+       M_{n+N} S_{N+n}M_{-N-n}g\|_{L^2[-\pi, \pi]}
          = \frac 1N\sum_{n=0}^{N-1} \|
-    S_{N+n}M_{N+n}g\|_{L^2[-\pi, \pi]}
+    S_{N+n}M_{-N-n}g\|_{L^2[-\pi, \pi]}
     \end{equation*}
      \begin{equation}
      \le \frac 1N\sum_{n=0}^{N-1} \|
- M_{N+n}g\|_{L^2[-\pi, \pi]} = \frac 1N\sum_{n=0}^{N-1} \|
+ M_{-N-n}g\|_{L^2[-\pi, \pi]} = \frac 1N\sum_{n=0}^{N-1} \|
 g\|_{L^2[-\pi, \pi]} =\|g\|_{L^2[-\pi, \pi]}\, .
     \end{equation}
 This proves \eqref{lnbound} and completes the proof of the lemma.
@@ -8598,12 +8598,13 @@ and all $2\pi$-periodic bounded measurable functions $f$ on $\R$
 \end{equation}
 and
 \begin{equation}\label{eqdifflhil}
-    \left|L'(x)-\mathbf{1}_{\{y:\, r<|y|<1\}} \kappa(x)\right|\le 2^{5}k_r(x)\, .
+    \left|L'(x)-\mathbf{1}_{\{y:\, r<|y|<1\}} \kappa(x)\right|\le 12 k_r(x)\, .
 \end{equation}
 \end{lemma}
 
 
 \begin{proof}
+\leanok
 We have by definition and \Cref{Dirichlet-kernel}
 \begin{equation}
     L_Ng(x)=
@@ -8636,40 +8637,40 @@ in \Cref{Dirichlet-kernel} to obtain
 \begin{equation*}
     {L'}(x)= \frac 1N\sum_{n=0}^{N-1}
      \left(\frac{e^{i(N+n)x}}{1-e^{-ix}}
-      +\frac {e^{-i(N+n)x}}{1-e^{ix}}\right) e^{-i(N+n)x}
+      +\frac {e^{-i(N+n)x}}{1-e^{ix}}\right) e^{i(N+n)x}
 \end{equation*}
 \begin{equation*}
     = \frac 1N\sum_{n=0}^{N-1}
-    \left(\frac{1}{1-e^{-ix}}
-      +\frac {e^{-i2(N+n)x}}{1-e^{ix}}\right)
+    \left(\frac{e^{i2(N+n)x}}{1-e^{-ix}}
+      +\frac {1}{1-e^{ix}}\right)
 \end{equation*}
 \begin{equation}\label{eqhil3}
-    = \frac{1}{1-e^{-ix}} +
-     \frac 1N \frac {e^{-i2Nx}}{1-e^{ix}}
+    = \frac{1}{1-e^{ix}} +
+     \frac 1N \frac {e^{i2Nx}}{1-e^{-ix}}
      \sum_{n=0}^{N-1}
-    {e^{-i2nx}}
+    {e^{i2nx}}
 \end{equation}
 and thus
 \begin{equation}
 \label{eq-L'L''}
-  {L'}(x) -\mathbf{1}_{\{y:\, r<|y|<1\}}\kappa(x)=L''(x)+ \frac{1-\mathbf{1}_{{\{y:\, r<|y|<1\}}}(x)(1-|x|)}{1-e^{-ix}},
+  {L'}(x) -\mathbf{1}_{\{y:\, r<|y|<1\}}\kappa(x)=L''(x)+ \frac{1-\mathbf{1}_{{\{y:\, r<|y|<1\}}}(x)(1-|x|)}{1-e^{ix}},
 \end{equation}
 where
-$$L''(x):=\frac 1N \frac {e^{-i2Nx}}{1-e^{ix}}
+$$L''(x):=\frac 1N \frac {e^{i2Nx}}{1-e^{-ix}}
      \sum_{n=0}^{N-1}
-    {e^{-i2nx}}.$$
+    {e^{i2nx}}.$$
 For $x\in [-\pi, r]\cup [r, \pi]$, we have using \Cref{lower-secant-bound} that
 \begin{equation*}
-   \left|\frac{1-\mathbf{1}_{{\{y:\, r<|y|<1\}}}(x)(1-|x|)}{1-e^{-ix}} \right|=\left|\frac{\min(|x|, 1)}{1-e^{-ix}} \right|\leq \frac{8\min(|x|, 1)}{|x|}
+   \left|\frac{1-\mathbf{1}_{{\{y:\, r<|y|<1\}}}(x)(1-|x|)}{1-e^{ix}} \right|=\left|\frac{\min(|x|, 1)}{1-e^{ix}} \right|\leq \frac{2\min(|x|, 1)}{|x|}
 \end{equation*}
 \begin{equation}
  \label{eq-diffzero2}
-    \leq 2^3\cdot 1\leq 2^{3} k_r(x).
+    \leq 2\cdot 1\leq 2 k_r(x).
 \end{equation}
 Next, we need to estimate $L''(x)$. If the real part of
 $e^{ix}$ is negative, we have
 \begin{equation}
-  1\le |1-e^{ix}|\le 2\, .
+  1\le |1-e^{-ix}|\le 2\, .
 \end{equation}
 and hence
 \begin{equation}\label{eqhil12}
@@ -8680,29 +8681,38 @@ and hence
 \end{equation}
 If the real part of $e^{ix}$ is positive and in particular while still $e^{ix}\neq \pm 1$, then we have by telescoping
 \begin{equation}
- (1-e^{-2ix})
+ (1-e^{2ix})
      \sum_{n=0}^{N-1}
-    {e^{-i2nx}}=1-e^{-i2Nx}\, .
+    {e^{i2nx}}=1-e^{i2Nx}\, .
 \end{equation}
-As $e^{-2ix}\neq 1$, we may divide by $1-e^{-2ix}$ and insert this into
+As $e^{2ix}\neq 1$, we may divide by $1-e^{2ix}$ and insert this into
 \eqref{eqhil3} to obtain
 \begin{equation}
  L''(x)=
-           \frac 1N \frac {e^{-i2Nx}}{1-e^{ix}}
-     \frac{1-e^{-i2Nx}}{1-e^{-2ix}}\, .
+           \frac 1N \frac {e^{i2Nx}}{1-e^{-ix}}
+     \frac{1-e^{i2Nx}}{1-e^{2ix}}\, .
 \end{equation}
 Hence, using the nonnegativity of the real part of $e^{ix}$
 \begin{equation*}
     |L''(x)|
  \le \frac 2 N \frac {1}{|1-e^{ix}|}
-     \frac{1}{|1-e^{-2ix}|}
+     \frac{1}{|1-e^{2ix}|}
  \end{equation*}
 \begin{equation}\label{eqhil11}
     = \frac 2 N \frac {1}{|1-e^{ix}|^2}
      \frac{1}{|1+e^{ix}|}\le
  \frac {2r}{|1-e^{ix}|^2}\le 2 \left(1+\frac {r}{|1-e^{ix}|^2}\right)
 \end{equation}
-Inequalities \eqref{eqhil13}, \eqref{eqdiffzero}, \eqref{eq-L'L''}, \eqref{eq-diffzero2}, \eqref{eqhil12}, and \eqref{eqhil11} prove \eqref{eqdifflhil}. This completes the proof of the lemma.
+Moreover, for $|x| \in [r, \pi]$, one checks easily that
+\begin{equation*}
+  1+\frac {r}{|1-e^{ix}|^2} \leq 5 k_r(x).
+\end{equation*}
+Therefore,~\eqref{eqhil12} and~\eqref{eqhil11} show that, in this range of $x$,
+\begin{equation*}
+  |L''(x)| \le 10 k_r(x).
+\end{equation*}
+Together with~\eqref{eq-diffzero2}, this prove \eqref{eqdifflhil} for $|x| \in [r, \pi]$.
+As the range $|x| \in [0,r)$ is covered by~\eqref{eqdiffzero}, this completes the proof of the lemma.
 \end{proof}
 
 

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -8617,20 +8617,20 @@ the continuous function
       K_{N+n}(x) e^{-i(N+n)x}\, .
 \end{equation}
 With \eqref{eqksumexp} of \Cref{Dirichlet-kernel}
-we have $|K_N(x)|\le N$ for every $x$ and thus
+we have $|K_N(x)|\le 2N+1$ for every $x$ and thus
 \begin{equation}\label{eqhil13}
     |{L'}(x)|\le \frac 1N\sum_{n=0}^{N-1}
-      (N+n) \le 2N\le 2^2 r^{-1}\, .
+      (2N+2n+1) \le 4N\le 2^3 r^{-1}\, .
 \end{equation}
 Therefore, for $|x|\in [0, r)\cup (1, \pi]$, we have
 \begin{equation}
     \label{eqdiffzero}
-    \left|L'(x)-\mathbf{1}_{\{y:\, r<|y|<1\}}(x)\kappa(x)\right|=|L'(x)|\leq 2^{2} r^{-1}.
+    \left|L'(x)-\mathbf{1}_{\{y:\, r<|y|<1\}}(x)\kappa(x)\right|=|L'(x)|\leq 2^{3} r^{-1}.
 \end{equation}
 This proves \eqref{eqdifflhil} for $|x|\in [0, r)$ since $k_r(x)=r^{-1}$ in this case.
 
-For $e^{ix'}\neq 1$
-and may use the expression
+For $e^{ix}\neq 1$
+one may use the expression
 \eqref{eqksumhil} for $K_N$
 in \Cref{Dirichlet-kernel} to obtain
 \begin{equation*}
@@ -8691,7 +8691,7 @@ As $e^{-2ix}\neq 1$, we may divide by $1-e^{-2ix}$ and insert this into
            \frac 1N \frac {e^{-i2Nx}}{1-e^{ix}}
      \frac{1-e^{-i2Nx}}{1-e^{-2ix}}\, .
 \end{equation}
-Hence, with \Cref{lower-secant-bound} and nonnegativity of the real part of $e^{ix}$
+Hence, using the nonnegativity of the real part of $e^{ix}$
 \begin{equation*}
     |L''(x)|
  \le \frac 2 N \frac {1}{|1-e^{ix}|}
@@ -8700,7 +8700,7 @@ Hence, with \Cref{lower-secant-bound} and nonnegativity of the real part of $e^{
 \begin{equation}\label{eqhil11}
     = \frac 2 N \frac {1}{|1-e^{ix}|^2}
      \frac{1}{|1+e^{ix}|}\le
- \frac {4r}{|1-e^{ix}|^2}\le 2^{2} \left(1+\frac {r}{|1-e^{ix}|^2}\right)
+ \frac {2r}{|1-e^{ix}|^2}\le 2 \left(1+\frac {r}{|1-e^{ix}|^2}\right)
 \end{equation}
 Inequalities \eqref{eqhil13}, \eqref{eqdiffzero}, \eqref{eq-L'L''}, \eqref{eq-diffzero2}, \eqref{eqhil12}, and \eqref{eqhil11} prove \eqref{eqdifflhil}. This completes the proof of the lemma.
 \end{proof}


### PR DESCRIPTION
I had to change a little bit the blueprint and the Lean statements, as the original proof was only correct up to sign: in the proof of Lemma 11.3.5, one wants to approximate a function kappa of the form .../(1 - e^{i x}), but the proof pretends that it's .../(1 - e^{-ix}) instead, see (11.3.24). In the PR, I change the definition of the approximate Hilbert transform (11.3.2), replacing M_{-n-N} S_{n+N} M_{n+N} with M_{n+N} S_{n+N} M_{-n-N} to make sure that what comes out is indeed .../(1 - e^{ix}). With this modified approximate Hilbert transform, everything seems to work fine.