### PR TITLE
Change `471a^3+4` to `472a^3`

### DIFF
--- a/Carleson/Defs.lean
+++ b/Carleson/Defs.lean
@@ -462,10 +462,6 @@ class ProofData {X : Type*} (a : outParam ℕ) (q : outParam ℝ) (K : outParam 
   isBounded_G : IsBounded G
   measurableSet_F : MeasurableSet F
   measurableSet_G : MeasurableSet G
-  /-- `volume_F_pos` can probably be removed. -/
-  volume_F_pos : 0 < volume F
-  /-- `volume_G_pos` can probably be removed. -/
-  volume_G_pos : 0 < volume G
   measurable_σ₁ : Measurable σ₁
   measurable_σ₂ : Measurable σ₂
   finite_range_σ₁ : Finite (range σ₁)

--- a/Carleson/Discrete/MainTheorem.lean
+++ b/Carleson/Discrete/MainTheorem.lean
@@ -10,7 +10,7 @@ variable {X : Type*} {a : ℕ} {q : ℝ} {K : X → X → ℂ} {σ₁ σ₂ : X 
 /-! ## Proposition 2.0.2 -/
 
 /-- The constant used in Proposition 2.0.2,
-which has value `2 ^ (434 * a ^ 3) / (q - 1) ^ 5` in the blueprint. -/
+which has value `2 ^ (471 * a ^ 3 + 1) / (q - 1) ^ 5` in the blueprint. -/
 noncomputable def C2_0_2 (a : ℕ) (q : ℝ≥0) : ℝ≥0 := C5_1_2 a q + C5_1_3 a q
 
 omit [TileStructure Q D κ S o] in

--- a/Carleson/FinitaryCarleson.lean
+++ b/Carleson/FinitaryCarleson.lean
@@ -95,7 +95,7 @@ theorem tile_sum_operator {G' : Set X} {f : X → ℂ}
 
 end
 
-/- The constant used in Proposition 2.0.1 -/
+/-- The constant used in Proposition 2.0.1. -/
 def C2_0_1 (a : ℕ) (q : ℝ≥0) : ℝ≥0 := C2_0_2 a q
 
 lemma C2_0_1_pos [TileStructure Q D κ S o] : C2_0_1 a nnq > 0 := C2_0_2_pos

--- a/Carleson/MetricCarleson/Truncation.lean
+++ b/Carleson/MetricCarleson/Truncation.lean
@@ -80,23 +80,8 @@ theorem finitary_carleson_step
     ∫⁻ x in G \ G', ‖T_lin CP.Q σ₁ σ₂ f x‖ₑ ≤
     C2_0_1 a q * (volume G) ^ (q' : ℝ)⁻¹ * (volume F) ^ (q : ℝ)⁻¹ := by
   obtain ⟨Q, BST_T_Q, hq, hqq', bF, mF, mf, nf, mσ₁, mσ₂, rσ₁, rσ₂, lσ⟩ := CP
-  rcases eq_zero_or_pos (volume G) with vG | vG
-  · use ∅, empty_subset _, isBounded_empty, MeasurableSet.empty
-    simp only [measure_empty, mul_zero, zero_le, diff_empty, true_and]
-    rw [setLIntegral_measure_zero _ _ vG]; exact zero_le _
-  rcases eq_zero_or_pos (volume F) with vF | vF
-  · use ∅, empty_subset _, isBounded_empty, MeasurableSet.empty
-    simp only [measure_empty, mul_zero, zero_le, diff_empty, true_and]
-    suffices ∀ x, ‖T_lin Q σ₁ σ₂ f x‖ₑ = 0 by
-      rw [lintegral_congr this, lintegral_zero]; exact zero_le _
-    intro x; rw [enorm_eq_zero, T_lin]
-    refine Finset.sum_eq_zero fun s ms ↦ integral_eq_zero_of_ae ?_
-    classical
-    convert ite_ae_eq_of_measure_zero (fun y ↦ Ks s x y * f y * exp (I * Q x y)) 0 F vF using 1
-    ext y; symm; rw [ite_eq_left_iff]; intro ny
-    specialize nf y; simp_rw [indicator_of_notMem ny, norm_le_zero_iff] at nf; simp [nf]
   let PD : ProofData a q K σ₁ σ₂ F G :=
-    ⟨‹_›, hq, bF, bG, mF, mG, vF, vG, mσ₁, mσ₂, rσ₁, rσ₂, lσ, Q, BST_T_Q⟩
+    ⟨‹_›, hq, bF, bG, mF, mG, mσ₁, mσ₂, rσ₁, rσ₂, lσ, Q, BST_T_Q⟩
   obtain ⟨G₁, mG₁, vG₁, hG₁⟩ := finitary_carleson X
   refine ⟨G ∩ G₁, inter_subset_left, bG.subset inter_subset_left, mG.inter mG₁, ?_, ?_⟩
   · refine le_trans ?_ vG₁; gcongr; exact inter_subset_right

--- a/Carleson/MetricCarleson/Truncation.lean
+++ b/Carleson/MetricCarleson/Truncation.lean
@@ -587,7 +587,7 @@ def T_R (K : X → X → ℂ) (Q : SimpleFunc X (Θ X)) (R₁ R₂ R : ℝ) (f :
   (ball o R).indicator (fun x ↦ carlesonOperatorIntegrand K (Q x) R₁ R₂ f x) x
 
 /-- The constant used from `R_truncation` to `metric_carleson`. -/
-def C1_0_2 (a : ℕ) (q : ℝ≥0) : ℝ≥0 := 2 ^ (471 * a ^ 3 + 4) / (q - 1) ^ 6
+def C1_0_2 (a : ℕ) (q : ℝ≥0) : ℝ≥0 := 2 ^ (472 * a ^ 3) / (q - 1) ^ 6
 
 lemma C1_0_2_pos {a : ℕ} {q : ℝ≥0} (hq : 1 < q) : 0 < C1_0_2 a q := by
   rw [C1_0_2]
@@ -623,7 +623,11 @@ lemma le_C1_0_2 (a4 : 4 ≤ a) (hq : q ∈ Ioc 1 2) :
           _ = 107 * a ^ 3 := by ring
           _ ≤ 471 * a ^ 3 := by gcongr; norm_num
           _ ≤ _ := Nat.le_add_right ..
-    _ = _ := by rw [C3_0_4, ← two_mul, ← mul_div_assoc, ← pow_succ', C1_0_2]
+    _ ≤ _ := by
+      rw [C3_0_4, ← two_mul, ← mul_div_assoc, ← pow_succ', C1_0_2]; gcongr
+      · exact one_le_two
+      · rw [add_assoc, show 472 * a ^ 3 = 471 * a ^ 3 + a ^ 3 by ring]
+        gcongr; exact a4.trans (Nat.le_pow zero_lt_three)
 
 variable [IsCancellative X (defaultτ a)]
 

--- a/Carleson/TwoSidedCarleson/MainTheorem.lean
+++ b/Carleson/TwoSidedCarleson/MainTheorem.lean
@@ -7,9 +7,9 @@ open scoped NNReal
 noncomputable section
 
 /-- The constant used in `two_sided_metric_carleson`.
-Has value `2 ^ (452 * a ^ 3) / (q - 1) ^ 6` in the blueprint. -/
+Has value `2 ^ (474 * a ^ 3) / (q - 1) ^ 6` in the blueprint. -/
 -- todo: put C_K in NNReal?
-def C10_0_1 (a : ℕ) (q : ℝ≥0) : ℝ≥0 := (C_K a) ^ 2 * C1_0_2 a q
+def C10_0_1 (a : ℕ) (q : ℝ≥0) : ℝ≥0 := C_K a ^ 2 * C1_0_2 a q
 
 lemma C10_0_1_pos {a : ℕ} {q : ℝ≥0} (hq : 1 < q) : 0 < C10_0_1 a q :=
   mul_pos (pow_two_pos_of_ne_zero <| by simp_rw [ne_eq, C_K_pos.ne', not_false_eq_true])

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -417,7 +417,7 @@ Then there exists a Borel set $G'$ with $2\mu(G') \leq \mu(G)$ such that for all
 we have
 \begin{equation}
     \label{disclesssim}
-   \int_{G \setminus G'} \left| \sum_{\fp \in \fP} T_{\fp} f (x) \right| \, \mathrm{d}\mu(x) \le \frac{2^{434a^3}}{(q-1)^4} \mu(G)^{1-\frac{1}{q}} \mu(F)^{\frac{1}{q}}\,.
+   \int_{G \setminus G'} \left| \sum_{\fp \in \fP} T_{\fp} f (x) \right| \, \mathrm{d}\mu(x) \le \frac{2^{471a^3+1}}{(q-1)^5} \mu(G)^{1-\frac{1}{q}} \mu(F)^{\frac{1}{q}}\,.
 \end{equation}
 \end{proposition}
 

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -161,7 +161,7 @@ which by interpolation techniques recovers $L^q$ estimates for the open range $1
     $|f|\le \mathbf{1}_F$, we have, with $T$ defined in \eqref{def-main-op},
     \begin{equation}
         \label{resweak}
-        \left|\int_{G} T f \, \mathrm{d}\mu\right| \leq \frac{2^{471a^3+4}}{(q-1)^6} \mu(G)^{1-\frac{1}{q}} \mu(F)^{\frac{1}{q}}\, .
+        \left|\int_{G} T f \, \mathrm{d}\mu\right| \leq \frac{2^{472a^3}}{(q-1)^6} \mu(G)^{1-\frac{1}{q}} \mu(F)^{\frac{1}{q}}\, .
     \end{equation}
 \end{theorem}
 
@@ -200,7 +200,7 @@ where again $e(r)=e^{ir}$.
     $|f|\le \mathbf{1}_F$, we have, with $T_\tQ$ defined in \eqref{def-lin-main-op},
     \begin{equation}
         \label{linresweak}
-        \left|\int_{G} T_\tQ f \, \mathrm{d}\mu\right| \le \frac{2^{471a^3+4}}{(q-1)^6} \mu(G)^{1-\frac{1}{q}} \mu(F)^{\frac{1}{q}}\, .
+        \left|\int_{G} T_\tQ f \, \mathrm{d}\mu\right| \le \frac{2^{472a^3}}{(q-1)^6} \mu(G)^{1-\frac{1}{q}} \mu(F)^{\frac{1}{q}}\, .
     \end{equation}
 \end{theorem}
 
@@ -928,11 +928,8 @@ For each $x$ and all $f$, the functions $\sup_{2^{-n} < R_1 < R_2 < 2^n} T_{R_1,
     \uses{S-truncation}
 
     Let $F$, $G$ be Borel sets in $X$. Let $f:X\to \C$ be a Borel function with $|f|\le 1_F$. Then for all $R\in 2^\N$ we have
-    $$
-        \int \mathbf{1}_G \sup_{1/R<R_1<R_2<R} |T_{R_1,R_2,R} f(x)|\, d\mu(x)
-    $$
     \begin{equation} \label{Rcut}
-        \le \frac{2^{471a^3+4}}{(q-1)^6} \mu(G)^{1-\frac{1}{q}} \mu(F)^{\frac{1}{q}},
+        \int \mathbf{1}_G \sup_{1/R<R_1<R_2<R} |T_{R_1,R_2,R} f(x)|\, d\mu(x) \le \frac{2^{472a^3}}{(q-1)^6} \mu(G)^{1-\frac{1}{q}} \mu(F)^{\frac{1}{q}},
     \end{equation}
     where
     \begin{equation}\label{TRR}

--- a/blueprint/src/chapter/main.tex
+++ b/blueprint/src/chapter/main.tex
@@ -6873,7 +6873,7 @@ T_r f(x):= \int_{r\le\rho(x,y)} K(x,y) f(y) \, d\mu(y) = \int_{X\setminus B(x,r)
         $|f|\le \mathbf{1}_F$, we have, with $T$ defined in \eqref{def-main-op},
       \begin{equation}
         \label{two-sided-resweak}
-            \left|\int_{G} T f \, \mathrm{d}\mu\right| \leq \frac{2^{452a^3}}{(q-1)^6} \mu(G)^{1-\frac{1}{q}} \mu(F)^{\frac{1}{q}}\, .
+            \left|\int_{G} T f \, \mathrm{d}\mu\right| \leq \frac{2^{474a^3}}{(q-1)^6} \mu(G)^{1-\frac{1}{q}} \mu(F)^{\frac{1}{q}}\, .
         \end{equation}
 \end{theorem}
 
@@ -8002,7 +8002,7 @@ All subsections past \Cref{10classical} are mutually independent.
 Let a uniformly continuous $2\pi$-periodic function $f:\R\to \mathbb{C}$ and $\epsilon>0$ be given.
 Let
 \begin{equation}
-    C_{a,q} := \frac{2^{452a^3}}{(q-1)^6}
+    C_{a,q} := \frac{2^{474a^3}}{(q-1)^6}
 \end{equation}
 denote the constant from \Cref{two-sided-metric-space-Carleson}.
 Define


### PR DESCRIPTION
Including the `discrete_carleson`, `finitary_carleson` and `two_sided_metric_carleson` constants that were never quite corrected after bumps.

Also remove `volume_F_pos` and `volume_G_pos` since 1.0.2 is completed and none of #452 (11.1.6), #438 (6.1.3) or #449 (7.7.2) use those assumptions.