### PR TITLE
`mem_filter_univ` and `with` notation for sums

### DIFF
--- a/Carleson/Antichain/AntichainOperator.lean
+++ b/Carleson/Antichain/AntichainOperator.lean
@@ -78,14 +78,14 @@ lemma dens1_antichain_dach (hg : Measurable g) (hgG : ∀ x, ‖g x‖ ≤ G.ind
         ‖∫ x, adjointCarleson p' g x * conj (adjointCarleson p g x)‖ₑ := by
       congr! 2 with p mp; nth_rw 2 [← Finset.filter_filter]
       refine (Finset.sum_filter_of_ne fun x mx nx ↦ ?_).symm
-      simp_rw [Finset.mem_filter, Finset.mem_univ, true_and] at mx
+      rw [Finset.mem_filter_univ] at mx
       contrapose! nx; exact Tile.correlation_zero_of_ne_subset mx.2 nx
     _ ≤ 2 * ∑ p with p ∈ 𝔄,
         ∑ p' with (p' ∈ 𝔄 ∧ 𝔰 p' ≤ 𝔰 p) ∧ (𝓘 p' : Set X) ⊆ ball (𝔠 p) (14 * D ^ 𝔰 p),
         Tile.C6_1_5 a * (1 + edist_(p') (𝒬 p') (𝒬 p)) ^ (-(2 * a ^ 2 + a ^ 3 : ℝ)⁻¹) /
         volume (𝓘 p : Set X) * (∫⁻ y in E p', ‖g y‖ₑ) * ∫⁻ x in E p, ‖g x‖ₑ := by
       gcongr with p mp p' mp'
-      simp_rw [Finset.mem_filter, Finset.mem_univ, true_and] at mp'
+      rw [Finset.mem_filter_univ] at mp'
       exact Tile.correlation_le mp'.1.2 hg hgG
     _ = 2 * Tile.C6_1_5 a * ∑ p with p ∈ 𝔄, (∫⁻ x in E p, ‖g x‖ₑ) * (volume (𝓘 p : Set X))⁻¹ *
         ∑ p' with (p' ∈ 𝔄 ∧ 𝔰 p' ≤ 𝔰 p) ∧ (𝓘 p' : Set X) ⊆ ball (𝔠 p) (14 * D ^ 𝔰 p),
@@ -169,7 +169,7 @@ lemma dach_bound (h𝔄 : IsAntichain (· ≤ ·) 𝔄) {p : 𝔓 X} (mp : p ∈
         rw [← mul_assoc, ← mul_assoc, mul_comm _ (_ ^ _), mul_assoc, mul_assoc]
       congr! 2 with p' mp'
       rw [← mul_assoc, ← inter_indicator_mul]; simp_rw [Pi.one_apply, mul_one]
-      simp_rw [A, mem_setOf_eq, Finset.mem_filter, Finset.mem_univ, true_and] at mp'
+      simp_rw [A, mem_setOf_eq, Finset.mem_filter_univ] at mp'
       have inter_eq : B ∩ E p' = E p' := by
         rw [inter_eq_right]; exact E_subset_𝓘.trans mp'.2
       rw [inter_eq]
@@ -249,7 +249,7 @@ lemma dens1_antichain_sq (h𝔄 : IsAntichain (· ≤ ·) 𝔄)
         ∫⁻ y in E p, C6_1_6 a * dens₁ 𝔄 ^ (p₆ a)⁻¹ * M14 𝔄 (q₆ a) g y * ‖g y‖ₑ := by
       gcongr with p mp; rw [← lintegral_const_mul _ hg.enorm]
       refine setLIntegral_mono' measurableSet_E fun x mx ↦ mul_le_mul_right' ?_ _
-      simp_rw [Finset.mem_filter, Finset.mem_univ, true_and] at mp
+      rw [Finset.mem_filter_univ] at mp
       refine dach_bound h𝔄 mp hg hgG <|
         ((E_subset_𝓘.trans Grid_subset_ball).trans (ball_subset_ball ?_)) mx
       change (4 : ℝ) * D ^ 𝔰 p ≤ _; gcongr; norm_num
@@ -264,7 +264,7 @@ lemma dens1_antichain_sq (h𝔄 : IsAntichain (· ≤ ·) 𝔄)
         have := (E_disjoint h𝔄 mp mp').mt hn
         rwa [not_not] at this
       · exact fun _ _ ↦ measurableSet_E
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+      simp only [Finset.mem_filter_univ]
     _ ≤ Tile.C6_1_5 a * 2 ^ (6 * a + 1) * C6_1_6 a * dens₁ 𝔄 ^ (p₆ a)⁻¹ *
         ∫⁻ y, M14 𝔄 (q₆ a) g y * ‖g y‖ₑ := by gcongr; exact setLIntegral_le_lintegral _ _
     _ ≤ Tile.C6_1_5 a * 2 ^ (6 * a + 1) * C6_1_6 a * dens₁ 𝔄 ^ (p₆ a)⁻¹ *

--- a/Carleson/Antichain/AntichainTileCount.lean
+++ b/Carleson/Antichain/AntichainTileCount.lean
@@ -72,20 +72,17 @@ lemma tile_reach {ϑ : Θ X} {N : ℕ} {p p' : 𝔓 X} (hp : dist_(p) (𝒬 p) �
       exact le_cdist_iterate (by positivity) (𝒬 p') o' (5*a + 2)
     rw [← le_div_iff₀' (by positivity), div_eq_mul_inv, ← zpow_neg, neg_add, ← neg_mul,
       ← sub_eq_add_neg, mul_comm _ ((2 : ℝ) ^ _)] at hle
-    calc dist_{𝔠 p, 2^((2 : ℤ) - 5*a^2 - 2*a) * D^𝔰 p'} (𝒬 p') o'
-      _ ≤ 2^(-(5 : ℤ)*a - 2) * dist_{𝔠 p, 4 * D^𝔰 p'} (𝒬 p') o' := hle
-      _ < 2^(-(5 : ℤ)*a - 2) * 2^(5*a + N + 2) := (mul_lt_mul_left (by positivity)).mpr hlt2
-      _ = 2^N := by
-        rw [← zpow_natCast, ← zpow_add₀ two_ne_zero]
-        simp only [Int.reduceNeg, neg_mul, Nat.cast_add, Nat.cast_mul, Nat.cast_ofNat,
-          sub_add_add_cancel, neg_add_cancel_left, zpow_natCast]
+    calc
+      _ ≤ 2 ^ (-5 * a - 2 : ℤ) * dist_{𝔠 p, 4 * D ^ 𝔰 p'} (𝒬 p') o' := hle
+      _ < 2 ^ (-5 * a - 2 : ℤ) * 2 ^ (5 * a + N + 2) := (mul_lt_mul_left (by positivity)).mpr hlt2
+      _ = _ := by rw [← zpow_natCast, ← zpow_natCast, ← zpow_add₀ two_ne_zero]; congr 1; omega
   -- 6.3.12
-  have hp'3 : dist_(p) (𝒬 p') o' < 2^N := by
+  have hp'3 : dist_(p) (𝒬 p') o' < 2 ^ N := by
     apply lt_of_le_of_lt (cdist_mono _) hlt3
     gcongr
     rw [div_le_iff₀ (by positivity)]
     rw [mul_comm, ← mul_assoc]
-    calc (D : ℝ) ^ 𝔰 p
+    calc
       _ = 1 * (D : ℝ) ^ 𝔰 p := by rw [one_mul]
       _ ≤ 4 * 2 ^ (2 - 5 * (a : ℤ) ^ 2 - 2 * ↑a) * D * D ^ 𝔰 p := by
         have h4 : (4 : ℝ) = 2^(2 : ℤ) := by ring
@@ -98,8 +95,8 @@ lemma tile_reach {ϑ : Θ X} {N : ℕ} {p p' : 𝔓 X} (hp : dist_(p) (𝒬 p) �
           gcongr --uses h12
           ring_nf
           nlinarith only
-      _ = (4 * 2 ^ (2 - 5 * (a : ℤ)  ^ 2 - 2 * ↑a)) * (D * D ^ 𝔰 p) := by ring
-      _ ≤ 4 * 2 ^ (2 - 5 * (a : ℤ)  ^ 2 - 2 * ↑a) * D ^ 𝔰 p' := by
+      _ = 4 * 2 ^ (2 - 5 * (a : ℤ) ^ 2 - 2 * a) * (D * D ^ 𝔰 p) := by ring
+      _ ≤ _ := by
         have h1D : 1 ≤ (D : ℝ) := one_le_D
         nth_rewrite 1 [mul_le_mul_left (by positivity), ← zpow_one (D : ℝ),
           ← zpow_add₀ (ne_of_gt (defaultD_pos _))]
@@ -108,12 +105,11 @@ lemma tile_reach {ϑ : Θ X} {N : ℕ} {p p' : 𝔓 X} (hp : dist_(p) (𝒬 p) �
         exact hs
   -- 6.3.13 (and 6.3.3.)
   have h34 : (3 : ℝ) < 4 := by linarith
-  calc dist_(p) o' (𝒬 p)
+  calc
     _ = dist_(p) (𝒬 p) o' := by rw [dist_comm]
     _ ≤ dist_(p) (𝒬 p) (𝒬 p') + dist_(p) (𝒬 p') o' := dist_triangle _ _ _
-    _ < 2^(N + 1) + 2^N := add_lt_add_of_le_of_lt hp'2 hp'3
-    _ < 2^(N + 2) := by ring_nf; gcongr -- uses h34
-  -- 6.3.14 -- Not needed
+    _ < 2 ^ (N + 1) + 2 ^ N := add_lt_add_of_le_of_lt hp'2 hp'3
+    _ < _ := by ring_nf; gcongr -- uses h34
 
 /-- Def 6.3.15. -/
 def 𝔄_aux (𝔄 : Set (𝔓 X)) (ϑ : Θ X) (N : ℕ) : Set (𝔓 X) :=
@@ -156,32 +152,31 @@ open Metric
 open scoped Classical in
 -- Lemma 6.3.2
 lemma stack_density (𝔄 : Set (𝔓 X)) (ϑ : Θ X) (N : ℕ) (L : Grid X) :
-    ∑ (p ∈ {p ∈ (𝔄_aux 𝔄 ϑ N).toFinset | 𝓘 p = L}), volume (E p ∩ G) ≤
-      2^(a * (N + 5)) * dens₁ (𝔄 : Set (𝔓 X)) * volume (L : Set X) := by
+    ∑ p ∈ 𝔄_aux 𝔄 ϑ N with 𝓘 p = L, volume (E p ∩ G) ≤
+    2 ^ (a * (N + 5)) * dens₁ 𝔄 * volume (L : Set X) := by
   -- 6.3.17
   set 𝔄' : Set (𝔓 X) := {p ∈ (𝔄_aux 𝔄 ϑ N) | 𝓘 p = L} with 𝔄'_def
   have hI : ∀ {q q' : 𝔓 X} (hq : q ∈ 𝔄') (hq' : q' ∈ 𝔄'), 𝓘 q = 𝓘 q' := fun hq hq' ↦ by
-      simp only [𝔄'_def, 𝔄_aux] at hq hq'
-      rw [hq.2, hq'.2]
-  have heq : ∑ p ∈ (𝔄_aux 𝔄 ϑ N).toFinset with 𝓘 p = L, volume (E p ∩ G) =
-      ∑ p ∈ 𝔄'.toFinset, volume (E p ∩ G) := by congr; aesop
+    simp only [𝔄'_def, 𝔄_aux] at hq hq'
+    rw [hq.2, hq'.2]
+  have heq : ∑ p ∈ 𝔄_aux 𝔄 ϑ N with 𝓘 p = L, volume (E p ∩ G) =
+      ∑ p ∈ 𝔄', volume (E p ∩ G) := by congr; aesop
   by_cases h𝔄' : 𝔄'.Nonempty
   · -- 6.3.18
-    have h_aux : ∀ (p : 𝔓 X) (hp : p ∈ 𝔄'.toFinset), volume (E p ∩ G) ≤
-        2^a * dens₁ (𝔄' : Set (𝔓 X)) * volume (L : Set X) := by
-      intro p hp
+    have h_aux (p : 𝔓 X) (hp : p ∈ 𝔄'.toFinset) :
+        volume (E p ∩ G) ≤ 2 ^ a * dens₁ 𝔄' * volume (L : Set X) := by
       rw [mem_toFinset] at hp
-      calc volume (E p ∩ G)
+      calc
         _ ≤ volume (E₂ 2 p) := by
           apply measure_mono
           intro x hx
           have hQ : Q x ∈ ball_(p) (𝒬 p) 1 := subset_cball hx.1.2.1
           simp only [E₂, TileLike.toSet, smul_fst, smul_snd, mem_inter_iff, mem_preimage, mem_ball]
           exact ⟨⟨hx.1.1, hx.2⟩, lt_trans hQ one_lt_two⟩
-        _ ≤ 2^a * dens₁ (𝔄' : Set (𝔓 X)) * volume (L : Set X) := by
+        _ ≤ 2 ^ a * dens₁ 𝔄' * volume (L : Set X) := by
           -- Wow this is messy.
           have hIL : 𝓘 p = L := by simp_rw [← hp.2]
-          have h2a : ((2 : ℝ≥0∞) ^ a)⁻¹ = 2^(-(a : ℤ)) := by
+          have h2a : ((2 : ℝ≥0∞) ^ a)⁻¹ = 2 ^ (-(a : ℤ)) := by
             rw [← zpow_natCast, ENNReal.zpow_neg two_ne_zero ENNReal.ofNat_ne_top]
           rw [← ENNReal.div_le_iff, ← ENNReal.div_le_iff' (Ne.symm (NeZero.ne' (2 ^ a))),
             ENNReal.div_eq_inv_mul, h2a, dens₁]
@@ -272,21 +267,20 @@ lemma stack_density (𝔄 : Set (𝔓 X)) (ϑ : Θ X) (N : ℕ) (L : Grid X) :
       use (hex q hq).choose_spec.2
       rw [← hfq, hf, hfq']
       exact (hex q' hq').choose_spec.2
-    --6.3.16
-    calc ∑ p ∈ (𝔄_aux 𝔄 ϑ N).toFinset with 𝓘 p = L, volume (E p ∩ G)
-      _ = ∑ p ∈ 𝔄'.toFinset, volume (E p ∩ G) := heq
-      _ ≤ ∑ p ∈ 𝔄'.toFinset, 2^a * dens₁ (𝔄' : Set (𝔓 X)) * volume (L : Set X) :=
-        Finset.sum_le_sum h_aux
-      _ = 𝔄'.toFinset.card * (2^a * dens₁ (𝔄' : Set (𝔓 X)) * volume (L : Set X)) := by
-          rw [Finset.sum_const, nsmul_eq_mul]
-      _ ≤ 2 ^ (a * (N + 5)) * dens₁  (𝔄' : Set (𝔓 X)) * volume (L : Set X) := by
+    -- 6.3.16
+    calc
+      _ = _ := heq
+      _ ≤ ∑ p ∈ 𝔄', 2 ^ a * dens₁ 𝔄' * volume (L : Set X) := Finset.sum_le_sum h_aux
+      _ = 𝔄'.toFinset.card * (2 ^ a * dens₁ 𝔄' * volume (L : Set X)) := by
+        rw [Finset.sum_const, nsmul_eq_mul]
+      _ ≤ 2 ^ (a * (N + 5)) * dens₁ 𝔄' * volume (L : Set X) := by
         simp only [← mul_assoc]
         gcongr
         norm_cast
         calc 𝔄'.toFinset.card * 2 ^ a
           _ ≤ 2 ^ (a * (N + 4)) * 2 ^ a := mul_le_mul_right' hcard _
           _ = 2 ^ (a * (N + 5)) := by ring
-      _ ≤ 2 ^ (a * (N + 5)) * dens₁  (𝔄 : Set (𝔓 X)) * volume (L : Set X) := by
+      _ ≤ 2 ^ (a * (N + 5)) * dens₁ 𝔄 * volume (L : Set X) := by
         have hss : 𝔄' ⊆ 𝔄 := by
           calc 𝔄'
             _ ⊆ 𝔄_aux 𝔄 ϑ N := sep_subset _ _
@@ -335,8 +329,8 @@ lemma Ep_inter_G_inter_Ip'_subset_E2 {𝔄 : Set (𝔓 X)} (ϑ : Θ X) (N : ℕ)
 open Classical in
 lemma local_antichain_density {𝔄 : Set (𝔓 X)} (h𝔄 : IsAntichain (· ≤ ·) 𝔄) (ϑ : Θ X) (N : ℕ)
     {p' : 𝔓 X} (hp' : ϑ ∈ ball_(p') (𝒬 p') (2 ^ (N + 1))) :
-    ∑ (p ∈ {p ∈ (𝔄_aux 𝔄 ϑ N).toFinset | 𝔰 p' < 𝔰 p}), volume (E p ∩ G ∩ 𝓘 p') ≤
-      volume (E₂ (2 ^ (N + 3)) p') := by
+    ∑ p ∈ 𝔄_aux 𝔄 ϑ N with 𝔰 p' < 𝔰 p, volume (E p ∩ G ∩ 𝓘 p') ≤
+    volume (E₂ (2 ^ (N + 3)) p') := by
   rw [← MeasureTheory.measure_biUnion_finset _
     (fun _ _ ↦  MeasurableSet.inter (measurableSet_E.inter measurableSet_G) coeGrid_measurable)]
   · apply measure_mono
@@ -374,9 +368,8 @@ def 𝔄_min : Set (𝔓 X) := {p ∈ 𝔄_aux 𝔄 ϑ N | ((𝓘 p : Set X) ∩
 
 open Classical in
 private lemma 𝔄_aux_sum_splits :
-    ∑ p ∈ (𝔄_aux 𝔄 ϑ N).toFinset, volume (E p ∩ G) =
-      ∑ p ∈ (𝔄' 𝔄 ϑ N).toFinset, volume (E p ∩ G) +
-      ∑ p ∈ (𝔄_min 𝔄 ϑ N).toFinset, volume (E p ∩ G) := by
+    ∑ p ∈ 𝔄_aux 𝔄 ϑ N, volume (E p ∩ G) =
+    ∑ p ∈ 𝔄' 𝔄 ϑ N, volume (E p ∩ G) + ∑ p ∈ 𝔄_min 𝔄 ϑ N, volume (E p ∩ G) := by
   rw [← Finset.sum_union]
   · have hss : (𝔄' 𝔄 ϑ N).toFinset ∪ (𝔄_min 𝔄 ϑ N).toFinset ⊆ (𝔄_aux 𝔄 ϑ N).toFinset := by
       simp only [subset_toFinset, Finset.coe_union, coe_toFinset, union_subset_iff]
@@ -406,11 +399,10 @@ def 𝓛_min : Set (Grid X) := {I : Grid X | ∃ (p : 𝔄_min 𝔄 ϑ N), I = �
 -- Ineq 6.3.26
 open Classical in
 private lemma 𝔄_min_sum_le :
-    ∑ p ∈ (𝔄_min 𝔄 ϑ N).toFinset, volume (E p ∩ G) ≤
-      2 ^ (a * (N + 5)) * dens₁ (𝔄 : Set (𝔓 X)) * volume (⋃ p ∈ 𝔄, (𝓘 p : Set X)) := by
-  calc ∑ p ∈ (𝔄_min 𝔄 ϑ N).toFinset, volume (E p ∩ G)
-    _ = ∑ L ∈ (𝓛_min 𝔄 ϑ N).toFinset,
-          ∑ (p ∈ {p ∈ (𝔄_aux 𝔄 ϑ N).toFinset | 𝓘 p = L}), volume (E p ∩ G) := by
+    ∑ p ∈ 𝔄_min 𝔄 ϑ N, volume (E p ∩ G) ≤
+    2 ^ (a * (N + 5)) * dens₁ 𝔄 * volume (⋃ p ∈ 𝔄, (𝓘 p : Set X)) := by
+  calc ∑ p ∈ 𝔄_min 𝔄 ϑ N, volume (E p ∩ G)
+    _ = ∑ L ∈ 𝓛_min 𝔄 ϑ N, ∑ p ∈ 𝔄_aux 𝔄 ϑ N with 𝓘 p = L, volume (E p ∩ G) := by
       rw [Finset.sum_comm' (t' := (𝔄_min 𝔄 ϑ N).toFinset)
         (s' := fun p ↦ {L ∈ (𝓛_min 𝔄 ϑ N).toFinset | 𝓘 p = L})]
       · apply Finset.sum_congr rfl
@@ -433,9 +425,9 @@ private lemma 𝔄_min_sum_le :
           exact hp'.2
         · simp only [𝔄_min, mem_setOf_eq, mem_toFinset,Finset.mem_filter] at hL hp ⊢
           use hL.1, hp.1, hL.2
-    _ ≤ ∑ L ∈ (𝓛_min 𝔄 ϑ N).toFinset, 2 ^ (a * (N + 5)) * dens₁ 𝔄 * volume (L : Set X) := by
+    _ ≤ ∑ L ∈ 𝓛_min 𝔄 ϑ N, 2 ^ (a * (N + 5)) * dens₁ 𝔄 * volume (L : Set X) := by
       gcongr; apply stack_density
-    _ = 2 ^ (a * (N + 5)) * dens₁ 𝔄 * ∑ L ∈ (𝓛_min 𝔄 ϑ N).toFinset, volume (L : Set X) := by
+    _ = 2 ^ (a * (N + 5)) * dens₁ 𝔄 * ∑ L ∈ 𝓛_min 𝔄 ϑ N, volume (L : Set X) := by
       rw [Finset.mul_sum]
     _ ≤ 2 ^ (a * (N + 5)) * dens₁ 𝔄 * volume (⋃ p ∈ 𝔄, (𝓘 p : Set X)) := by
       gcongr
@@ -462,10 +454,9 @@ def 𝓛 : Set (Grid X) := {I : Grid X | (∃ (p : 𝔄' 𝔄 ϑ N), I ≤ 𝓘 
     (∀ (p : 𝔄' 𝔄 ϑ N), 𝓘 (p : 𝔓 X) ≤ I → 𝔰 (p : 𝔓 X) = - S)}
 
 -- Ineq 6.3.27
-lemma I_p_subset_union_L (p : 𝔄' 𝔄 ϑ N) : (𝓘 (p : 𝔓 X) : Set X) ⊆ ⋃ (L ∈ 𝓛 𝔄 ϑ N), L := by
-  calc (𝓘 (p : 𝔓 X) : Set X)
-    _ ⊆ ⋃ (I ∈ {I : Grid X | s I = -S ∧ I ≤ 𝓘 (p : 𝔓 X)}), I := by
-      intro x hx
+lemma I_p_subset_union_L (p : 𝔄' 𝔄 ϑ N) : (𝓘 (p : 𝔓 X) : Set X) ⊆ ⋃ L ∈ 𝓛 𝔄 ϑ N, L := by
+  calc
+    _ ⊆ ⋃ I ∈ {I | s I = -S ∧ I ≤ 𝓘 (p : 𝔓 X)}, I := fun x hx ↦ by
       -- Apply 2.0.7
       obtain ⟨I, hI, hxI⟩ := Grid.exists_containing_subcube (i := 𝓘 (p : 𝔓 X)) (-S)
         (by simp [mem_Icc, le_refl, scale_mem_Icc.1]) hx
@@ -473,15 +464,14 @@ lemma I_p_subset_union_L (p : 𝔄' 𝔄 ϑ N) : (𝓘 (p : 𝔓 X) : Set X) ⊆
       simp only [Grid.le_def, mem_setOf_eq, mem_iUnion, exists_prop]
       exact ⟨I, ⟨hI, Or.resolve_right (GridStructure.fundamental_dyadic' hsI)
         (not_disjoint_iff.mpr ⟨x, hxI, hx⟩), hsI⟩, hxI⟩
-    _ ⊆ ⋃ (L ∈ 𝓛 𝔄 ϑ N), L := by
-      intro x hx
+    _ ⊆ _ := fun x hx ↦ by
       simp only [mem_iUnion] at hx ⊢
       obtain ⟨I, ⟨hsI, hI⟩, hxI⟩ := hx
       simp only [𝓛, Subtype.exists, exists_prop, Subtype.forall]
       exact ⟨I, ⟨⟨p, p.2, hI⟩, fun _ _ hqI ↦ le_antisymm (hsI ▸ hqI.2) scale_mem_Icc.1⟩, hxI⟩
 
 -- Ineq 6.3.28
-lemma union_L_eq_union_I_p : ⋃ (L ∈ 𝓛 𝔄 ϑ N), L = ⋃ (p ∈ 𝔄' 𝔄 ϑ N), (𝓘 (p : 𝔓 X) : Set X) := by
+lemma union_L_eq_union_I_p : ⋃ L ∈ 𝓛 𝔄 ϑ N, L = ⋃ p ∈ 𝔄' 𝔄 ϑ N, (𝓘 (p : 𝔓 X) : Set X) := by
   apply le_antisymm
   · intro _ hx
     simp only [mem_iUnion, exists_prop] at hx ⊢
@@ -506,7 +496,7 @@ lemma pairwiseDisjoint_𝓛' :
       (this (mem_toFinset.mp mJ) (mem_toFinset.mp mI) hn.symm)
 
 -- Equality 6.3.29
-lemma union_L'_eq_union_I_p : ⋃ (L ∈ 𝓛' 𝔄 ϑ N), L = ⋃ (p ∈ 𝔄' 𝔄 ϑ N), (𝓘 (p : 𝔓 X) : Set X) := by
+lemma union_L'_eq_union_I_p : ⋃ L ∈ 𝓛' 𝔄 ϑ N, L = ⋃ p ∈ 𝔄' 𝔄 ϑ N, (𝓘 (p : 𝔓 X) : Set X) := by
   classical
   rw [← union_L_eq_union_I_p]
   apply le_antisymm
@@ -721,7 +711,7 @@ private lemma ineq_6_3_36 {L : Grid X} (hL : L ∈ 𝓛' 𝔄 ϑ N) :
 -- Ineq. 6.3.38
 private lemma ineq_6_3_38 {L : Grid X} (hL : L ∈ 𝓛' 𝔄 ϑ N) :
     volume (E₂ (2 ^ (N + 3)) (pΘ hL)) ≤
-      2 ^ (a * N + a * 3) * (dens₁ (𝔄 : Set (𝔓 X)) * volume (L' hL : Set X)) := by
+    2 ^ (a * N + a * 3) * (dens₁ 𝔄 * volume (L' hL : Set X)) := by
   have h2 : (2 : ℝ≥0∞) ^ (a * N + a * 3) = (2 ^ (N + 3) : ℝ≥0) ^ a := by
     norm_cast; rw [← pow_mul]; ring
   rw [← I_pΘ_eq_L', h2, ← mul_assoc]
@@ -737,12 +727,12 @@ private lemma ineq_6_3_38 {L : Grid X} (hL : L ∈ 𝓛' 𝔄 ϑ N) :
 
 -- Ineq. 6.3.39
 open Classical in
-private lemma ineq_6_3_39 (h𝔄 : IsAntichain (· ≤ ·) 𝔄) {L : Grid X}
-    (hL : L ∈ 𝓛' 𝔄 ϑ N) : ∑ p ∈ 𝔄' 𝔄 ϑ N with ¬𝓘 p = L' hL, volume (E p ∩ G ∩ L) ≤
-      volume (E₂ (2 ^ (N + 3)) (pΘ hL)) := by
+private lemma ineq_6_3_39 (h𝔄 : IsAntichain (· ≤ ·) 𝔄) {L : Grid X} (hL : L ∈ 𝓛' 𝔄 ϑ N) :
+    ∑ p ∈ 𝔄' 𝔄 ϑ N with ¬𝓘 p = L' hL, volume (E p ∩ G ∩ L) ≤
+    volume (E₂ (2 ^ (N + 3)) (pΘ hL)) := by
   apply le_trans _ (local_antichain_density h𝔄 ϑ N (eq_6_3_37 hL))
-  calc ∑ p ∈ (𝔄' 𝔄 ϑ N).toFinset with ¬𝓘 p = L' hL, volume (E p ∩ G ∩ ↑L)
-    _ ≤ ∑ p ∈ (𝔄' 𝔄 ϑ N).toFinset with 𝔰 (pΘ hL) < 𝔰 p, volume (E p ∩ G ∩ ↑(𝓘 (pΘ hL))) := by
+  calc
+    _ ≤ ∑ p ∈ 𝔄' 𝔄 ϑ N with 𝔰 (pΘ hL) < 𝔰 p, volume (E p ∩ G ∩ ↑(𝓘 (pΘ hL))) := by
       simp only [Finset.sum_filter, ite_not]
       gcongr
       rename_i p hp
@@ -797,7 +787,7 @@ private lemma ineq_6_3_39 (h𝔄 : IsAntichain (· ≤ ·) 𝔄) {L : Grid X}
           rw [if_neg hp', if_pos hs]
           gcongr
           exact I_pΘ_eq_L' hL ▸ (L_le_L' hL).1
-    _ ≤ ∑ p ∈ (𝔄_aux 𝔄 ϑ N).toFinset with 𝔰 (pΘ hL) < 𝔰 p, volume (E p ∩ G ∩ ↑(𝓘 (pΘ hL))) := by
+    _ ≤ _ := by
       gcongr; simp only [𝔄']
       exact sep_subset _ _
 
@@ -837,10 +827,8 @@ private lemma volume_L'_le {L : Grid X} (hL : L ∈ 𝓛' 𝔄 ϑ N) :
 
 -- Ineq. 6.3.30
 open Classical in
-lemma global_antichain_density_aux (h𝔄 : IsAntichain (· ≤ ·) 𝔄) {L : Grid X}
-    (hL : L ∈ 𝓛' 𝔄 ϑ N) :
-    ∑ (p ∈ 𝔄' 𝔄 ϑ N), volume (E p ∩ G ∩ L) ≤
-      (C6_3_4' a N) * dens₁ (𝔄 : Set (𝔓 X)) * volume (L : Set X) := by
+lemma global_antichain_density_aux (h𝔄 : IsAntichain (· ≤ ·) 𝔄) {L : Grid X} (hL : L ∈ 𝓛' 𝔄 ϑ N) :
+    ∑ p ∈ 𝔄' 𝔄 ϑ N, volume (E p ∩ G ∩ L) ≤ C6_3_4' a N * dens₁ 𝔄 * volume (L : Set X) := by
   classical
   calc ∑ p ∈ 𝔄' 𝔄 ϑ N, volume (E p ∩ G ∩ ↑L)
     -- Express LHS as 6.3.31 + 6.3.32.
@@ -855,35 +843,35 @@ lemma global_antichain_density_aux (h𝔄 : IsAntichain (· ≤ ·) 𝔄) {L : G
       calc ∑ p ∈ 𝔄' 𝔄 ϑ N with 𝓘 p = L' hL, volume (E p ∩ G ∩ ↑L)
         _ ≤ ∑ p ∈ 𝔄' 𝔄 ϑ N with 𝓘 p = L' hL, volume (E p ∩ G) :=
           Finset.sum_le_sum (fun _ _ ↦ OuterMeasureClass.measure_mono volume inter_subset_left)
-        _ ≤ ∑ (p ∈ {p ∈ (𝔄_aux 𝔄 ϑ N).toFinset | 𝓘 p = L' hL}), volume (E p ∩ G) := by
+        _ ≤ ∑ p ∈ 𝔄_aux 𝔄 ϑ N with 𝓘 p = L' hL, volume (E p ∩ G) := by
           gcongr
           intro _ hp
           simp only [𝔄', ne_eq] at hp
           exact hp.1
-        _ ≤ 2 ^ (a * (N + 5)) * dens₁ (𝔄 : Set (𝔓 X)) * volume (L' hL : Set X) :=
+        _ ≤ 2 ^ (a * (N + 5)) * dens₁ 𝔄 * volume (L' hL : Set X) :=
           stack_density 𝔄 ϑ N (L' hL)
     -- Apply ineq. 6.3.39: estimate 6.3.32.
-    _ ≤ 2^(a * (N + 5)) * dens₁ (𝔄 : Set (𝔓 X)) * volume (L' hL : Set X) +
+    _ ≤ 2^(a * (N + 5)) * dens₁ 𝔄 * volume (L' hL : Set X) +
         volume (E₂ (2 ^ (N + 3)) (pΘ hL)) := by grw [ineq_6_3_39 h𝔄 hL]
     -- Ineq. 6.3.40, using 6.3.38
-    _ ≤ (2^(a * (N + 5)) + 2^(a * N + a * 3)) * dens₁ (𝔄 : Set (𝔓 X)) *
+    _ ≤ (2^(a * (N + 5)) + 2^(a * N + a * 3)) * dens₁ 𝔄 *
         volume (L' hL : Set X) := by
       conv_rhs => rw [mul_assoc]
       rw [add_mul, ← mul_assoc]
       gcongr
       exact ineq_6_3_38 hL
-    _ ≤ (2^(a * (N + 5)) + 2^(a * N + a * 3)) * dens₁ (𝔄 : Set (𝔓 X)) *
+    _ ≤ (2^(a * (N + 5)) + 2^(a * N + a * 3)) * dens₁ 𝔄 *
         2 ^ (100*a^3 + 5*a) * volume (L : Set X) := by
       grw [mul_assoc _ (2 ^ (100*a^3 + 5*a))  _, volume_L'_le hL]
-    _ = ((2^(a * (N + 5)) + 2^(a * N + a * 3)) * 2 ^ (100*a^3 + 5*a)) * dens₁ (𝔄 : Set (𝔓 X)) *
+    _ = ((2 ^ (a * (N + 5)) + 2 ^ (a * N + a * 3)) * 2 ^ (100 * a ^ 3 + 5 * a)) * dens₁ 𝔄 *
         volume (L : Set X) := by ring
-    _ = ↑(C6_3_4' a N) * dens₁ (𝔄 : Set (𝔓 X)) * volume (L : Set X) := by rfl
+    _ = _ := by rfl
 
 variable (𝔄 ϑ N)
 
 open Classical in
 private lemma volume_union_I_p_eq_sum :
-    volume (⋃ (p ∈ 𝔄' 𝔄 ϑ N), (𝓘 p : Set X)) = ∑ (L ∈ 𝓛' 𝔄 ϑ N), volume (L : Set X) := by
+    volume (⋃ p ∈ 𝔄' 𝔄 ϑ N, (𝓘 p : Set X)) = ∑ L ∈ 𝓛' 𝔄 ϑ N, volume (L : Set X) := by
   rw [← union_L'_eq_union_I_p 𝔄 ϑ N]
   convert MeasureTheory.measure_biUnion_finset (pairwiseDisjoint_𝓛' 𝔄 ϑ N)
     (fun _ _ ↦ coeGrid_measurable)
@@ -891,10 +879,10 @@ private lemma volume_union_I_p_eq_sum :
   rw [mem_toFinset]
 
 open Classical in
-private lemma lhs' : ∑ (p ∈ (𝔄' 𝔄 ϑ N).toFinset), volume (E p ∩ G) =
-    (∑ (L ∈ (𝓛' 𝔄 ϑ N).toFinset), ∑ (p ∈ (𝔄' 𝔄 ϑ N).toFinset), volume (E p ∩ G ∩ L)) := by
-  calc ∑ p ∈ 𝔄' 𝔄 ϑ N, volume (E p ∩ G)
-    _ = ∑ p ∈ 𝔄' 𝔄 ϑ N, volume (E p ∩ G ∩ (⋃ (p ∈ 𝔄' 𝔄 ϑ N), (𝓘 (p : 𝔓 X) : Set X))) := by
+private lemma lhs' : ∑ p ∈ 𝔄' 𝔄 ϑ N, volume (E p ∩ G) =
+    ∑ L ∈ 𝓛' 𝔄 ϑ N, ∑ p ∈ 𝔄' 𝔄 ϑ N, volume (E p ∩ G ∩ L) := by
+  calc
+    _ = ∑ p ∈ 𝔄' 𝔄 ϑ N, volume (E p ∩ G ∩ ⋃ p ∈ 𝔄' 𝔄 ϑ N, (𝓘 p : Set X)) := by
       apply Finset.sum_congr rfl
       intro p hp
       congr 1
@@ -902,10 +890,10 @@ private lemma lhs' : ∑ (p ∈ (𝔄' 𝔄 ϑ N).toFinset), volume (E p ∩ G) 
       intro _ hx
       simp only [mem_iUnion]
       use p, mem_toFinset.mp hp, hx.1.1
-    _ = ∑ p ∈ 𝔄' 𝔄 ϑ N, volume (E p ∩ G ∩ (⋃ (L ∈ 𝓛' 𝔄 ϑ N), L)) := by rw [union_L'_eq_union_I_p]
-    _ = ∑ p ∈ (𝔄' 𝔄 ϑ N), volume (⋃ (L ∈ (𝓛' 𝔄 ϑ N).toFinset), E p ∩ G ∩ L):= by
+    _ = ∑ p ∈ 𝔄' 𝔄 ϑ N, volume (E p ∩ G ∩ ⋃ L ∈ 𝓛' 𝔄 ϑ N, L) := by rw [union_L'_eq_union_I_p]
+    _ = ∑ p ∈ 𝔄' 𝔄 ϑ N, volume (⋃ L ∈ (𝓛' 𝔄 ϑ N).toFinset, E p ∩ G ∩ L):= by
         congr; ext p; simp_rw [inter_iUnion₂, mem_toFinset]
-    _ = ∑ p ∈ (𝔄' 𝔄 ϑ N), ∑ L ∈ (𝓛' 𝔄 ϑ N).toFinset, volume (E p ∩ G ∩ ↑L) := by
+    _ = ∑ p ∈ 𝔄' 𝔄 ϑ N, ∑ L ∈ (𝓛' 𝔄 ϑ N).toFinset, volume (E p ∩ G ∩ L) := by
       congr
       ext p
       -- Note that both measurability and fun_prop fail here.
@@ -918,44 +906,43 @@ private lemma lhs' : ∑ (p ∈ (𝔄' 𝔄 ϑ N).toFinset), volume (E p ∩ G) 
       simp only [Set.Nonempty, mem_inter_iff] at hLM ⊢
       obtain ⟨x, hxL, hxM⟩ := hLM
       exact ⟨x, hxL.2, hxM.2⟩
-    _ = ∑ L ∈ 𝓛' 𝔄 ϑ N, ∑ p ∈ 𝔄' 𝔄 ϑ N, volume (E p ∩ G ∩ ↑L) := Finset.sum_comm
+    _ = _ := Finset.sum_comm
 
 open Classical in
-private lemma lhs : ∑ (p ∈ (𝔄_aux 𝔄 ϑ N).toFinset), volume (E p ∩ G) =
-    (∑ (L ∈ (𝓛' 𝔄 ϑ N).toFinset), ∑ (p ∈ (𝔄' 𝔄 ϑ N).toFinset), volume (E p ∩ G ∩ L)) +
-    ∑ p ∈ (𝔄_min 𝔄 ϑ N).toFinset, volume (E p ∩ G) := by
-  calc ∑ p ∈ (𝔄_aux 𝔄 (↑ϑ) N).toFinset, volume (E p ∩ G)
-    _ = ∑ p ∈ (𝔄' 𝔄 ϑ N).toFinset, volume (E p ∩ G) +
-          ∑ p ∈ (𝔄_min 𝔄 ϑ N).toFinset, volume (E p ∩ G) := by rw [𝔄_aux_sum_splits]
-    _ = ∑ L ∈ (𝓛' 𝔄 ϑ N).toFinset, ∑ p ∈ (𝔄' 𝔄 ϑ N).toFinset, volume (E p ∩ G ∩ ↑L) +
-          ∑ p ∈ (𝔄_min 𝔄 ϑ N).toFinset, volume (E p ∩ G) := by rw [lhs']
+private lemma lhs : ∑ p ∈ 𝔄_aux 𝔄 ϑ N, volume (E p ∩ G) =
+    ∑ L ∈ 𝓛' 𝔄 ϑ N, ∑ p ∈ 𝔄' 𝔄 ϑ N, volume (E p ∩ G ∩ L) +
+    ∑ p ∈ 𝔄_min 𝔄 ϑ N, volume (E p ∩ G) := by
+  calc
+    _ = ∑ p ∈ 𝔄' 𝔄 ϑ N, volume (E p ∩ G) +
+        ∑ p ∈ 𝔄_min 𝔄 ϑ N, volume (E p ∩ G) := by rw [𝔄_aux_sum_splits]
+    _ = _ := by rw [lhs']
 
 private lemma le_C6_3_4 (ha : 4 ≤ a) :
     (((2 : ℝ≥0∞) ^ (a * (N + 5)) + 2 ^ (a * N + a * 3)) * 2 ^ (100 * a ^ 3 + 5 * a)) +
-      2 ^ (a * (N + 5)) ≤ (C6_3_4 a N) := by
-  calc ((2 : ℝ≥0∞) ^ (a * (N + 5)) + 2 ^ (a * N + a * 3)) * 2 ^ (100 * a ^ 3 + 5 * a) +
-      2 ^ (a * (N + 5))
-    _ ≤ (2^(a * N + a * 5) + 2^(a * N + a * 5)) * 2 ^ (100*a^3 + 5*a) + 2 ^ (a * N + a* 5) * 1 := by
+      2 ^ (a * (N + 5)) ≤ C6_3_4 a N := by
+  calc
+    _ ≤ ((2 : ℝ≥0∞) ^ (a * N + a * 5) +
+        2 ^ (a * N + a * 5)) * 2 ^ (100 * a ^ 3 + 5 * a) + 2 ^ (a * N + a * 5) * 1 := by
       have h12 : (1 : ℝ≥0∞) ≤ 2 := one_le_two
       have h35 : 3 ≤ 5 := by omega
       gcongr <;> apply le_of_eq <;> ring
-    _ = 2^(a * N + a * 5) * (2 * 2 ^ (100*a^3 + 5*a)) + 2 ^ (a * N + a* 5) * 1 := by
+    _ = 2 ^ (a * N + a * 5) * (2 * 2 ^ (100 * a ^ 3 + 5 * a)) + 2 ^ (a * N + a * 5) * 1 := by
       rw [← two_mul]; ring
-    _ = 2^(a * N + a * 5) * (2 * 2 ^ (100*a^3 + 5*a) + 1) := by ring
-    _ ≤ 2^(a * N + a * 5) * (2^2 * 2 ^ (100*a^3 + 5*a)) := by
+    _ = 2 ^ (a * N + a * 5) * (2 * 2 ^ (100 * a ^ 3 + 5 * a) + 1) := by ring
+    _ ≤ 2 ^ (a * N + a * 5) * (2 ^ 2 * 2 ^ (100 * a ^ 3 + 5 * a)) := by
       gcongr
       norm_cast
       rw [pow_two, mul_assoc 2 2]
       conv_rhs => rw [two_mul]
       gcongr
       exact NeZero.one_le
-    _ = 2^(100*a^3 + a * N + a * 10 + 2) := by
+    _ = 2 ^ (100 * a ^ 3 + a * N + a * 10 + 2) := by
       rw [← pow_add, ← pow_add]
       congr 1
       ring
-    _ ≤ ↑(C6_3_4 a N) := by
-      have h101 : 101 * a ^ 3 = 100 * a ^ 3 +  a ^ 3 := by ring
-      have ha3 : a ^ 3 = a * (a^2 - 1) + a := by
+    _ ≤ _ := by
+      have h101 : 101 * a ^ 3 = 100 * a ^ 3 + a ^ 3 := by ring
+      have ha3 : a ^ 3 = a * (a ^ 2 - 1) + a := by
         simp only [mul_tsub, mul_one]
         rw [tsub_add_cancel_of_le]
         · ring
@@ -971,33 +958,32 @@ private lemma le_C6_3_4 (ha : 4 ≤ a) :
       rw [add_assoc, h101]
       nth_rewrite 3 [ha3]
       gcongr
-      · calc 10
-        _ ≤ 4^2 - 1 := by norm_num
-        _ ≤ a ^ 2 - 1 := by gcongr
+      · calc
+          _ ≤ 4 ^ 2 - 1 := by norm_num
+          _ ≤ _ := by gcongr
       · linarith
 
 -- Lemma 6.3.4
 open Classical in
 lemma global_antichain_density {𝔄 : Set (𝔓 X)} (h𝔄 : IsAntichain (· ≤ ·) 𝔄) (ϑ : range Q) (N : ℕ) :
-    ∑ p ∈ (𝔄_aux 𝔄 ϑ.val N).toFinset, volume (E p ∩ G) ≤
-      C6_3_4 a N * dens₁ (𝔄 : Set (𝔓 X)) * volume (⋃ p ∈ 𝔄, (𝓘 p : Set X)) := by
+    ∑ p ∈ 𝔄_aux 𝔄 ϑ.val N, volume (E p ∩ G) ≤
+    C6_3_4 a N * dens₁ 𝔄 * volume (⋃ p ∈ 𝔄, (𝓘 p : Set X)) := by
   rw [lhs]
-  calc ∑ L ∈ (𝓛' 𝔄 ϑ N).toFinset, ∑ p ∈ (𝔄' 𝔄 ϑ N).toFinset, volume (E p ∩ G ∩ ↑L) +
-          ∑ p ∈ (𝔄_min 𝔄 ϑ N).toFinset, volume (E p ∩ G)
-    _ ≤ ∑ L ∈ (𝓛' 𝔄 ϑ N).toFinset, ↑(C6_3_4' a N) * dens₁ 𝔄 * volume (L : Set X) +
+  calc
+    _ ≤ ∑ L ∈ 𝓛' 𝔄 ϑ N, C6_3_4' a N * dens₁ 𝔄 * volume (L : Set X) +
         2 ^ (a * (N + 5)) * dens₁ 𝔄 * volume (⋃ p ∈ 𝔄, (𝓘 p : Set X)) :=
         add_le_add (Finset.sum_le_sum (fun L (hL : L ∈ (𝓛' 𝔄 ϑ N).toFinset) ↦
           global_antichain_density_aux h𝔄 (mem_toFinset.mp hL))) (𝔄_min_sum_le _ _ _)
-    _ = ↑(C6_3_4'  a N) * dens₁ 𝔄 * volume (⋃ p ∈ 𝔄' 𝔄 ϑ N, (𝓘 p : Set X)) +
+    _ = C6_3_4' a N * dens₁ 𝔄 * volume (⋃ p ∈ 𝔄' 𝔄 ϑ N, (𝓘 p : Set X)) +
         2 ^ (a * (N + 5)) * dens₁ 𝔄 * volume (⋃ p ∈ 𝔄, (𝓘 p : Set X)) := by
       rw [volume_union_I_p_eq_sum 𝔄 ϑ N, Finset.mul_sum]
-    _ ≤ ↑(C6_3_4'  a N) * dens₁ 𝔄 * volume (⋃ p ∈ 𝔄, (𝓘 p : Set X)) +
+    _ ≤ C6_3_4' a N * dens₁ 𝔄 * volume (⋃ p ∈ 𝔄, (𝓘 p : Set X)) +
         2 ^ (a * (N + 5)) * dens₁ 𝔄 * volume (⋃ p ∈ 𝔄, (𝓘 p : Set X)) := by
       gcongr
       apply iUnion_subset_iUnion_const
       simp only [𝔄', 𝔄_aux]
       exact fun h ↦ h.1.1
-    _ ≤ ↑(C6_3_4 a N) * dens₁ 𝔄 * volume (⋃ p ∈ 𝔄, (𝓘 p : Set X)) := by
+    _ ≤ _ := by
       simp only [mul_assoc, ← add_mul]
       gcongr
       simp only [C6_3_4', ENNReal.coe_pow, ENNReal.coe_ofNat, C6_3_4]

--- a/Carleson/Antichain/AntichainTileCount.lean
+++ b/Carleson/Antichain/AntichainTileCount.lean
@@ -140,7 +140,7 @@ lemma biUnion_𝔄_aux {𝔄 : Set (𝔓 X)} {ϑ : Θ X} :
   obtain ⟨p₀, mp₀, hp₀⟩ := 𝔄.toFinset.exists_max_image f h𝔄'
   use f p₀ + 1; ext p
   simp only [𝔄_aux, mem_Ico, sep_and, toFinset_inter, toFinset_setOf, Finset.mem_biUnion,
-    Finset.mem_range, Finset.mem_inter, Finset.mem_filter, Finset.mem_univ, true_and, mem_toFinset]
+    Finset.mem_range, Finset.mem_inter, Finset.mem_filter_univ, mem_toFinset]
   refine ⟨fun hp ↦ hp.choose_spec.2.1.1, fun hp ↦ ?_⟩
   simp only [hp, true_and]
   use f p, Nat.lt_add_one_iff.mpr (hp₀ p (mem_toFinset.mpr hp))
@@ -310,7 +310,7 @@ lemma Ep_inter_G_inter_Ip'_subset_E2 {𝔄 : Set (𝔓 X)} (ϑ : Θ X) (N : ℕ)
   -- 6.3.22
   have hϑin : dist_(p) (𝒬 p) ϑ < ((2 : ℝ)^(N + 1)) := by
     simp only [𝔄_aux, mem_Ico, sep_and, toFinset_inter, toFinset_setOf, Finset.mem_inter,
-      Finset.mem_filter, Finset.mem_univ, true_and] at hpin
+      Finset.mem_filter_univ] at hpin
     exact (lt_one_add (dist_(p) (𝒬 p) ϑ)).trans hpin.2.2
   -- 6.3.24
   have hsmul_le : smul (2 ^ (N + 3)) p' ≤ smul (2 ^ (N + 3)) p :=
@@ -350,12 +350,10 @@ lemma local_antichain_density {𝔄 : Set (𝔓 X)} (h𝔄 : IsAntichain (· ≤
           (sep_subset ↑(𝓘 p) fun x ↦ Q x ∈ Ω p ∧ 𝔰 p ∈ Icc (σ₁ x) (σ₂ x)))
       rw [inter_comm, ← inter_assoc, hemp, empty_inter]
       exact empty_subset _
-  · simp only [Finset.coe_filter]
+  · rw [Finset.coe_filter]
     intro q hq q' hq' hqq'
-    simp only [𝔄_aux, mem_Ico, sep_and, toFinset_inter,
-      toFinset_setOf, Finset.mem_inter, Finset.mem_filter, Finset.mem_univ, true_and,
-      mem_setOf_eq] at hq hq'
-    have hE : Disjoint (E q) (E q') := by simpa using (E_disjoint h𝔄 hq.1.1.1 hq'.1.1.1).mt hqq'
+    rw [𝔄_aux, mem_setOf, toFinset_setOf, Finset.mem_filter_univ] at hq hq'
+    have hE : Disjoint (E q) (E q') := by simpa using (E_disjoint h𝔄 hq.1.1 hq'.1.1).mt hqq'
     change Disjoint (_ ∩ _ ∩ _) (_ ∩ _ ∩ _)
     rw [inter_assoc, inter_assoc]; exact (hE.inter_right _).inter_left _
 
@@ -1114,9 +1112,8 @@ lemma tile_count_aux {𝔄 : Set (𝔓 X)} (h𝔄 : IsAntichain (· ≤ ·) 𝔄
       · intro i mi j mj hn
         rw [mul_assoc (2 ^ _), ← inter_indicator_mul, mul_assoc _ _ (G.indicator 1 x),
           ← inter_indicator_mul, mul_mul_mul_comm, ← inter_indicator_mul, inter_inter_inter_comm]
-        simp only [𝔄_aux, mem_Ico, sep_and, toFinset_inter, toFinset_setOf, Finset.mem_inter,
-          Finset.mem_filter, Finset.mem_univ, true_and] at mi mj
-        have key := (E_disjoint h𝔄 mi.1.1 mj.1.1).mt hn
+        rw [𝔄_aux, toFinset_setOf, Finset.mem_filter_univ] at mi mj
+        have key := (E_disjoint h𝔄 mi.1 mj.1).mt hn
         rw [not_not, disjoint_iff_inter_eq_empty] at key; simp [key]
       rw [ENNReal.enorm_sum_eq_sum_enorm]; swap
       · refine fun p mp ↦ pow_nonneg (mul_nonneg ?_ (indicator_nonneg (by simp) _)) _

--- a/Carleson/Antichain/Basic.lean
+++ b/Carleson/Antichain/Basic.lean
@@ -178,7 +178,7 @@ lemma MaximalBoundAntichain {𝔄 : Set (𝔓 X)} (h𝔄 : IsAntichain (· ≤ �
     have hxE : x ∈ E ↑p := mem_of_indicator_ne_zero hpx
     have hne_p : ∀ b ∈ ({p | p ∈ 𝔄} : Finset (𝔓 X)), b ≠ ↑p → carlesonOn b f x = 0 := by
       intro p' hp' hpp'
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hp'
+      rw [Finset.mem_filter_univ] at hp'
       by_contra hp'x
       exact hpp' (E_disjoint h𝔄 hp' p.2 <|
         not_disjoint_iff.mpr ⟨x, mem_of_indicator_ne_zero hp'x, hxE⟩)
@@ -267,9 +267,9 @@ lemma MaximalBoundAntichain {𝔄 : Set (𝔓 X)} (h𝔄 : IsAntichain (· ≤ �
       simp only [iSup_le_iff, ENNReal.rpow_one]
       exact (fun _ hc ↦ hc p.1 p.2)
   · simp only [ne_eq, Subtype.exists, exists_prop, not_exists, not_and, Decidable.not_not] at hx
-    have h0 : (carlesonSum 𝔄 f x) = 0 := by
-      apply Finset.sum_eq_zero (fun p hp ↦ ?_)
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hp
+    have h0 : carlesonSum 𝔄 f x = 0 := by
+      refine Finset.sum_eq_zero (fun p hp ↦ ?_)
+      rw [Finset.mem_filter_univ] at hp
       exact hx p hp
     simp only [h0, enorm_zero, zero_le]
 

--- a/Carleson/Discrete/Defs.lean
+++ b/Carleson/Discrete/Defs.lean
@@ -310,8 +310,8 @@ lemma setA_subset_iUnion_𝓒 {l k n : ℕ} :
   replace mx := (zero_le _).trans_lt mx
   rw [Finset.card_pos] at mx
   obtain ⟨p, hp⟩ := mx
-  simp_rw [Finset.mem_filter, Finset.mem_univ, true_and, 𝔐, mem_setOf, maximal_iff,
-    aux𝔐, mem_setOf, TilesAt, mem_preimage] at hp
+  simp_rw [Finset.mem_filter_univ, 𝔐, mem_setOf, maximal_iff, aux𝔐, mem_setOf, TilesAt,
+    mem_preimage] at hp
   rw [mem_iUnion₂]; use 𝓘 p, hp.1.1.1, hp.2
 
 lemma setA_subset_setA {l k n : ℕ} : setA (X := X) (l + 1) k n ⊆ setA l k n := by

--- a/Carleson/Discrete/ExceptionalSet.lean
+++ b/Carleson/Discrete/ExceptionalSet.lean
@@ -385,7 +385,7 @@ section TopTiles
 open scoped Classical in
 /-- The volume of a "layer" in the key function of Lemma 5.2.7. -/
 def layervol (k n : ℕ) (t : ℝ) : ℝ≥0∞ :=
-  volume {x | t ≤ ∑ m ∈ {p | p ∈ 𝔐 (X := X) k n },
+  volume {x | t ≤ ∑ m with m ∈ 𝔐 (X := X) k n,
     (𝓘 m : Set X).indicator (1 : X → ℝ) x}
 
 lemma indicator_sum_eq_natCast {s : Finset (𝔓 X)} :
@@ -434,16 +434,16 @@ lemma lintegral_Ioc_layervol_le {a b : ℕ} : ∫⁻ t in Ioc (a : ℝ) b, layer
     _ = _ := by rw [Finset.sum_const, Nat.card_Ico, nsmul_eq_mul]
 
 open scoped Classical in
-lemma top_tiles_aux : ∑ m ∈ { p | p ∈ 𝔐 (X := X) k n }, volume (𝓘 m : Set X) =
+lemma top_tiles_aux : ∑ m with m ∈ 𝔐 (X := X) k n, volume (𝓘 m : Set X) =
     ∫⁻ t in Ioc 0 ((𝔐 (X := X) k n).toFinset.card * 2 ^ (n + 1) : ℝ), layervol (X := X) k n t := by
   set M := 𝔐 (X := X) k n
   set Mc := M.toFinset.card
   calc
-    _ = ∑ m ∈ { p | p ∈ M }, ∫⁻ x, (𝓘 m : Set X).indicator 1 x := by
+    _ = ∑ m with m ∈ M, ∫⁻ x, (𝓘 m : Set X).indicator 1 x := by
       congr! with m; exact (lintegral_indicator_one coeGrid_measurable).symm
-    _ = ∫⁻ x, ∑ m ∈ { p | p ∈ M }, (𝓘 m : Set X).indicator 1 x :=
+    _ = ∫⁻ x, ∑ m with m ∈ M, (𝓘 m : Set X).indicator 1 x :=
       (lintegral_finset_sum _ fun _ _ ↦ measurable_one.indicator coeGrid_measurable).symm
-    _ = ∫⁻ x, ENNReal.ofReal (∑ m ∈ { p | p ∈ M }, (𝓘 m : Set X).indicator 1 x) := by
+    _ = ∫⁻ x, ENNReal.ofReal (∑ m with m ∈ M, (𝓘 m : Set X).indicator 1 x) := by
       congr! 2 with x; rw [ENNReal.ofReal_sum_of_nonneg]
       · congr!; unfold indicator; split_ifs <;> simp
       · exact fun _ _ ↦ indicator_nonneg (fun _ _ ↦ by simp) _
@@ -466,7 +466,7 @@ lemma top_tiles_aux : ∑ m ∈ { p | p ∈ 𝔐 (X := X) k n }, volume (𝓘 m 
 
 open scoped Classical in
 /-- Lemma 5.2.7 -/
-lemma top_tiles : ∑ m ∈ { p | p ∈ 𝔐 (X := X) k n }, volume (𝓘 m : Set X) ≤
+lemma top_tiles : ∑ m with m ∈ 𝔐 (X := X) k n, volume (𝓘 m : Set X) ≤
     2 ^ (n + k + 3) * volume G := by
   set M := 𝔐 (X := X) k n
   let Mc := M.toFinset.card
@@ -838,16 +838,16 @@ lemma third_exception_aux :
       measure_biUnion_le _ (𝔘₁ k n j).to_countable _
     _ ≤ ∑' u : 𝔘₁ (X := X) k n j, C5_2_9 X n * volume (𝓘 u.1 : Set X) :=
       ENNReal.tsum_le_tsum fun x ↦ boundary_exception
-    _ = C5_2_9 X n * ∑ u ∈ { p | p ∈ 𝔘₁ (X := X) k n j }, volume (𝓘 u : Set X) := by
+    _ = C5_2_9 X n * ∑ u with u ∈ 𝔘₁ (X := X) k n j, volume (𝓘 u : Set X) := by
       rw [filter_mem_univ_eq_toFinset, ENNReal.tsum_mul_left]; congr
       rw [tsum_fintype]; convert (Finset.sum_subtype _ (fun u ↦ mem_toFinset) _).symm; rfl
     _ ≤ C5_2_9 X n * 2 ^ (9 * a - j : ℤ) *
-        ∑ m ∈ { p | p ∈ 𝔐 (X := X) k n }, volume (𝓘 m : Set X) := by
+        ∑ m with m ∈ 𝔐 (X := X) k n, volume (𝓘 m : Set X) := by
       rw [mul_assoc]; refine mul_le_mul_left' ?_ _
       simp_rw [← lintegral_indicator_one coeGrid_measurable,
         ← lintegral_finset_sum _ fun _ _ ↦ measurable_one.indicator coeGrid_measurable]
       have c1 : ∀ C : Set (𝔓 X),
-          ∫⁻ x, ∑ u ∈ { p | p ∈ C }, (𝓘 u : Set X).indicator 1 x =
+          ∫⁻ x, ∑ u with u ∈ C, (𝓘 u : Set X).indicator 1 x =
           ∫⁻ x, stackSize C x := fun C ↦ by
         refine lintegral_congr fun _ ↦ ?_; rw [stackSize, Nat.cast_sum]; congr!
         simp_rw [indicator]; split_ifs <;> simp

--- a/Carleson/Discrete/ExceptionalSet.lean
+++ b/Carleson/Discrete/ExceptionalSet.lean
@@ -145,9 +145,9 @@ lemma dense_cover (k : ℕ) : volume (⋃ i ∈ 𝓒 (X := X) k, (i : Set X)) �
     _ ≤ 2 ^ (k + 1) * ∑ j ∈ M', volume (G ∩ j) := by
       rw [Finset.mul_sum]; refine Finset.sum_le_sum fun i hi ↦ ?_
       replace hi : i ∈ M := Finset.mem_of_subset (Finset.filter_subset _ M) hi
-      simp_rw [M, Finset.mem_filter, Finset.mem_univ, true_and] at hi
-      rw [← ENNReal.rpow_intCast, show (-(k + 1 : ℕ) : ℤ) = (-(k + 1) : ℝ) by simp,
-        mul_comm, ← ENNReal.lt_div_iff_mul_lt (by simp) (by simp), ENNReal.div_eq_inv_mul,
+      rw [Finset.mem_filter_univ, ← ENNReal.rpow_intCast,
+        show (-(k + 1 : ℕ) : ℤ) = (-(k + 1) : ℝ) by simp, mul_comm,
+        ← ENNReal.lt_div_iff_mul_lt (by simp) (by simp), ENNReal.div_eq_inv_mul,
         ← ENNReal.rpow_neg, neg_neg] at hi
       exact_mod_cast hi.le
     _ = 2 ^ (k + 1) * volume (⋃ j ∈ M', G ∩ j) := by
@@ -177,15 +177,15 @@ lemma dyadic_union (hx : x ∈ setA l k n) : ∃ i : Grid X, x ∈ i ∧ (i : Se
   simp_rw [setA, mem_setOf, stackSize, indicator_apply, Pi.one_apply, Finset.sum_boole, Nat.cast_id,
     Finset.filter_filter] at hx ⊢
   obtain ⟨b, memb, minb⟩ := M.exists_min_image 𝔰 (Finset.card_pos.mp (zero_le'.trans_lt hx))
-  simp_rw [M, Finset.mem_filter, Finset.mem_univ, true_and] at memb minb
+  simp_rw [M, Finset.mem_filter_univ] at memb minb
   use 𝓘 b, memb.2; intro c mc; rw [mem_setOf]
   refine hx.trans_le (Finset.card_le_card fun y hy ↦ ?_)
-  simp_rw [Finset.mem_filter, Finset.mem_univ, true_and] at hy ⊢
+  rw [Finset.mem_filter_univ] at hy ⊢
   exact ⟨hy.1, mem_of_mem_of_subset mc (le_of_mem_of_mem (minb y hy) memb.2 hy.2).1⟩
 
 lemma iUnion_MsetA_eq_setA : ⋃ i ∈ MsetA (X := X) l k n, ↑i = setA (X := X) l k n := by
   ext x
-  simp_rw [mem_iUnion₂, MsetA, Finset.mem_filter, Finset.mem_univ, true_and]
+  simp_rw [mem_iUnion₂, MsetA, Finset.mem_filter_univ]
   constructor <;> intro mx
   · obtain ⟨j, mj, lj⟩ := mx; exact mem_of_mem_of_subset lj mj
   · obtain ⟨j, mj, lj⟩ := dyadic_union mx; use j, lj, mj
@@ -202,8 +202,8 @@ lemma john_nirenberg_aux1 {L : Grid X} (mL : L ∈ Grid.maxCubes (MsetA l k n))
     at mx
   simp_rw [mem_setOf_eq, and_assoc] at mx
   have mid0 : stackSize { p' ∈ 𝔐 k n | ¬𝓘 p' ≤ L ∧ Disjoint (𝓘 p' : Set X) L} x = 0 := by
-    simp_rw [stackSize, Finset.sum_eq_zero_iff, indicator_apply_eq_zero,
-      show ¬(1 : X → ℕ) x = 0 by simp, imp_false, Finset.mem_filter, Finset.mem_univ, true_and]
+    simp_rw [stackSize, Finset.sum_eq_zero_iff, indicator_apply_eq_zero, Finset.mem_filter_univ,
+      show ¬(1 : X → ℕ) x = 0 by simp, imp_false]
     rintro y ⟨-, -, dj2⟩
     exact disjoint_right.mp dj2 mx₂
   rw [mid0, zero_add] at mx

--- a/Carleson/Discrete/ForestComplement.lean
+++ b/Carleson/Discrete/ForestComplement.lean
@@ -325,7 +325,7 @@ lemma card_𝔒 (p' : 𝔓 X) {l : ℝ≥0} (hl : 2 ≤ l) : (𝔒 p' l).card �
   have tO : ∀ p'' ∈ 𝔒 p' l,
       ball_(p') (𝒬 p'') 5⁻¹ ⊆ ball_(p') (𝒬 p') (l + 6 / 5) := fun p'' mp'' ↦ by
     apply ball_subset_ball'
-    simp_rw [𝔒, Finset.mem_filter, Finset.mem_univ, true_and] at mp''
+    simp_rw [𝔒, Finset.mem_filter_univ] at mp''
     obtain ⟨x, mx₁, mx₂⟩ := not_disjoint_iff.mp mp''.2
     replace mx₂ := _root_.subset_cball mx₂
     rw [@mem_ball] at mx₁ mx₂
@@ -549,9 +549,9 @@ lemma antichain_L2 : IsAntichain (· ≤ ·) (𝔏₂ (X := X) k n j) := by
   let C : Finset (LTSeries (ℭ₁' k n j)) := { s | s.head = ⟨p, cp⟩ }
   have Cn : C.Nonempty := by
     use RelSeries.singleton _ ⟨p, cp⟩
-    simp_rw [C, Finset.mem_filter, Finset.mem_univ, true_and]; rfl
+    rw [Finset.mem_filter_univ]; rfl
   obtain ⟨z, mz, maxz⟩ := C.exists_max_image (·.length) Cn
-  simp_rw [C, Finset.mem_filter, Finset.mem_univ, true_and] at mz
+  rw [Finset.mem_filter_univ] at mz
   by_cases mu : z.last.1 ∈ 𝔘₁ k n j
   · have px : z.head ≤ z.last := z.monotone (Fin.zero_le _)
     rw [mz] at px
@@ -607,10 +607,10 @@ lemma carlesonSum_𝔓₁_compl_eq_𝔓pos_inter (f : X → ℂ) :
   symm
   apply Finset.sum_subset
   · intro p hp
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hp ⊢
+    simp_rw [Finset.mem_filter_univ] at hp ⊢
     exact hp.2
   · intro p hp h'p
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hp h'p
+    simp_rw [Finset.mem_filter_univ] at hp h'p
     simp only [mem_inter_iff, hp, and_true] at h'p
     have : x ∉ 𝓘 p := hx _ h'p h'x
     have : x ∉ E p := by simp at this; simp [E, this]

--- a/Carleson/Discrete/ForestUnion.lean
+++ b/Carleson/Discrete/ForestUnion.lean
@@ -52,11 +52,11 @@ lemma ordConnected_C1 : OrdConnected (ℭ₁ k n j : Set (𝔓 X)) := by
   simp_rw [mp''.1.1, true_and, true_implies] at mp''
   constructor
   · refine mp''.1.trans (Finset.card_le_card fun b mb ↦ ?_)
-    simp_rw [Finset.mem_filter, Finset.mem_univ, true_and, 𝔅, mem_setOf] at mb ⊢
+    simp_rw [Finset.mem_filter_univ, 𝔅, mem_setOf] at mb ⊢
     have h100 := wiggle_order_11_10 (n := 100) mp'.2 (C5_3_3_le (X := X).trans (by norm_num))
     exact ⟨mb.1, h100.trans mb.2⟩
   · refine (Finset.card_le_card fun b mb ↦ ?_).trans_lt mp.2
-    simp_rw [Finset.mem_filter, Finset.mem_univ, true_and, 𝔅, mem_setOf] at mb ⊢
+    simp_rw [Finset.mem_filter_univ, 𝔅, mem_setOf] at mb ⊢
     have h100 := wiggle_order_11_10 (n := 100) mp'.1 (C5_3_3_le (X := X).trans (by norm_num))
     exact ⟨mb.1, h100.trans mb.2⟩
 
@@ -527,7 +527,7 @@ lemma forest_stacking (x : X) (hkn : k ≤ n) : stackSize (𝔘₃ (X := X) k n 
   let C' : Finset (Grid X) := C.image 𝓘
   have C'n : C'.Nonempty := by rwa [Finset.image_nonempty]
   obtain ⟨i, mi, li⟩ := C'.exists_minimal C'n
-  simp_rw [C', Finset.mem_image, C, Finset.mem_filter, Finset.mem_univ, true_and] at mi
+  simp_rw [C', Finset.mem_image, C, Finset.mem_filter_univ] at mi
   obtain ⟨u, ⟨mu, mx⟩, uei⟩ := mi; subst uei
   have uA : (𝓘 u : Set X) ⊆ setA (2 * n + 6) k n := fun y my ↦
     calc
@@ -536,10 +536,10 @@ lemma forest_stacking (x : X) (hkn : k ≤ n) : stackSize (𝔘₃ (X := X) k n 
       _ ≤ stackSize (𝔘₃ k n j) y := by
         simp_rw [stackSize, indicator_apply, Pi.one_apply, Finset.sum_boole, Nat.cast_id]
         apply Finset.card_le_card fun v mv ↦ ?_
-        simp_rw [Finset.mem_filter, Finset.mem_univ, true_and] at mv ⊢
+        simp_rw [Finset.filter_filter, Finset.mem_filter_univ] at mv ⊢
         have mvC' : 𝓘 v ∈ C' := by
           simp_rw [C', Finset.mem_image]; use v
-          simp_rw [C, Finset.mem_filter, Finset.mem_univ, true_and, and_true]; exact mv
+          simp_rw [C, Finset.mem_filter_univ, and_true]; exact mv
         specialize li mvC'
         have inc := (or_assoc.mpr (le_or_ge_or_disjoint (i := 𝓘 u) (j := 𝓘 v))).resolve_right
           (not_disjoint_iff.mpr ⟨_, mx, mv.2⟩)
@@ -626,8 +626,8 @@ lemma stackSize_𝔘₄_le (x : X) : stackSize (𝔘₄ (X := X) k n j l) x ≤ 
       exact disjoint_iff_forall_ne.1 this hp hq
     congr
     ext p
-    simp only [mem_Ico, mem_iUnion, exists_prop, Finset.mem_filter, Finset.mem_univ, true_and,
-      Finset.mem_biUnion, Finset.mem_Ico] -- perf: squeezed
+    simp_rw [Finset.mem_biUnion, Finset.mem_filter_univ, mem_Ico, Finset.mem_Ico, mem_iUnion,
+      exists_prop]
   _ ≤ ∑ i ∈ Finset.Ico (l * 2 ^ n) ((l + 1) * 2 ^ n), 1 := by
     gcongr with i hi
     apply stackSize_le_one_of_pairwiseDisjoint
@@ -697,10 +697,10 @@ lemma carlesonSum_ℭ₅_eq_ℭ₆ {f : X → ℂ} {x : X} (hx : x ∈ G \ G') {
   symm
   apply Finset.sum_subset
   · intro p hp
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hp ⊢
+    rw [Finset.mem_filter_univ] at hp ⊢
     exact ℭ₆_subset_ℭ₅ hp
   · intro p hp h'p
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hp h'p
+    rw [Finset.mem_filter_univ] at hp h'p
     have : x ∉ 𝓘 p := by
       simp only [ℭ₆, mem_setOf_eq, not_and, Decidable.not_not] at h'p
       intro h'x
@@ -748,8 +748,7 @@ lemma lintegral_carlesonSum_forest
       have := forest_disjoint (X := X) (𝔘₄_subset_𝔘₃ ha) (𝔘₄_subset_𝔘₃ hb) hab
       exact disjoint_iff_forall_ne.1 this hx hy
     congr with p
-    simp only [mem_iUnion, exists_prop, Finset.mem_filter, Finset.mem_univ, true_and, forest, 𝔉]
-    exact Iff.rfl
+    simp_rw [mem_iUnion, exists_prop, Finset.mem_filter_univ]; rfl
   rw [this]
   have W := forest_operator_le_volume 𝔉 hf h2f (A := G \ G')
     (measurableSet_G.diff measurable_G') diff_subset

--- a/Carleson/Discrete/ForestUnion.lean
+++ b/Carleson/Discrete/ForestUnion.lean
@@ -736,7 +736,7 @@ lemma lintegral_carlesonSum_forest
   classical
   let 𝔉 := forest (X := X) k n j l
   have : ∫⁻ x in G \ G', ‖carlesonSum (⋃ u ∈ 𝔘₄ k n j l, 𝔗₂ k n j u) f x‖ₑ =
-      ∫⁻ x in G \ G', ‖∑ u ∈ { p | p ∈ 𝔉 }, carlesonSum (𝔉 u) f x‖ₑ := by
+      ∫⁻ x in G \ G', ‖∑ u with u ∈ 𝔉, carlesonSum (𝔉 u) f x‖ₑ := by
     congr with x
     congr
     rw [sum_carlesonSum_of_pairwiseDisjoint]; swap

--- a/Carleson/FinitaryCarleson.lean
+++ b/Carleson/FinitaryCarleson.lean
@@ -42,8 +42,8 @@ private lemma 𝔓_biUnion : @Finset.univ (𝔓 X) _ = (Icc (-S : ℤ) S).toFins
 private lemma sum_eq_zero_of_notMem_Icc {f : X → ℂ} {x : X} (s : ℤ)
     (hs : s ∈ (Icc (-S : ℤ) S).toFinset.filter (fun t ↦ t ∉ Icc (σ₁ x) (σ₂ x))) :
     ∑ i ∈ Finset.univ.filter (fun p ↦ 𝔰 p = s), carlesonOn i f x = 0 := by
-  refine Finset.sum_eq_zero (fun p hp ↦ ?_)
-  simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hp
+  refine Finset.sum_eq_zero fun p hp ↦ ?_
+  rw [Finset.mem_filter_univ] at hp
   simp only [mem_Icc, not_and, not_le, toFinset_Icc, Finset.mem_filter, Finset.mem_Icc] at hs
   rw [carlesonOn, Set.indicator_of_notMem]
   simp only [E, Grid.mem_def, mem_Icc, sep_and, mem_inter_iff, mem_setOf_eq, not_and, not_le]

--- a/Carleson/ForestOperator/AlmostOrthogonality.lean
+++ b/Carleson/ForestOperator/AlmostOrthogonality.lean
@@ -59,19 +59,17 @@ lemma adjoint_tile_support2_sum (hu : u ∈ t) :
   unfold adjointCarlesonSum
   classical
   calc
-    _ = ∑ p ∈ {p | p ∈ t u},
+    _ = ∑ p with p ∈ t u,
         (𝓘 u : Set X).indicator (adjointCarleson p ((𝓘 u : Set X).indicator f)) := by
       ext x; simp only [Finset.sum_apply]; congr! 1 with p mp
-      simp_rw [Finset.mem_filter, Finset.mem_univ, true_and] at mp
-      rw [adjoint_tile_support2 hu mp]
+      rw [Finset.mem_filter_univ] at mp; rw [adjoint_tile_support2 hu mp]
     _ = _ := by simp_rw [← Finset.indicator_sum, ← Finset.sum_apply]
 
 /-- A partially applied variant of `adjoint_tile_support2_sum`, used to prove Lemma 7.7.3. -/
 lemma adjoint_tile_support2_sum_partial (hu : u ∈ t) :
     adjointCarlesonSum (t u) f = (adjointCarlesonSum (t u) ((𝓘 u : Set X).indicator f)) := by
   unfold adjointCarlesonSum
-  ext x; congr! 1 with p mp
-  simp_rw [Finset.mem_filter, Finset.mem_univ, true_and] at mp
+  ext x; congr! 1 with p mp; classical rw [Finset.mem_filter_univ] at mp
   rw [← adjoint_eq_adjoint_indicator (E_subset_𝓘.trans (t.smul_four_le hu mp).1.1)]
 
 lemma enorm_adjointCarleson_le {x : X} :

--- a/Carleson/ForestOperator/Forests.lean
+++ b/Carleson/ForestOperator/Forests.lean
@@ -224,8 +224,8 @@ lemma stackSize_remainder_ge_one_of_exists (t : Forest X n) (j : ℕ) (x : X)
   rw [← Finset.sum_erase_add _ (a := 𝔲')]
   · rw [indicator_apply,← Grid.mem_def,if_pos h𝔲'.right,Pi.one_apply]
     simp only [le_add_iff_nonneg_left, zero_le]
-  simp only [mem_inter_iff, Finset.mem_filter, Finset.mem_univ, true_and]
-  exact ⟨t.rowDecomp_𝔘_subset j h𝔲'.left,h𝔲'.left⟩
+  simp_rw [Finset.mem_filter_univ, mem_inter_iff]
+  exact ⟨t.rowDecomp_𝔘_subset j h𝔲'.1, h𝔲'.1⟩
 
 lemma remainder_stackSize_le (t : Forest X n) (j : ℕ) :
   ∀ x:X, stackSize (t \ ⋃ i < j, t.rowDecomp i : Set _) x ≤ 2 ^ n - j := by
@@ -286,7 +286,7 @@ lemma remainder_stackSize_le (t : Forest X n) (j : ℕ) :
         dsimp [stackSize]
         push_neg at h
         rw [Finset.sum_congr rfl (g := fun _ => 0) (by
-          simp only [Finset.mem_filter, Finset.mem_univ, true_and, indicator_apply_eq_zero,
+          simp_rw [Finset.mem_filter_univ, indicator_apply_eq_zero,
             Pi.one_apply, one_ne_zero] at h ⊢
           exact h)]
         rw [Finset.sum_eq_zero (fun _ _ => rfl)]
@@ -404,7 +404,7 @@ lemma row_correlation_aux (hf : BoundedCompactSupport f) (nf : ∀ x, ‖f x‖ 
       exact setLIntegral_le_lintegral _ _
     _ ≤ (∑ u ∈ U, (C7_4_3 a * eLpNorm ((𝓘 u : Set X).indicator f) 2 volume) ^ 2) ^ (2 : ℝ)⁻¹ := by
       gcongr with u mu
-      simp_rw [U, Finset.mem_filter, Finset.mem_univ, true_and] at mu
+      rw [Finset.mem_filter_univ] at mu
       apply adjoint_tree_control (mem_forest_of_mem mu) (hf.indicator coeGrid_measurable)
       intro x; by_cases mx : x ∈ 𝓘 u
       · rw [indicator_of_mem mx]; exact nf x
@@ -468,7 +468,7 @@ lemma row_correlation (lj : j < 2 ^ n) (lj' : j' < 2 ^ n) (hn : j ≠ j')
         ‖∫ x, adjointCarlesonSum (t u) ((𝓘 u : Set X).indicator f₁) x *
         conj (adjointCarlesonSum (t u') ((𝓘 u' : Set X).indicator f₂) x)‖ₑ := by
       congr! 5 with u mu u' mu' x
-      simp_rw [Finset.mem_filter, Finset.mem_univ, true_and] at mu mu'
+      rw [Finset.mem_filter_univ] at mu mu'
       rw [adjoint_tile_support2_sum_partial (mem_forest_of_mem mu),
         adjoint_tile_support2_sum_partial (mem_forest_of_mem mu')]
     _ ≤ ∑ u with u ∈ rowDecomp t j, ∑ u' with u' ∈ rowDecomp t j',
@@ -478,7 +478,7 @@ lemma row_correlation (lj : j < 2 ^ n) (lj' : j' < 2 ^ n) (hn : j ≠ j')
         eLpNorm ((𝓘 u ∩ 𝓘 u' : Set X).indicator
           (adjointBoundaryOperator t u' ((𝓘 u' : Set X).indicator f₂)) ·) 2 volume := by
       gcongr with u mu u' mu'
-      simp_rw [Finset.mem_filter, Finset.mem_univ, true_and] at mu mu'
+      rw [Finset.mem_filter_univ] at mu mu'
       refine correlation_separated_trees (mem_forest_of_mem mu) (mem_forest_of_mem mu') ?_
         (hf₁.indicator coeGrid_measurable) (hf₂.indicator coeGrid_measurable)
       exact (pairwiseDisjoint_rowDecomp lj lj' hn).ne_of_mem mu mu'
@@ -580,7 +580,7 @@ lemma forest_operator_g_prelude
 lemma adjointCarlesonRowSum_rowSupport :
     adjointCarlesonRowSum t j f = adjointCarlesonRowSum t j ((rowSupport t j).indicator f) := by
   ext x; unfold adjointCarlesonRowSum adjointCarlesonSum; congr! 2 with u mu p mp
-  simp_rw [Finset.mem_filter, Finset.mem_univ, true_and] at mu mp
+  simp_rw [Finset.mem_filter_univ] at mu mp
   refine setIntegral_congr_ae measurableSet_E (.of_forall fun y my ↦ ?_)
   congr; refine (indicator_of_mem ?_ _).symm
   simp_rw [rowSupport, mem_iUnion₂]; exact ⟨_, mu, _, mp, my⟩
@@ -716,7 +716,7 @@ lemma carlesonRowSum_rowSupport :
     carlesonRowSum t j f = (rowSupport t j).indicator (carlesonRowSum t j f) := by
   symm; rw [indicator_eq_self, support_subset_iff']
   refine fun x nx ↦ Finset.sum_eq_zero fun u mu ↦ Finset.sum_eq_zero fun p mp ↦ ?_
-  simp only [Finset.mem_filter, Finset.mem_univ, true_and] at mu mp
+  simp_rw [Finset.mem_filter_univ] at mu mp
   simp only [rowSupport, mem_iUnion, exists_prop, not_exists, not_and] at nx
   exact indicator_of_notMem (nx _ mu _ mp) _
 

--- a/Carleson/ForestOperator/Forests.lean
+++ b/Carleson/ForestOperator/Forests.lean
@@ -977,7 +977,7 @@ open scoped Classical in
 the integral of the function multiplied by another function. -/
 theorem forest_operator' {n : ℕ} (𝔉 : Forest X n) {f : X → ℂ} {A : Set X}
     (hf : Measurable f) (h2f : ∀ x, ‖f x‖ ≤ F.indicator 1 x) (hA : MeasurableSet A) (sA : A ⊆ G) :
-    ∫⁻ x in A, ‖∑ u ∈ { p | p ∈ 𝔉 }, carlesonSum (𝔉 u) f x‖ₑ ≤
+    ∫⁻ x in A, ‖∑ u with u ∈ 𝔉, carlesonSum (𝔉 u) f x‖ₑ ≤
     C2_0_4 a q n * (dens₂ (⋃ u ∈ 𝔉, 𝔉 u)) ^ (q⁻¹ - 2⁻¹) *
     eLpNorm f 2 volume * (volume A) ^ (1/2 : ℝ) := by
   /- This follows from the other version by taking for the test function `g` the argument of
@@ -1026,7 +1026,7 @@ the integral of the function multiplied by another function, and with the upper 
 of `volume F` and `volume G`. -/
 theorem forest_operator_le_volume {n : ℕ} (𝔉 : Forest X n) {f : X → ℂ} {A : Set X}
     (hf : Measurable f) (h2f : ∀ x, ‖f x‖ ≤ F.indicator 1 x) (hA : MeasurableSet A) (sA : A ⊆ G) :
-    ∫⁻ x in A, ‖∑ u ∈ { p | p ∈ 𝔉 }, carlesonSum (𝔉 u) f x‖ₑ ≤
+    ∫⁻ x in A, ‖∑ u with u ∈ 𝔉, carlesonSum (𝔉 u) f x‖ₑ ≤
     C2_0_4 a q n * (dens₂ (⋃ u ∈ 𝔉, 𝔉 u)) ^ (q⁻¹ - 2⁻¹) *
     (volume F) ^ (1/2 : ℝ) * (volume A) ^ (1/2 : ℝ) := by
   apply (forest_operator' 𝔉 hf h2f hA sA).trans

--- a/Carleson/ForestOperator/L2Estimate.lean
+++ b/Carleson/ForestOperator/L2Estimate.lean
@@ -388,7 +388,7 @@ def kissing (I : Grid X) : Finset (Grid X) :=
 
 lemma subset_of_kissing (h : J ∈ kissing I) :
     ball (c J) (D ^ s J / 4) ⊆ ball (c I) (33 * D ^ s I) := by
-  simp_rw [kissing, Finset.mem_filter, Finset.mem_univ, true_and] at h
+  simp_rw [kissing, Finset.mem_filter_univ] at h
   obtain ⟨x, xI, xJ⟩ := not_disjoint_iff.mp h.2
   apply ball_subset_ball'
   calc
@@ -405,7 +405,7 @@ lemma subset_of_kissing (h : J ∈ kissing I) :
 
 lemma volume_le_of_kissing (h : J ∈ kissing I) :
     volume (ball (c I) (33 * D ^ s I)) ≤ 2 ^ (9 * a) * volume (ball (c J) (D ^ s J / 4)) := by
-  simp_rw [kissing, Finset.mem_filter, Finset.mem_univ, true_and] at h
+  simp_rw [kissing, Finset.mem_filter_univ] at h
   obtain ⟨x, xI, xJ⟩ := not_disjoint_iff.mp h.2
   have : ball (c I) (33 * D ^ s I) ⊆ ball (c J) (128 * D ^ s J) := by
     apply ball_subset_ball'
@@ -619,7 +619,7 @@ lemma boundary_geometric_series :
       by_cases hs : k = s I; swap; · simp [hs]
       suffices (J : Set X) ⊆ ball (c I) (16 * D ^ s I) → I ∈ kissing J' by
         split_ifs; exacts [by simp_all, by tauto, by positivity, by rfl]
-      intro mJ; simp_rw [kissing, Finset.mem_filter, Finset.mem_univ, true_and]
+      intro mJ; simp_rw [kissing, Finset.mem_filter_univ]
       refine ⟨pJ'.1 ▸ hs.symm, not_disjoint_iff.mpr ⟨c J, ?_, mJ Grid.c_mem_Grid⟩⟩
       refine (pJ'.2.1.trans Grid_subset_ball |>.trans (ball_subset_ball ?_)) Grid.c_mem_Grid
       change (4 : ℝ) * D ^ s J' ≤ 16 * D ^ s J'; gcongr; norm_num

--- a/Carleson/ForestOperator/LargeSeparation.lean
+++ b/Carleson/ForestOperator/LargeSeparation.lean
@@ -972,7 +972,7 @@ lemma local_tree_control_sumsumsup (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu
     (h2u : 𝓘 u₁ ≤ 𝓘 u₂) (hJ : J ∈ 𝓙₅ t u₁ u₂) :
     ⨆ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f x‖ₑ ≤
     ∑ k ∈ Finset.Icc (s J) (s J + 3),
-    ∑ p ∈ {p | 𝔰 p = k ∧ ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8⁻¹ * D ^ s J))},
+    ∑ p with 𝔰 p = k ∧ ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8⁻¹ * D ^ s J)),
       ⨆ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarleson p f x‖ₑ :=
   calc
     _ ≤ ⨆ x ∈ ball (c J) (8⁻¹ * D ^ s J),
@@ -1072,17 +1072,17 @@ lemma local_tree_control (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ �
   classical
   calc
     _ ≤ ∑ k ∈ Finset.Icc (s J) (s J + 3),
-        ∑ p ∈ {p | 𝔰 p = k ∧ ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8⁻¹ * D ^ s J))},
+        ∑ p with 𝔰 p = k ∧ ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8⁻¹ * D ^ s J)),
           ⨆ x ∈ ball (c J) (8⁻¹ * D ^ s J), ‖adjointCarleson p f x‖ₑ :=
       local_tree_control_sumsumsup hu₁ hu₂ hu h2u hJ
     _ ≤ ∑ k ∈ Finset.Icc (s J) (s J + 3),
-        ∑ p ∈ {p | 𝔰 p = k ∧ ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8⁻¹ * D ^ s J))},
+        ∑ p with 𝔰 p = k ∧ ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8⁻¹ * D ^ s J)),
           2 ^ (103 * a ^ 3) * (volume (ball (c J) (16 * D ^ k)))⁻¹ * ∫⁻ x in E p, ‖f x‖ₑ := by
       gcongr with k mk p mp; rw [Finset.mem_filter_univ] at mp
       exact local_tree_control_sup_bound mk mp hf.aestronglyMeasurable.enorm
     _ = 2 ^ (103 * a ^ 3) * ∑ k ∈ Finset.Icc (s J) (s J + 3),
         (volume (ball (c J) (16 * D ^ k)))⁻¹ *
-          ∑ p ∈ {p | 𝔰 p = k ∧ ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8⁻¹ * D ^ s J))},
+          ∑ p with 𝔰 p = k ∧ ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8⁻¹ * D ^ s J)),
             ∫⁻ x in E p, ‖f x‖ₑ := by
       simp_rw [Finset.mul_sum, mul_assoc]
     _ = 2 ^ (103 * a ^ 3) * ∑ k ∈ Finset.Icc (s J) (s J + 3),

--- a/Carleson/ForestOperator/LargeSeparation.lean
+++ b/Carleson/ForestOperator/LargeSeparation.lean
@@ -1078,8 +1078,7 @@ lemma local_tree_control (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ �
     _ ≤ ∑ k ∈ Finset.Icc (s J) (s J + 3),
         ∑ p ∈ {p | 𝔰 p = k ∧ ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (8⁻¹ * D ^ s J))},
           2 ^ (103 * a ^ 3) * (volume (ball (c J) (16 * D ^ k)))⁻¹ * ∫⁻ x in E p, ‖f x‖ₑ := by
-      gcongr with k mk p mp
-      simp_rw [Finset.mem_filter, Finset.mem_univ, true_and] at mp
+      gcongr with k mk p mp; rw [Finset.mem_filter_univ] at mp
       exact local_tree_control_sup_bound mk mp hf.aestronglyMeasurable.enorm
     _ = 2 ^ (103 * a ^ 3) * ∑ k ∈ Finset.Icc (s J) (s J + 3),
         (volume (ball (c J) (16 * D ^ k)))⁻¹ *
@@ -1102,7 +1101,7 @@ lemma local_tree_control (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ �
     _ ≤ 2 ^ (103 * a ^ 3) * ∑ k ∈ Finset.Icc (s J) (s J + 3),
         (volume (ball (c J) (16 * D ^ k)))⁻¹ * ∫⁻ x in ball (c J) (16 * D ^ k), ‖f x‖ₑ := by
       gcongr with k mk; refine lintegral_mono_set (iUnion₂_subset fun p mp ↦ ?_)
-      simp_rw [Finset.mem_filter, Finset.mem_univ, true_and] at mp
+      rw [Finset.mem_filter_univ] at mp
       refine (E_subset_𝓘.trans Grid_subset_ball).trans (ball_subset_ball' ?_)
       obtain ⟨y, my₁, my₂⟩ := not_disjoint_iff.mp mp.2
       rw [mem_ball] at my₁ my₂; change 4 * D ^ 𝔰 p + dist (𝔠 p) (c J) ≤ _
@@ -1501,7 +1500,7 @@ lemma support_holderFunction_subset (u₂ : 𝔓 X) (f₁ f₂ : X → ℂ) (J :
   rw [support_subset_iff']; intro x nx
   have : adjointCarlesonSum (t u₁) f₁ x = 0 := by
     refine Finset.sum_eq_zero fun p mp ↦ ?_
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at mp
+    simp_rw [Finset.mem_filter_univ] at mp
     rw [adjoint_tile_support2 hu₁ mp]
     exact indicator_of_notMem nx _
   rw [holderFunction, this, mul_zero, mul_zero, zero_mul]
@@ -1545,7 +1544,7 @@ lemma holder_correlation_tree_1 (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : 
   by_cases mu₁ : x ∉ 𝓘 u₁
   · have : adjointCarlesonSum (t u₁) f₁ x = 0 := by
       refine Finset.sum_eq_zero fun p mp ↦ ?_
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at mp
+      simp_rw [Finset.mem_filter_univ] at mp
       rw [adjoint_tile_support2 hu₁ mp]
       exact indicator_of_notMem mu₁ _
     rw [this, enorm_zero, mul_zero, zero_mul]; exact zero_le _

--- a/Carleson/ForestOperator/PointwiseEstimate.lean
+++ b/Carleson/ForestOperator/PointwiseEstimate.lean
@@ -100,7 +100,7 @@ open scoped Classical in
 /-- The projection operator `P_𝓒 f(x)`, given above Lemma 7.1.3.
 In lemmas the `c` will be pairwise disjoint on `C`. -/
 def approxOnCube (C : Set (Grid X)) (f : X → E') (x : X) : E' :=
-  ∑ J ∈ { p | p ∈ C }, (J : Set X).indicator (fun _ ↦ ⨍ y in J, f y) x
+  ∑ J with J ∈ C, (J : Set X).indicator (fun _ ↦ ⨍ y in J, f y) x
 
 lemma stronglyMeasurable_approxOnCube (C : Set (Grid X)) (f : X → E') :
     StronglyMeasurable (approxOnCube (X := X) (K := K) C f) :=
@@ -1114,7 +1114,7 @@ lemma pointwise_tree_estimate (hu : u ∈ t) (hL : L ∈ 𝓛 (t u)) (hx : x ∈
     apply (integrable_Ks_x <| one_lt_D (K := K)).bdd_mul
     · exact (stronglyMeasurable_approxOnCube _ _).aestronglyMeasurable
     · classical
-      use ∑ J ∈ { p | p ∈ 𝓙 (t.𝔗 u) }, ‖⨍ y in J, f y‖
+      use ∑ J with J ∈ 𝓙 (t u), ‖⨍ y in J, f y‖
       refine fun x ↦ (norm_sum_le _ _).trans <| Finset.sum_le_sum (fun J hJ ↦ ?_)
       by_cases h : x ∈ (J : Set X) <;> simp [h]
   have : ∃ C, ∀ (y : X), ‖cexp (I * (-𝒬 u y + Q x y + 𝒬 u x - Q x x)) - 1‖ ≤ C := by

--- a/Carleson/ForestOperator/PointwiseEstimate.lean
+++ b/Carleson/ForestOperator/PointwiseEstimate.lean
@@ -128,7 +128,7 @@ lemma approxOnCube_apply {C : Set (Grid X)} (hC : C.PairwiseDisjoint (fun I ↦ 
     suffices ∀ i ∈ (Finset.univ.filter (· ∈ C)).filter (¬ J = ·),
       (i : Set X).indicator (fun _ ↦ ⨍ y in i, f y) x = 0 by simp [Finset.sum_congr rfl this]
     intro i hi
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hi
+    rw [Finset.mem_filter, Finset.mem_filter_univ] at hi
     apply indicator_of_notMem <|
       Set.disjoint_left.mp ((hC.eq_or_disjoint hJ hi.1).resolve_left hi.2) xJ
   have eq_ave : ∑ i ∈ (Finset.univ.filter (· ∈ C)).filter (J = ·),
@@ -662,7 +662,7 @@ lemma second_tree_pointwise (hu : u ∈ t) (hL : L ∈ 𝓛 (t u)) (hx : x ∈ L
   rcases (t.σ u x).eq_empty_or_nonempty with hne | hne; · simp [hne]
   let s₁ := Finset.min' (t.σ u x) hne
   have ms₁ : s₁ ∈ t.σ u x := Finset.min'_mem ..
-  simp_rw [σ, Finset.mem_image, Finset.mem_filter, Finset.mem_univ, true_and] at ms₁
+  simp_rw [σ, Finset.mem_image, Finset.mem_filter_univ] at ms₁
   obtain ⟨p, ⟨mp, xp, _, _⟩, sp⟩ := ms₁
   have Lle : L ≤ 𝓘 p := by
     rcases 𝓛_subset_𝓛₀ hL with hL | hL
@@ -670,7 +670,7 @@ lemma second_tree_pointwise (hu : u ∈ t) (hL : L ∈ 𝓛 (t u)) (hx : x ∈ L
     · exact (le_or_ge_of_mem_of_mem xp hx).resolve_left (hL.2 p mp)
   let s₂ := Finset.max' (t.σ u x) hne
   have ms₂ : s₂ ∈ t.σ u x := Finset.max'_mem ..
-  simp_rw [σ, Finset.mem_image, Finset.mem_filter, Finset.mem_univ, true_and] at ms₂
+  simp_rw [σ, Finset.mem_image, Finset.mem_filter_univ] at ms₂
   obtain ⟨p', ⟨mp', xp', Qxp', _⟩, sp'⟩ := ms₂
   have s_ineq : 𝔰 p ≤ 𝔰 p' := by
     rw [sp, sp']; exact (t.σ u x).min'_le s₂ (Finset.max'_mem ..)
@@ -746,7 +746,7 @@ private lemma p_sum_eq_s_sum {α : Type*} [AddCommMonoid α] (I : ℤ → X → 
       ∑ p ∈ Finset.univ.filter (· ∈ t.𝔗 u), (E p).indicator (I (𝔰 p)) x := by
     apply Finset.sum_subset (fun p hp ↦ by simp [(Finset.mem_filter.mp hp).2.1])
     intro p p𝔗 p𝔗'
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and, not_and, 𝔗'] at p𝔗 p𝔗'
+    simp_rw [𝔗', Finset.mem_filter_univ, not_and] at p𝔗 p𝔗'
     exact indicator_of_notMem (p𝔗' p𝔗) (I (𝔰 p))
   rw [← this]
   -- Now the relevant values of `p` and `s` are in bijection.

--- a/Carleson/ForestOperator/RemainingTiles.lean
+++ b/Carleson/ForestOperator/RemainingTiles.lean
@@ -316,8 +316,8 @@ lemma square_function_count (hJ : J ∈ 𝓙₆ t u₁) {s' : ℤ} :
       gcongr
       linarith
   simp_rw [← Nat.cast_le (α := ℝ≥0∞)] at est₁
-  have est₂ (x) (hx : x ∈ J) : (∑ I ∈ {I : Grid X | s I = s J - s' ∧ Disjoint (I : Set X) (𝓘 u₁) ∧
-      ¬ Disjoint (J : Set X) (ball (c I) (8 * D ^ s I)) },
+  have est₂ (x) (hx : x ∈ J) : (∑ I with s I = s J - s' ∧ Disjoint (I : Set X) (𝓘 u₁) ∧
+      ¬Disjoint (J : Set X) (ball (c I) (8 * D ^ s I)),
       (ball (c I) (8 * D ^ s I)).indicator (1 : X → ℝ≥0∞) x) ≤
       if x ∈ supp then (defaultA a) ^ 7 else 0 := by
     split_ifs with hx'
@@ -770,7 +770,7 @@ lemma cntp_approxOnCube_eq (hu₁ : u₁ ∈ t) :
   ext x; simp only [approxOnCube]
   classical
   calc
-    _ = ∑ p ∈ {b | b ∈ 𝓙₆ t u₁}, (p : Set X).indicator (fun x ↦ ⨍ y in p,
+    _ = ∑ p with p ∈ 𝓙₆ t u₁, (p : Set X).indicator (fun x ↦ ⨍ y in p,
         ‖U.indicator (adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f₂) y‖) x := by
       apply (Finset.sum_subset (fun p mp ↦ ?_) (fun p mp np ↦ ?_)).symm
       · rw [Finset.mem_filter_univ] at mp ⊢

--- a/Carleson/ForestOperator/RemainingTiles.lean
+++ b/Carleson/ForestOperator/RemainingTiles.lean
@@ -326,7 +326,7 @@ lemma square_function_count (hJ : J ∈ 𝓙₆ t u₁) {s' : ℤ} :
       refine le_trans ?_ (est₁ (s J - s') x)
       gcongr
       intro I
-      simp only [mem_ball, Finset.mem_filter, Finset.mem_univ, true_and, mem_toFinset, 𝒟]
+      simp_rw [Finset.filter_filter, Finset.mem_filter_univ, mem_toFinset]
       exact fun H ↦ ⟨H.2, H.1.1⟩
     · have (I : Grid X) : ball (c I) (8 * D ^ s I) = EMetric.ball (c I) (8 * D ^ s I) := by
         trans EMetric.ball (c I) (show ℝ≥0 from ⟨8 * D ^ s I, by positivity⟩)
@@ -773,9 +773,9 @@ lemma cntp_approxOnCube_eq (hu₁ : u₁ ∈ t) :
     _ = ∑ p ∈ {b | b ∈ 𝓙₆ t u₁}, (p : Set X).indicator (fun x ↦ ⨍ y in p,
         ‖U.indicator (adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f₂) y‖) x := by
       apply (Finset.sum_subset (fun p mp ↦ ?_) (fun p mp np ↦ ?_)).symm
-      · simp_rw [Finset.mem_filter, Finset.mem_univ, true_and, 𝓙₆] at mp ⊢
+      · rw [Finset.mem_filter_univ] at mp ⊢
         exact mp.1
-      · simp_rw [Finset.mem_filter, Finset.mem_univ, true_and] at mp np
+      · rw [Finset.mem_filter_univ] at mp np
         rw [indicator_apply_eq_zero]; intro mx
         rw [show (0 : ℝ) = ⨍ y in (p : Set X), 0 by simp]
         refine setAverage_congr_fun coeGrid_measurable (.of_forall fun y my ↦ ?_)
@@ -798,7 +798,7 @@ lemma cntp_approxOnCube_eq (hu₁ : u₁ ∈ t) :
     _ = _ := by
       congr! 3 with p mp
       refine setAverage_congr_fun coeGrid_measurable (.of_forall fun y my ↦ ?_)
-      simp_rw [Finset.mem_filter, Finset.mem_univ, true_and, 𝓙₆, mem_inter_iff, mem_Iic] at mp
+      rw [Finset.mem_filter_univ, 𝓙₆, mem_inter_iff, mem_Iic] at mp
       rw [indicator_of_mem (mp.2.1 my)]
 
 /-- The constant used in `correlation_near_tree_parts`. -/

--- a/Carleson/GridStructure.lean
+++ b/Carleson/GridStructure.lean
@@ -245,10 +245,10 @@ lemma exists_unique_succ (i : Grid X) (h : ¬IsMax i) :
   simp_rw [Finset.mem_univ, true_and]
   classical let incs : Finset (Grid X) := { j | i < j }
   have ine : incs.Nonempty := by
-    use topCube; simp only [incs, Finset.mem_filter, Finset.mem_univ, true_and]
+    use topCube; simp_rw [incs, Finset.mem_filter_univ]
     exact lt_of_le_of_ne le_topCube (isMax_iff.not.mp h)
   obtain ⟨j, mj, hj⟩ := incs.exists_minimal ine
-  simp only [Finset.mem_filter, Finset.mem_univ, true_and, incs] at mj hj
+  simp only [incs, Finset.mem_filter_univ] at mj hj
   replace hj : ∀ (x : Grid X), i < x → j ≤ x := fun x mx ↦ by
     rcases lt_or_ge (s x) (s j) with c | c
     · refine (eq_of_le_of_not_lt (le_dyadic c.le mx.le mj.le) ?_).symm.le

--- a/Carleson/Operators.lean
+++ b/Carleson/Operators.lean
@@ -245,8 +245,7 @@ lemma adjointCarlesonSum_inter {A B : Set (𝔓 X)} {f : X → ℂ} {x : X} :
   · simp only [Finset.disjoint_filter, mem_diff, not_and, not_not]
     exact fun x _ ⟨xA, xB⟩ _ ↦ xB
   congr; ext x
-  simp only [Finset.mem_filter, Finset.mem_univ, true_and, mem_inter_iff, mem_diff,
-    Finset.mem_union]
+  simp_rw [Finset.mem_union, Finset.mem_filter_univ, mem_inter_iff, mem_diff]
   tauto
 
 variable {f g : X → ℂ}

--- a/Carleson/Operators.lean
+++ b/Carleson/Operators.lean
@@ -55,7 +55,7 @@ open Classical in
 /-- The operator `T_ℭ f` defined at the bottom of Section 7.4.
 We will use this in other places of the formalization as well. -/
 def carlesonSum (ℭ : Set (𝔓 X)) (f : X → ℂ) (x : X) : ℂ :=
-  ∑ p ∈ {p | p ∈ ℭ}, carlesonOn p f x
+  ∑ p with p ∈ ℭ, carlesonOn p f x
 
 @[fun_prop]
 lemma measurable_carlesonSum {ℭ : Set (𝔓 X)} {f : X → ℂ} (measf : Measurable f) :
@@ -235,7 +235,7 @@ def adjointCarleson (p : 𝔓 X) (f : X → ℂ) (x : X) : ℂ :=
 open scoped Classical in
 /-- The definition of `T_ℭ*g(x)`, defined at the bottom of Section 7.4 -/
 def adjointCarlesonSum (ℭ : Set (𝔓 X)) (f : X → ℂ) (x : X) : ℂ :=
-  ∑ p ∈ {p | p ∈ ℭ}, adjointCarleson p f x
+  ∑ p with p ∈ ℭ, adjointCarleson p f x
 
 /-- A helper lemma used in Lemma 7.5.10. -/
 lemma adjointCarlesonSum_inter {A B : Set (𝔓 X)} {f : X → ℂ} {x : X} :
@@ -448,14 +448,14 @@ lemma adjointCarlesonSum_adjoint
     (hf : BoundedCompactSupport f) (hg : BoundedCompactSupport g) (ℭ : Set (𝔓 X)) :
     ∫ x, conj (g x) * carlesonSum ℭ f x = ∫ x, conj (adjointCarlesonSum ℭ g x) * f x := by
   classical calc
-    _ = ∫ x, ∑ p ∈ {p | p ∈ ℭ}, conj (g x) * carlesonOn p f x := by
+    _ = ∫ x, ∑ p with p ∈ ℭ, conj (g x) * carlesonOn p f x := by
       unfold carlesonSum; simp_rw [Finset.mul_sum]
-    _ = ∑ p ∈ {p | p ∈ ℭ}, ∫ x, conj (g x) * carlesonOn p f x := by
+    _ = ∑ p with p ∈ ℭ, ∫ x, conj (g x) * carlesonOn p f x := by
       apply integral_finset_sum; intro p _
       refine hg.conj.mul hf.carlesonOn |>.integrable
-    _ = ∑ p ∈ {p | p ∈ ℭ}, ∫ y, conj (adjointCarleson p g y) * f y := by
+    _ = ∑ p with p ∈ ℭ, ∫ y, conj (adjointCarleson p g y) * f y := by
       simp_rw [adjointCarleson_adjoint hf hg]
-    _ = ∫ y, ∑ p ∈ {p | p ∈ ℭ}, conj (adjointCarleson p g y) * f y := by
+    _ = ∫ y, ∑ p with p ∈ ℭ, conj (adjointCarleson p g y) * f y := by
       symm; apply integral_finset_sum; intro p _
       refine BoundedCompactSupport.mul ?_ hf |>.integrable
       exact hg.adjointCarleson.conj

--- a/Carleson/TileStructure.lean
+++ b/Carleson/TileStructure.lean
@@ -413,10 +413,10 @@ variable {C C' : Set (𝔓 X)} {x x' : X}
 open scoped Classical in
 /-- The number of tiles `p` in `s` whose underlying cube `𝓘 p` contains `x`. -/
 def stackSize (C : Set (𝔓 X)) (x : X) : ℕ :=
-  ∑ p ∈ { p | p ∈ C }, (𝓘 p : Set X).indicator 1 x
+  ∑ p with p ∈ C, (𝓘 p : Set X).indicator 1 x
 
 lemma stackSize_setOf_add_stackSize_setOf_not {P : 𝔓 X → Prop} :
-    stackSize {p ∈ C | P p} x + stackSize {p ∈ C | ¬ P p} x = stackSize C x := by
+    stackSize {p ∈ C | P p} x + stackSize {p ∈ C | ¬P p} x = stackSize C x := by
   classical
   simp_rw [stackSize]
   conv_rhs => rw [← Finset.sum_filter_add_sum_filter_not _ P]
@@ -445,7 +445,7 @@ lemma stackSize_mono (h : C ⊆ C') : stackSize C x ≤ stackSize C' x := by
 open scoped Classical in
 -- Simplify the cast of `stackSize C x` from `ℕ` to `ℝ`
 lemma stackSize_real (C : Set (𝔓 X)) (x : X) : (stackSize C x : ℝ) =
-    ∑ p ∈ { p | p ∈ C }, (𝓘 p : Set X).indicator (1 : X → ℝ) x := by
+    ∑ p with p ∈ C, (𝓘 p : Set X).indicator (1 : X → ℝ) x := by
   rw [stackSize, Nat.cast_sum]
   refine Finset.sum_congr rfl (fun u _ ↦ ?_)
   by_cases hx : x ∈ (𝓘 u : Set X) <;> simp [hx]
@@ -591,7 +591,7 @@ lemma eq_biUnion_iteratedMaximalSubfamily (A : Set (𝔓 X)) {N : ℕ} (hN : ∀
     ext
     simp (config := {contextual := true}) [hp]
   classical
-  have : ∑ p ∈ {p | p ∈ u '' (Iio N)}, (𝓘 p : Set X).indicator 1 x
+  have : ∑ p with p ∈ u '' (Iio N), (𝓘 p : Set X).indicator 1 x
       ≤ stackSize {q | q ∈ A ∧ q ≠ p} x := by
     apply Finset.sum_le_sum_of_subset
     rintro p hp
@@ -601,14 +601,14 @@ lemma eq_biUnion_iteratedMaximalSubfamily (A : Set (𝔓 X)) {N : ℕ} (hN : ∀
       Finset.mem_univ, iteratedMaximalSubfamily_subset _ _ (hu n hn), true_and]
     rintro rfl
     exact hN n hn (hu n hn)
-  have : ∑ p ∈ {p | p ∈ u '' (Iio N)}, (𝓘 p : Set X).indicator 1 x
-      = ∑ p ∈ {p | p ∈ u '' (Iio N)}, 1 := by
+  have : ∑ p with p ∈ u '' (Iio N), (𝓘 p : Set X).indicator 1 x
+      = ∑ p with p ∈ u '' (Iio N), 1 := by
     apply Finset.sum_congr rfl (fun p hp ↦ ?_)
     simp only [Finset.mem_filter_univ, mem_image, mem_Iio] at hp
     rcases hp with ⟨n, hn, rfl⟩
     have : x ∈ (𝓘 (u n) : Set X) := h'u n hn hxp
     simp [this]
-  have : ∑ p ∈ {p | p ∈ u '' (Iio N)}, 1 = N := by
+  have : ∑ p with p ∈ u '' (Iio N), 1 = N := by
     have : Finset.filter (fun p ↦ p ∈ u '' Iio N) Finset.univ = Finset.image u (Finset.Iio N) := by
       ext p; simp
     simp only [Finset.sum_const, smul_eq_mul, mul_one, this]

--- a/Carleson/TileStructure.lean
+++ b/Carleson/TileStructure.lean
@@ -435,7 +435,7 @@ lemma stackSize_congr (h : ∀ p ∈ C, x ∈ (𝓘 p : Set X) ↔ x' ∈ (𝓘 
     stackSize C x = stackSize C x' := by
   classical
   refine Finset.sum_congr rfl fun p hp ↦ ?_
-  simp_rw [Finset.mem_filter, Finset.mem_univ, true_and] at hp
+  rw [Finset.mem_filter_univ] at hp
   simp_rw [indicator, h p hp, Pi.one_apply]
 
 lemma stackSize_mono (h : C ⊆ C') : stackSize C x ≤ stackSize C' x := by
@@ -462,12 +462,12 @@ lemma stackSize_le_one_of_pairwiseDisjoint {C : Set (𝔓 X)} {x : X}
     · simp [pC]
     · intro b hb hbp
       simp only [indicator_apply_eq_zero, Pi.one_apply, one_ne_zero, imp_false]
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hb
+      classical rw [Finset.mem_filter_univ] at hb
       exact disjoint_left.1 (h pC hb hbp.symm) hp
     simp [hp]
   · have : stackSize C x = 0 := by
       apply Finset.sum_eq_zero (fun p hp ↦ ?_)
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and, not_exists, not_and,
+      simp only [Finset.mem_filter_univ, not_exists, not_and,
         indicator_apply_eq_zero, Pi.one_apply, one_ne_zero, imp_false] at hp hx ⊢
       exact hx _ hp
     linarith
@@ -476,7 +476,7 @@ lemma eq_empty_of_forall_stackSize_zero (s : Set (𝔓 X)) :
   (∀ x, stackSize s x = 0) → s = ∅ := by
   intro h
   dsimp [stackSize] at h
-  simp only [Finset.sum_eq_zero_iff, Finset.mem_filter, Finset.mem_univ, true_and,
+  simp only [Finset.sum_eq_zero_iff, Finset.mem_filter_univ,
     indicator_apply_eq_zero, Pi.one_apply, one_ne_zero, imp_false] at h
   ext 𝔲
   simp only [mem_empty_iff_false, iff_false]
@@ -595,7 +595,7 @@ lemma eq_biUnion_iteratedMaximalSubfamily (A : Set (𝔓 X)) {N : ℕ} (hN : ∀
       ≤ stackSize {q | q ∈ A ∧ q ≠ p} x := by
     apply Finset.sum_le_sum_of_subset
     rintro p hp
-    simp only [mem_image, mem_Iio, Finset.mem_filter, Finset.mem_univ, true_and] at hp
+    simp only [Finset.mem_filter_univ, mem_image, mem_Iio] at hp
     rcases hp with ⟨n, hn, rfl⟩
     simp only [ne_eq, mem_setOf_eq, Finset.mem_filter,
       Finset.mem_univ, iteratedMaximalSubfamily_subset _ _ (hu n hn), true_and]
@@ -604,7 +604,7 @@ lemma eq_biUnion_iteratedMaximalSubfamily (A : Set (𝔓 X)) {N : ℕ} (hN : ∀
   have : ∑ p ∈ {p | p ∈ u '' (Iio N)}, (𝓘 p : Set X).indicator 1 x
       = ∑ p ∈ {p | p ∈ u '' (Iio N)}, 1 := by
     apply Finset.sum_congr rfl (fun p hp ↦ ?_)
-    simp only [mem_image, mem_Iio, Finset.mem_filter, Finset.mem_univ, true_and] at hp
+    simp only [Finset.mem_filter_univ, mem_image, mem_Iio] at hp
     rcases hp with ⟨n, hn, rfl⟩
     have : x ∈ (𝓘 (u n) : Set X) := h'u n hn hxp
     simp [this]

--- a/Carleson/ToMathlib/HardyLittlewood.lean
+++ b/Carleson/ToMathlib/HardyLittlewood.lean
@@ -607,6 +607,20 @@ lemma hasStrongType_MB_finite [BorelSpace X] [NormedSpace ℝ E] [MeasurableSpac
 /-- The constant factor in the statement that `M_{𝓑, p}` has strong type. -/
 irreducible_def C2_0_6 (A p₁ p₂ : ℝ≥0) : ℝ≥0 := CMB A (p₂ / p₁) ^ (p₁⁻¹ : ℝ)
 
+lemma C2_0_6_defaultA_one_le {a : ℕ} {q : ℝ≥0} (hq : 1 < q) :
+    C2_0_6 (defaultA a) 1 q ≤ 2 ^ (2 * a + 1) * (q / (q - 1)) := by
+  rw [C2_0_6, div_one, defaultA, Nat.cast_pow, Nat.cast_ofNat, NNReal.coe_one,
+    inv_one, NNReal.rpow_one, CMB_eq_of_one_lt_q hq]
+  calc
+    _ ≤ 2 * (q / (q - 1) * (2 ^ a) ^ 2) := by
+      conv_rhs => enter [2]; rw [← NNReal.rpow_one (_ * _)]
+      gcongr
+      · nth_rw 1 [← mul_one 1]; gcongr
+        · exact (one_le_div (tsub_pos_of_lt hq)).mpr tsub_le_self
+        · norm_cast; rw [← pow_mul]; exact Nat.one_le_two_pow
+      · rw [inv_le_one_iff₀]; right; exact_mod_cast hq.le
+    _ = _ := by ring
+
 /-- Equation (2.0.44). The proof is given between (9.0.34) and (9.0.36).
 This is a special case of `hasStrongType_maximalFunction` below, which doesn't have the assumption
 `hR` (but uses this result in its proof). -/
@@ -986,16 +1000,11 @@ lemma C2_0_6'_defaultA_one_two_eq {a : ℕ} : C2_0_6' (defaultA a) 1 2 = 2 ^ (3 
 
 lemma C2_0_6'_defaultA_one_le {a : ℕ} {q : ℝ≥0} (hq : 1 < q) :
     C2_0_6' (defaultA a) 1 q ≤ 2 ^ (4 * a + 1) * (q / (q - 1)) := by
-  rw [C2_0_6', C2_0_6, div_one, defaultA, Nat.cast_pow, Nat.cast_ofNat, NNReal.coe_one,
-    inv_one, NNReal.rpow_one, CMB_eq_of_one_lt_q hq]
   calc
-    _ ≤ (2 ^ a) ^ 2 * (2 * (q / (q - 1) * (2 ^ a) ^ 2)) := by
-      conv_rhs => enter [2, 2]; rw [← NNReal.rpow_one (_ * _)]
-      gcongr
-      · nth_rw 1 [← mul_one 1]; gcongr
-        · exact (one_le_div (tsub_pos_of_lt hq)).mpr tsub_le_self
-        · norm_cast; rw [← pow_mul]; exact Nat.one_le_two_pow
-      · rw [inv_le_one_iff₀]; right; exact_mod_cast hq.le
+    _ ≤ (2 ^ a) ^ 2 * (2 ^ (2 * a + 1) * (q / (q - 1))) := by
+      rw [C2_0_6']; gcongr
+      · norm_cast
+      · exact C2_0_6_defaultA_one_le hq
     _ = _ := by ring
 
 /-- Equation (2.0.46). Easy from `hasStrongType_maximalFunction` -/


### PR DESCRIPTION
The first commit uses `Finset.mem_filter_univ` (https://github.com/leanprover-community/mathlib4/pull/27148) throughout the project. The second uses the (fairly) new `with` notation for sums.