### PR TITLE
Cleanup TwoSidedCarleson / MetricCarleson folders

### DIFF
--- a/Carleson.lean
+++ b/Carleson.lean
@@ -67,6 +67,7 @@ import Carleson.ToMathlib.MeasureTheory.Function.LpSpace.ContinuousFunctions
 import Carleson.ToMathlib.MeasureTheory.Function.LpSpace.Indicator
 import Carleson.ToMathlib.MeasureTheory.Integral.Average
 import Carleson.ToMathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
+import Carleson.ToMathlib.MeasureTheory.Integral.IntegrableOn
 import Carleson.ToMathlib.MeasureTheory.Integral.Lebesgue
 import Carleson.ToMathlib.MeasureTheory.Integral.MeanInequalities
 import Carleson.ToMathlib.MeasureTheory.Integral.Periodic

--- a/Carleson/Defs.lean
+++ b/Carleson/Defs.lean
@@ -304,6 +304,12 @@ lemma carlesonOperator_const_smul [FunctionDistances ℝ X] (K : X → X → ℂ
   simp_rw [linearizedCarlesonOperator_const_smul, Pi.smul_apply, ← smul_iSup]
   rfl
 
+lemma nontangentialOperator_const_smul (z : ℂ) {K : X → X → ℂ} :
+    nontangentialOperator (z • K) = ‖z‖ₑ • nontangentialOperator K := by
+  unfold nontangentialOperator
+  simp_rw [Pi.smul_apply, smul_eq_mul, mul_assoc, integral_const_mul, enorm_mul, ← ENNReal.mul_iSup]
+  rfl
+
 end DoublingMeasure
 
 /-- The main constant in the blueprint, driving all the construction, is `D = 2 ^ (100 * a ^ 2)`.

--- a/Carleson/MetricCarleson/Basic.lean
+++ b/Carleson/MetricCarleson/Basic.lean
@@ -284,7 +284,6 @@ irreducible_def C3_0_1 (a : ℕ) (R₁ R₂ : ℝ≥0) : ℝ≥0 :=
 
 lemma lintegral_inv_vol_le {R₁ R₂ : ℝ≥0} (hR₁ : 0 < R₁) (hR₂ : R₁ < R₂) :
     ∫⁻ y in Annulus.oo x R₁ R₂, (vol x y)⁻¹ ≤ ↑((2 * R₂ / R₁) ^ a) := by
-  -- rw [coe_pow, coe_div hR₁.ne', coe_mul, coe_ofNat]
   suffices ∀ y ∈ Annulus.oo x R₁ R₂, volume (ball x R₂) / ↑((2 * R₂ / R₁) ^ a) ≤ vol x y by
     calc
       _ ≤ ∫⁻ y in Annulus.oo x R₁ R₂, ↑((2 * R₂ / R₁) ^ a) / volume (ball x R₂) := by

--- a/Carleson/ToMathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Carleson/ToMathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -1,8 +1,9 @@
 import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
 import Mathlib.Analysis.Normed.Group.Basic
+import Carleson.ToMathlib.Misc -- for iSup_rpow
 
-open MeasureTheory
+open MeasureTheory Set
 open scoped ENNReal
 
 variable {α ε E F G : Type*} {m m0 : MeasurableSpace α} {p : ℝ≥0∞} {q : ℝ} {μ ν : Measure α}
@@ -37,5 +38,52 @@ theorem eLpNorm_comp_measurePreserving' {ν : Measure β} [MeasurableSpace E]
   Eq.symm <| hf.map_eq ▸ eLpNorm_map_measure' (hf.map_eq ▸ hg) hf.aemeasurable
 
 end MapMeasure
+
+section Suprema
+
+theorem eLpNormEssSup_iSup {α : Type*} {ι : Type*} [Countable ι] [MeasurableSpace α]
+    {μ : Measure α} (f : ι → α → ℝ≥0∞) :
+    ⨆ n, eLpNormEssSup (f n) μ = eLpNormEssSup (⨆ n, f n) μ := by
+  simp_rw [eLpNormEssSup, essSup_eq_sInf, enorm_eq_self]
+  apply le_antisymm
+  · refine iSup_le fun i ↦ le_sInf fun b hb ↦ sInf_le ?_
+    simp only [iSup_apply, mem_setOf_eq] at hb ⊢
+    exact nonpos_iff_eq_zero.mp <|le_of_le_of_eq
+        (measure_mono fun ⦃x⦄ h ↦ lt_of_lt_of_le h (le_iSup (fun i ↦ f i x) i)) hb
+  · apply sInf_le
+    simp only [iSup_apply, mem_setOf_eq]
+    apply nonpos_iff_eq_zero.mp
+    calc
+    _ ≤ μ (⋃ i, {x | ⨆ n, sInf {a | μ {x | a < f n x} = 0} < f i x}) := by
+      refine measure_mono fun x hx ↦ mem_iUnion.mpr ?_
+      simp only [mem_setOf_eq] at hx
+      exact lt_iSup_iff.mp hx
+    _ ≤ _ := measure_iUnion_le _
+    _ ≤ ∑' i, μ {x | sInf {a | μ {x | a < f i x} = 0} < f i x} := by
+      gcongr with i; apply le_iSup _ i
+    _ ≤ ∑' i, μ {x | eLpNormEssSup (f i) μ < ‖f i x‖ₑ} := by
+      gcongr with i; rw [eLpNormEssSup, essSup_eq_sInf]; rfl
+    _ = ∑' i, 0 := by congr with i; exact meas_eLpNormEssSup_lt
+    _ = 0 := by simp
+
+/-- Monotone convergence applied to eLpNorms. AEMeasurable variant.
+  Possibly imperfect hypotheses, particularly on `p`. Note that for `p = ∞` the stronger
+  statement in `eLpNormEssSup_iSup` holds. -/
+theorem eLpNorm_iSup' {α : Type*} [MeasurableSpace α] {μ : Measure α} {p : ℝ≥0∞}
+    {f : ℕ → α → ℝ≥0∞} (hf : ∀ n, AEMeasurable (f n) μ) (h_mono : ∀ᵐ x ∂μ, Monotone fun n => f n x) :
+    ⨆ n, eLpNorm (f n) p μ = eLpNorm (⨆ n, f n) p μ := by
+  unfold eLpNorm
+  split_ifs with hp hp'
+  · simp
+  · apply eLpNormEssSup_iSup
+  · unfold eLpNorm'
+    have := ENNReal.toReal_pos hp hp'
+    rw [← iSup_rpow (by positivity), ← lintegral_iSup']
+    · congr 2 with a; rw [← iSup_rpow (by positivity)]; simp
+    · fun_prop
+    · filter_upwards [h_mono] with a ha m n hmn
+      beta_reduce; gcongr; simp only [enorm_eq_self]; apply ha hmn
+
+end Suprema
 
 end MeasureTheory

--- a/Carleson/ToMathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Carleson/ToMathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -1,0 +1,22 @@
+import Mathlib.MeasureTheory.Integral.IntegrableOn
+
+open Set Filter TopologicalSpace MeasureTheory Function
+
+open scoped Topology Interval Filter ENNReal MeasureTheory
+
+-- Upstreaming note: Hypotheses and variables have been matched to corresponding Mathlib file
+
+variable {α β ε ε' E F : Type*} [MeasurableSpace α]
+
+section NormedAddCommGroup
+
+variable [NormedAddCommGroup E] {f g : α → ε'} {s t : Set α} {μ ν : Measure α}
+variable [TopologicalSpace ε'] [ENormedAddMonoid ε']
+
+theorem integrableOn_of_integrableOn_inter_support [PseudoMetrizableSpace ε'] {f : α → ε'}
+  (hs : MeasurableSet s) (hf : IntegrableOn f (s ∩ support f) μ) :
+    IntegrableOn f s μ := by
+  apply IntegrableOn.of_forall_diff_eq_zero hf hs
+  simp
+
+end NormedAddCommGroup

--- a/Carleson/ToMathlib/Misc.lean
+++ b/Carleson/ToMathlib/Misc.lean
@@ -30,6 +30,8 @@ end Real
 
 section ENNReal
 
+open ENNReal
+
 lemma tsum_one_eq' {α : Type*} (s : Set α) : ∑' (_:s), (1 : ℝ≥0∞) = s.encard := by
   if hfin : s.Finite then
     have hfin' : Finite s := hfin
@@ -103,6 +105,16 @@ lemma tsum_geometric_ite_eq_tsum_geometric {k c : ℕ} :
 
 lemma ENNReal.toReal_zpow (x : ℝ≥0∞) (z : ℤ) : x.toReal ^ z = (x ^ z).toReal := by
   rw [← rpow_intCast, ← toReal_rpow, Real.rpow_intCast]
+
+-- TODO: this helper lemma may be useful in other places to, for instance in `HardyLittlewood.lean`
+lemma iSup_rpow {f : ℕ → ℝ≥0∞} {p : ℝ} (hp : 0 < p) :
+    (⨆ n, f n) ^ p = ⨆ n, f n ^ p := by
+  apply le_antisymm
+  · rw [← rpow_le_rpow_iff (z := p⁻¹) (by positivity), rpow_rpow_inv (by positivity)]
+    refine iSup_le fun i ↦ ?_
+    rw [← rpow_le_rpow_iff (z := p) (by positivity), rpow_inv_rpow (by positivity)]
+    apply le_iSup _ i
+  · apply iSup_le; intro i; gcongr; apply le_iSup _ i
 
 end ENNReal
 

--- a/Carleson/TwoSidedCarleson/Basic.lean
+++ b/Carleson/TwoSidedCarleson/Basic.lean
@@ -1,29 +1,11 @@
 import Carleson.Calculations
+import Carleson.ToMathlib.MeasureTheory.Integral.IntegrableOn
 
 open MeasureTheory Set Metric Function Topology NNReal ENNReal
 
 variable {X : Type*} {a : ℕ} [MetricSpace X] [DoublingMeasure X (defaultA a : ℕ)]
 variable {r : ℝ}
 variable {K : X → X → ℂ} {x x' : X} [IsOneSidedKernel a K]
-
--- TODO move to ToMathlib, properly generalise
-theorem integrableOn_of_integrableOn_inter_support {f : X → ℂ} {μ : Measure X} {s : Set X}
-    (hs : MeasurableSet s) (hf : IntegrableOn f (s ∩ support f) μ) :
-    IntegrableOn f s μ := by
-  apply IntegrableOn.of_forall_diff_eq_zero hf hs
-  simp
-
--- Is this valuable? Not used right now
-lemma memLp_top_K_on_ball_complement (hr : 0 < r) {x : X} :
-    MemLp (K x) ∞ (volume.restrict (ball x r)ᶜ) := by
-  constructor
-  · exact (measurable_K_right x).aestronglyMeasurable
-  · simp only [eLpNorm_exponent_top]
-    apply eLpNormEssSup_lt_top_of_ae_enorm_bound
-    · apply ae_restrict_of_forall_mem
-      · measurability
-      · intro y hy
-        apply enorm_K_le_ball_complement' hr hy
 
 lemma czOperator_bound {g : X → ℂ} (hg : BoundedFiniteSupport g) (hr : 0 < r) (x : X) :
     ∃ (M : ℝ≥0), ∀ᵐ y ∂(volume.restrict (ball x r)ᶜ), ‖K x y * g y‖ ≤ M := by

--- a/Carleson/TwoSidedCarleson/MainTheorem.lean
+++ b/Carleson/TwoSidedCarleson/MainTheorem.lean
@@ -8,7 +8,6 @@ noncomputable section
 
 /-- The constant used in `two_sided_metric_carleson`.
 Has value `2 ^ (474 * a ^ 3) / (q - 1) ^ 6` in the blueprint. -/
--- todo: put C_K in NNReal?
 def C10_0_1 (a : ℕ) (q : ℝ≥0) : ℝ≥0 := C_K a ^ 2 * C1_0_2 a q
 
 lemma C10_0_1_pos {a : ℕ} {q : ℝ≥0} (hq : 1 < q) : 0 < C10_0_1 a q :=

--- a/Carleson/TwoSidedCarleson/WeakCalderonZygmund.lean
+++ b/Carleson/TwoSidedCarleson/WeakCalderonZygmund.lean
@@ -474,7 +474,7 @@ lemma volume_lt_of_not_GeneralCase
   refine lt_of_le_of_lt (eq_univ_iff_forall.mpr h ▸ maximal_theorem' α hf) ?_ |>.ne
   exact mul_lt_top coe_lt_top (hf.memLp 1).eLpNorm_lt_top
 
-private lemma isFiniteMeasure_finite
+private lemma isFiniteMeasure_of_not_generalCase
     (hf : BoundedFiniteSupport f) (h : ¬ GeneralCase f α) (hα : 0 < α) :
     IsFiniteMeasure (volume : Measure X) :=
   (isFiniteMeasure_iff _).mpr <| volume_lt_of_not_GeneralCase hf h hα
@@ -558,8 +558,7 @@ lemma czBall_subset_czPartition {hX : GeneralCase f α} {i : ℕ} :
   intro r hr
   rw [mem_ball] at hr
   unfold czPartition
-  refine mem_diff_of_mem ?_ ?_
-  · rw [mem_ball]; linarith [lt_of_le_of_lt dist_nonneg hr]
+  apply mem_diff_of_mem (by rw [mem_ball]; linarith [dist_nonneg.trans_lt hr])
   simp only [mem_union, mem_iUnion, mem_ball, not_or, not_exists, not_lt]
   refine ⟨?_, fun j hj ↦ by
     refine le_of_not_gt (disjoint_left.mp (czBall_pairwiseDisjoint ?_ ?_ hj.ne) hr) <;> tauto⟩
@@ -908,7 +907,7 @@ lemma integral_czRemainder' {hX : GeneralCase f α} {i : ℕ} :
 lemma integral_czRemainder {hf : BoundedFiniteSupport f}
     (hX : ¬ GeneralCase f α) (hα : 0 < α) :
     ∫ x, czRemainder f α x = 0 := by
-  have := isFiniteMeasure_finite hf hX hα
+  have := isFiniteMeasure_of_not_generalCase hf hX hα
   simpa [czRemainder, czApproximation, hX] using integral_sub_average volume f
 
 -- Inequality (10.2.32)
@@ -956,7 +955,7 @@ private lemma eLpNorm_restrict_czRemainder'_le {hf : BoundedFiniteSupport f} {hX
 private lemma eLpNorm_czRemainder_le'
     (hf : BoundedFiniteSupport f) (hX : ¬ GeneralCase f α) (hα : ⨍⁻ x, ‖f x‖ₑ < α) :
     eLpNorm (czRemainder f α) 1 volume ≤ 2 * ∫⁻ x, ‖f x‖ₑ :=
-  have := isFiniteMeasure_finite hf hX (lt_of_le_of_lt (zero_le _) hα)
+  have := isFiniteMeasure_of_not_generalCase hf hX (lt_of_le_of_lt (zero_le _) hα)
   calc
     _ = ∫⁻ x, ‖f x - ⨍ y, f y‖ₑ := by simp [czRemainder, eLpNorm, eLpNorm', czApproximation, hX]
     _ ≤ ∫⁻ x, (‖f x‖ₑ + ‖⨍ y, f y‖ₑ) := lintegral_mono (fun x ↦ enorm_sub_le)
@@ -971,7 +970,7 @@ lemma eLpNorm_czRemainder_le {hf : BoundedFiniteSupport f}
     eLpNorm (czRemainder f α) 1 volume ≤ 2 ^ (2 * a + 1) * α * volume (univ : Set X) := by
   by_cases h : Nonempty X; swap
   · have := not_nonempty_iff.mp h; simp
-  have := isFiniteMeasure_finite hf hX (lt_of_le_of_lt (zero_le _) hα)
+  have := isFiniteMeasure_of_not_generalCase hf hX (lt_of_le_of_lt (zero_le _) hα)
   calc
     _ ≤ 2 * ∫⁻ x, ‖f x‖ₑ := eLpNorm_czRemainder_le' hf hX hα
     _ ≤ 2 * (α * volume (univ : Set X)) := by
@@ -1063,8 +1062,7 @@ private lemma div_α'_eq {p : ℝ≥0∞} : p / α' a α = p / c10_0_3 a / α :=
   · left; rw [c10_0_3]; finiteness
 
 /-- Lemma 10.2.6 -/
-lemma estimate_good (hf : BoundedFiniteSupport f)
-    (hα : ⨍⁻ x, ‖f x‖ₑ / c10_0_3 a < α)
+lemma estimate_good (hf : BoundedFiniteSupport f) (hα : ⨍⁻ x, ‖f x‖ₑ / c10_0_3 a < α)
     (hT : HasBoundedStrongType (czOperator K r) 2 2 volume volume (C_Ts a)) :
     distribution (czOperator K r (czApproximation f (α' a α))) (α / 2) volume ≤
     C10_2_6 a / α * eLpNorm f 1 volume := by
@@ -1657,7 +1655,7 @@ lemma estimate_bad (ha : 4 ≤ a) (hr : 0 < r)
           C10_2_9]
         gcongr; exact le_self_add
 
-/- ### Lemmas 10.0.3 -/
+/- ### Lemma 10.0.3 -/
 
 /-- The constant used in `czOperator_weak_1_1`. -/
 irreducible_def C10_0_3 (a : ℕ) : ℝ≥0 := 2 ^ (a ^ 3 + 21 * a)


### PR DESCRIPTION
The TwoSidedCarleson folder still contained a number of general results that were supposed to go in ToMathlib.
This PR addresses that and other minor fixes.
The MetricCarleson folder was also checked with only minor changes.

I was not sure where to put `iSup_rpow` so I put it in Misc.