### PR TITLE
Cleanup base folder (except `Psi.lean`)

### DIFF
--- a/Carleson.lean
+++ b/Carleson.lean
@@ -85,6 +85,7 @@ import Carleson.ToMathlib.RealInterpolation.LorentzInterpolation
 import Carleson.ToMathlib.RealInterpolation.Main
 import Carleson.ToMathlib.RealInterpolation.Minkowski
 import Carleson.ToMathlib.RealInterpolation.Misc
+import Carleson.ToMathlib.Topology.Algebra.Support
 import Carleson.ToMathlib.Topology.Instances.AddCircle.Defs
 import Carleson.ToMathlib.WeakType
 import Carleson.TwoSidedCarleson.Basic

--- a/Carleson/FinitaryCarleson.lean
+++ b/Carleson/FinitaryCarleson.lean
@@ -63,8 +63,8 @@ lemma exists_Grid {x : X} (hx : x ∈ G) {s : ℤ} (hs : s ∈ (Icc (σ₁ x) (�
   simpa only [mem_iUnion, exists_prop] using Grid_subset_biUnion s s_mem x_mem_topCube
 
 /-- Lemma 4.0.3 -/
-theorem tile_sum_operator {G' : Set X} {f : X → ℂ}
-    {x : X} (hx : x ∈ G \ G') : ∑ (p : 𝔓 X), carlesonOn p f x =
+theorem tile_sum_operator {G' : Set X} {f : X → ℂ} {x : X} (hx : x ∈ G \ G') :
+    ∑ (p : 𝔓 X), carlesonOn p f x =
     ∑ s ∈ Icc (σ₁ x) (σ₂ x), ∫ y, Ks s x y * f y * exp (I * (Q x y - Q x x)) := by
   classical
   rw [𝔓_biUnion, Finset.sum_biUnion]; swap
@@ -101,6 +101,7 @@ def C2_0_1 (a : ℕ) (q : ℝ≥0) : ℝ≥0 := C2_0_2 a q
 lemma C2_0_1_pos [TileStructure Q D κ S o] : C2_0_1 a nnq > 0 := C2_0_2_pos
 
 variable (X) in
+/-- Proposition 2.0.1 -/
 theorem finitary_carleson : ∃ G', MeasurableSet G' ∧ 2 * volume G' ≤ volume G ∧
     ∀ f : X → ℂ, Measurable f → (∀ x, ‖f x‖ ≤ F.indicator 1 x) →
     ∫⁻ x in G \ G', ‖∑ s ∈ Icc (σ₁ x) (σ₂ x), ∫ y, Ks s x y * f y * exp (I * Q x y)‖ₑ ≤

--- a/Carleson/Forest.lean
+++ b/Carleson/Forest.lean
@@ -11,18 +11,6 @@ variable [TileStructure Q D κ S o] {u u' p p' : 𝔓 X} {f g : Θ X}
   {C C' : Set (𝔓 X)} {x x' : X}
 
 namespace TileStructure
--- variable (X) in
--- structure Tree where
---   carrier : Set (𝔓 X)
---   nonempty : Nonempty carrier
---   ordConnected : OrdConnected carrier -- (2.0.33)
-
--- attribute [coe] Tree.carrier
--- instance : CoeTC (Tree X) (Set (𝔓 X)) where coe := Tree.carrier
--- -- instance : CoeTC (Tree X) (Finset (𝔓 X)) where coe := Tree.carrier
--- -- instance : CoeTC (Tree X) (Set (𝔓 X)) where coe p := ((p : Finset (𝔓 X)) : Set (𝔓 X))
--- instance : Membership (𝔓 X) (Tree X) := ⟨fun x p => x ∈ (p : Set _)⟩
--- instance : Preorder (Tree X) := Preorder.lift Tree.carrier
 
 variable (X) in
 /-- An `n`-forest -/

--- a/Carleson/GridStructure.lean
+++ b/Carleson/GridStructure.lean
@@ -10,7 +10,7 @@ variable {𝕜 : Type*} [_root_.RCLike 𝕜]
 
 variable (X) in
 /-- A grid structure on `X`.
-I expect we prefer `coeGrid : Grid → Set X` over `Grid : Set (Set X)`
+We prefer `coeGrid : Grid → Set X` over `Grid : Set (Set X)`
 Note: the `s` in this paper is `-s` of Christ's paper.
 -/
 class GridStructure {A : outParam ℝ≥0} [PseudoMetricSpace X] [DoublingMeasure X A]
@@ -63,12 +63,6 @@ instance : Fintype (Grid X) := GridStructure.fintype_Grid
 instance : Coe (Grid X) (Set X) := ⟨GridStructure.coeGrid⟩
 instance : Membership X (Grid X) := ⟨fun i x ↦ x ∈ (i : Set X)⟩
 instance : PartialOrder (Grid X) := PartialOrder.lift _ GridStructure.inj
-/- These should probably not/only rarely be used. I comment them out for now,
-so that we don't accidentally use it. We can put it back if useful after all. -/
--- instance : HasSubset (Grid X) := ⟨fun i j ↦ (i : Set X) ⊆ (j : Set X)⟩
--- instance : HasSSubset (Grid X) := ⟨fun i j ↦ (i : Set X) ⊂ (j : Set X)⟩
--- @[simp] lemma Grid.subset_def : i ⊆ j ↔ (i : Set X) ⊆ (j : Set X) := .rfl
--- @[simp] lemma Grid.ssubset_def : i ⊂ j ↔ (i : Set X) ⊂ (j : Set X) := .rfl
 
 /- not sure whether these should be simp lemmas, but that might be required if we want to
   conveniently rewrite/simp with Set-lemmas -/
@@ -137,12 +131,6 @@ lemma volume_coeGrid_pos (hD : 0 < D) : 0 < volume (i : Set X) := by
 @[aesop (rule_sets := [finiteness]) safe apply]
 lemma volume_coeGrid_lt_top : volume (i : Set X) < ⊤ :=
   measure_lt_top_of_subset Grid_subset_ball measure_ball_ne_top
-
-/- lemma volumeNNReal_coeGrid_pos (hD : 0 < D) : 0 < volume.nnreal (i : Set X) := by
-  rw [lt_iff_le_and_ne]
-  refine ⟨zero_le _, ?_⟩
-  rw [ne_eq, eq_comm, measureNNReal_eq_zero_iff]
-  exact ne_of_gt (volume_coeGrid_pos hD) -/
 
 namespace Grid
 

--- a/Carleson/HolderVanDerCorput.lean
+++ b/Carleson/HolderVanDerCorput.lean
@@ -275,10 +275,10 @@ lemma norm_holderApprox_sub_le_aux {z : X} {R t : ℝ} (hR : 0 < R) (ht : 0 < t)
     {C : ℝ≥0} {ϕ : X → ℂ} (hc : Continuous ϕ) (hϕ : ϕ.support ⊆ ball z R)
     (hC : ∀ x, ‖ϕ x‖ ≤ C) {x x' : X} (h : dist x x' < R) :
     ‖holderApprox R t ϕ x' - holderApprox R t ϕ x‖ ≤
-    2⁻¹ * 2 ^ (4 * a) * t ^ (-1 - a : ℝ) * C * dist x x' / (2 * R) := by
+      2⁻¹ * 2 ^ (4 * a) * t ^ (-1 - a : ℝ) * C * dist x x' / (2 * R) := by
   have M : (2⁻¹ * volume.real (ball x (2⁻¹ * t * R))) *
-      ‖holderApprox R t ϕ x' - holderApprox R t ϕ x‖ ≤
-      2 * C * ∫ y, |cutoff R t x y - cutoff R t x' y| :=
+        ‖holderApprox R t ϕ x' - holderApprox R t ϕ x‖ ≤
+        2 * C * ∫ y, |cutoff R t x y - cutoff R t x' y| :=
     calc
       (2⁻¹ * volume.real (ball x (2⁻¹ * t * R))) * ‖holderApprox R t ϕ x' - holderApprox R t ϕ x‖
     _ ≤ (∫ y, cutoff R t x y) * ‖holderApprox R t ϕ x' - holderApprox R t ϕ x‖ := by
@@ -434,7 +434,7 @@ lemma lipschitzWith_holderApprox {z : X} {R t : ℝ} (hR : 0 < R) (ht : 0 < t) (
 lemma iLipENorm_holderApprox' {z : X} {R t : ℝ} (ht : 0 < t) (h't : t ≤ 1)
     {C : ℝ≥0} {ϕ : X → ℂ} (hc : Continuous ϕ) (hϕ : ϕ.support ⊆ ball z R) (hC : ∀ x, ‖ϕ x‖ ≤ C) :
     iLipENorm (holderApprox R t ϕ) z (2 * R) ≤
-    2 ^ (4 * a) * (ENNReal.ofReal t) ^ (-1 - a : ℝ) * C := by
+      2 ^ (4 * a) * (ENNReal.ofReal t) ^ (-1 - a : ℝ) * C := by
   let C' : ℝ≥0 := 2 ^ (4 * a) * (t.toNNReal) ^ (-1 - a : ℝ) * C
   have : 2 ^ (4 * a) * (ENNReal.ofReal t) ^ (-1 - a : ℝ) * C = C' := by
     simp only [ENNReal.coe_mul, ENNReal.coe_pow, ENNReal.coe_ofNat, C', ENNReal.ofReal]
@@ -471,7 +471,7 @@ lemma iLipENorm_holderApprox' {z : X} {R t : ℝ} (ht : 0 < t) (h't : t ≤ 1)
 lemma iLipENorm_holderApprox_le {z : X} {R t : ℝ} (ht : 0 < t) (h't : t ≤ 1)
     {ϕ : X → ℂ} (hϕ : support ϕ ⊆ ball z R) :
     iLipENorm (holderApprox R t ϕ) z (2 * R) ≤
-    2 ^ (4 * a) * (ENNReal.ofReal t) ^ (-1 - a : ℝ) * iHolENorm ϕ z (2 * R) := by
+      2 ^ (4 * a) * (ENNReal.ofReal t) ^ (-1 - a : ℝ) * iHolENorm ϕ z (2 * R) := by
   rcases eq_or_ne (iHolENorm ϕ z (2 * R)) ∞ with h'ϕ | h'ϕ
   · apply le_top.trans_eq
     rw [eq_comm]

--- a/Carleson/HolderVanDerCorput.lean
+++ b/Carleson/HolderVanDerCorput.lean
@@ -1,4 +1,5 @@
 import Carleson.TileStructure
+import Carleson.ToMathlib.Topology.Algebra.Support
 
 /-! This should roughly contain the contents of chapter 8. -/
 
@@ -133,16 +134,16 @@ lemma integral_mul_holderApprox {R t : ℝ} (hR : 0 < R) (ht : 0 < t) (ϕ : X �
   apply ne_of_gt
   exact integral_cutoff_pos hR ht
 
--- This surely exists in mathlib; how is it named?
-lemma foo {φ : X → ℂ} (hf : ∫ x, φ x ≠ 0) : ∃ z, φ z ≠ 0 := by
-  by_contra! h
-  exact hf (by simp [h])
-
 lemma support_holderApprox_subset_aux {z : X} {R R' t : ℝ} (hR : 0 < R)
     {ϕ : X → ℂ} (hϕ : ϕ.support ⊆ ball z R') (ht : t ∈ Ioc (0 : ℝ) 1) :
     support (holderApprox R t ϕ) ⊆ ball z (R + R') := by
   intro x hx
-  choose y hy using foo (left_ne_zero_of_mul hx)
+  have : ∃ z, cutoff R t x z * ϕ z ≠ 0 := by
+    suffices ∫ y, cutoff R t x y * ϕ y ≠ 0 by
+      by_contra! h
+      exact this (by simp only [h, integral_zero])
+    apply left_ne_zero_of_mul hx
+  choose y hy using this
   have : x ∈ ball y (t * R) := by
     apply aux_8_0_4 hR ht.1
     rw [cutoff_comm]
@@ -162,19 +163,6 @@ lemma support_holderApprox_subset {z : X} {R t : ℝ} (hR : 0 < R)
     support (holderApprox R t ϕ) ⊆ ball z (2 * R) := by
   convert support_holderApprox_subset_aux hR hϕ ht using 2
   ring
-
-/- unused
-lemma tsupport_holderApprox_subset {z : X} {R t : ℝ} (hR : 0 < R)
-    {ϕ : X → ℂ} (hϕ : tsupport ϕ ⊆ ball z R) (ht : t ∈ Ioc (0 : ℝ) 1) :
-    tsupport (holderApprox R t ϕ) ⊆ ball z (2 * R) := by
-  rcases exists_pos_lt_subset_ball hR (isClosed_tsupport ϕ) hϕ with ⟨R', R'_pos, hR'⟩
-  have A : support (holderApprox R t ϕ) ⊆ ball z (R + R') :=
-    support_holderApprox_subset_aux hR ((subset_tsupport _).trans hR') ht
-  have : tsupport (holderApprox R t ϕ) ⊆ closedBall z (R + R') :=
-    (closure_mono A).trans closure_ball_subset_closedBall
-  apply this.trans (closedBall_subset_ball ?_)
-  linarith [R'_pos.2]
--/
 
 open Filter
 
@@ -287,10 +275,10 @@ lemma norm_holderApprox_sub_le_aux {z : X} {R t : ℝ} (hR : 0 < R) (ht : 0 < t)
     {C : ℝ≥0} {ϕ : X → ℂ} (hc : Continuous ϕ) (hϕ : ϕ.support ⊆ ball z R)
     (hC : ∀ x, ‖ϕ x‖ ≤ C) {x x' : X} (h : dist x x' < R) :
     ‖holderApprox R t ϕ x' - holderApprox R t ϕ x‖ ≤
-      2⁻¹ * 2 ^ (4 * a) * t ^ (-1 - a : ℝ) * C * dist x x' / (2 * R) := by
+    2⁻¹ * 2 ^ (4 * a) * t ^ (-1 - a : ℝ) * C * dist x x' / (2 * R) := by
   have M : (2⁻¹ * volume.real (ball x (2⁻¹ * t * R))) *
       ‖holderApprox R t ϕ x' - holderApprox R t ϕ x‖ ≤
-        2 * C * ∫ y, |cutoff R t x y - cutoff R t x' y| :=
+      2 * C * ∫ y, |cutoff R t x y - cutoff R t x' y| :=
     calc
       (2⁻¹ * volume.real (ball x (2⁻¹ * t * R))) * ‖holderApprox R t ϕ x' - holderApprox R t ϕ x‖
     _ ≤ (∫ y, cutoff R t x y) * ‖holderApprox R t ϕ x' - holderApprox R t ϕ x‖ := by
@@ -408,7 +396,7 @@ lemma norm_holderApprox_sub_le {z : X} {R t : ℝ} (hR : 0 < R) (ht : 0 < t) (h'
     {C : ℝ≥0} {ϕ : X → ℂ} (hc : Continuous ϕ) (hϕ : ϕ.support ⊆ ball z R)
     (hC : ∀ x, ‖ϕ x‖ ≤ C) {x x' : X} :
     ‖holderApprox R t ϕ x - holderApprox R t ϕ x'‖ ≤
-      2⁻¹ * 2 ^ (4 * a) * t ^ (-1 - a : ℝ) * C * dist x x' / (2 * R) := by
+    2⁻¹ * 2 ^ (4 * a) * t ^ (-1 - a : ℝ) * C * dist x x' / (2 * R) := by
   rcases lt_or_ge (dist x x') R with hx | hx
   · rw [norm_sub_rev]
     exact norm_holderApprox_sub_le_aux hR ht h't hc hϕ hC hx
@@ -444,10 +432,9 @@ lemma lipschitzWith_holderApprox {z : X} {R t : ℝ} (hR : 0 < R) (ht : 0 < t) (
   ring
 
 lemma iLipENorm_holderApprox' {z : X} {R t : ℝ} (ht : 0 < t) (h't : t ≤ 1)
-    {C : ℝ≥0} {ϕ : X → ℂ} (hc : Continuous ϕ) (hϕ : ϕ.support ⊆ ball z R)
-    (hC : ∀ x, ‖ϕ x‖ ≤ C) :
+    {C : ℝ≥0} {ϕ : X → ℂ} (hc : Continuous ϕ) (hϕ : ϕ.support ⊆ ball z R) (hC : ∀ x, ‖ϕ x‖ ≤ C) :
     iLipENorm (holderApprox R t ϕ) z (2 * R) ≤
-      2 ^ (4 * a) * (ENNReal.ofReal t) ^ (-1 - a : ℝ) * C := by
+    2 ^ (4 * a) * (ENNReal.ofReal t) ^ (-1 - a : ℝ) * C := by
   let C' : ℝ≥0 := 2 ^ (4 * a) * (t.toNNReal) ^ (-1 - a : ℝ) * C
   have : 2 ^ (4 * a) * (ENNReal.ofReal t) ^ (-1 - a : ℝ) * C = C' := by
     simp only [ENNReal.coe_mul, ENNReal.coe_pow, ENNReal.coe_ofNat, C', ENNReal.ofReal]
@@ -484,7 +471,7 @@ lemma iLipENorm_holderApprox' {z : X} {R t : ℝ} (ht : 0 < t) (h't : t ≤ 1)
 lemma iLipENorm_holderApprox_le {z : X} {R t : ℝ} (ht : 0 < t) (h't : t ≤ 1)
     {ϕ : X → ℂ} (hϕ : support ϕ ⊆ ball z R) :
     iLipENorm (holderApprox R t ϕ) z (2 * R) ≤
-      2 ^ (4 * a) * (ENNReal.ofReal t) ^ (-1 - a : ℝ) * iHolENorm ϕ z (2 * R) := by
+    2 ^ (4 * a) * (ENNReal.ofReal t) ^ (-1 - a : ℝ) * iHolENorm ϕ z (2 * R) := by
   rcases eq_or_ne (iHolENorm ϕ z (2 * R)) ∞ with h'ϕ | h'ϕ
   · apply le_top.trans_eq
     rw [eq_comm]
@@ -501,19 +488,6 @@ lemma iLipENorm_holderApprox_le {z : X} {R t : ℝ} (ht : 0 < t) (h't : t ≤ 1)
 
 /-- The constant occurring in Proposition 2.0.5. -/
 def C2_0_5 (a : ℝ) : ℝ≥0 := 2 ^ (7 * a)
-
-section DivisionMonoid
-
-variable {α β : Type*} [TopologicalSpace α] [DivisionMonoid β]
-variable {f f' : α → β}
-
-/- PR after HasCompactMulSupport.inv' -/
-
-@[to_additive]
-theorem HasCompactMulSupport.div (hf : HasCompactMulSupport f) (hf' : HasCompactMulSupport f') :
-    HasCompactMulSupport (f / f') := hf.comp₂_left hf' (div_one 1)
-
-end DivisionMonoid
 
 --NOTE (MI) : there was a missing minus sign in the exponent.
 /-- Proposition 2.0.5. -/

--- a/Carleson/Operators.lean
+++ b/Carleson/Operators.lean
@@ -36,7 +36,9 @@ def carlesonOn (p : 𝔓 X) (f : X → ℂ) : X → ℂ :=
   indicator (E p)
     fun x ↦ ∫ y, exp (I * (Q x y - Q x x)) * K x y * ψ (D ^ (- 𝔰 p) * dist x y) * f y
 
--- not used anywhere and deprecated for `AEStronglyMeasurable.carlesonOn`
+/- Deprecated for `AEStronglyMeasurable.carlesonOn`
+Used through `measurable_carlesonSum` in `Antichain.AntichainOperator` and `ForestOperator.Forests`
+with nontrivial rework in order to move from `Measurable` to `AEStronglyMeasurable`. -/
 lemma measurable_carlesonOn {p : 𝔓 X} {f : X → ℂ} (measf : Measurable f) :
     Measurable (carlesonOn p f) := by
   refine (StronglyMeasurable.integral_prod_right ?_).measurable.indicator measurableSet_E
@@ -230,7 +232,6 @@ variable [MetricSpace X] [ProofData a q K σ₁ σ₂ F G] [TileStructure Q D κ
 /-- The definition of `Tₚ*g(x)`, defined above Lemma 7.4.1 -/
 def adjointCarleson (p : 𝔓 X) (f : X → ℂ) (x : X) : ℂ :=
   ∫ y in E p, conj (Ks (𝔰 p) y x) * exp (.I * (Q y y - Q y x)) * f y
-  -- todo: consider changing to `(E p).indicator 1 y`
 
 open scoped Classical in
 /-- The definition of `T_ℭ*g(x)`, defined at the bottom of Section 7.4 -/
@@ -460,15 +461,6 @@ lemma adjointCarlesonSum_adjoint
       refine BoundedCompactSupport.mul ?_ hf |>.integrable
       exact hg.adjointCarleson.conj
     _ = _ := by congr!; rw [← Finset.sum_mul, ← map_sum]; rfl
-
-/- XXX: this version is not used, and may not be useful in general
-lemma integrable_adjointCarlesonSum' (u : 𝔓 X) {f : X → ℂ} (hf : AEStronglyMeasurable f volume)
-    (hf' : IsBounded (range f)) (hf'' : HasCompactSupport f) :
-    Integrable (adjointCarlesonSum (t.𝔗 u) f ·) := by
-  obtain ⟨M, hM⟩ := hf'.exists_norm_le
-  have : BoundedCompactSupport f :=
-    ⟨memLp_top_of_bound hf M <| by filter_upwards with x using hM _ (mem_range_self x), hf''⟩
-  exact integrable_finset_sum _ fun i hi ↦ this.adjointCarleson (p := i).integrable -/
 
 lemma integrable_adjointCarlesonSum (s : Set (𝔓 X)) {f : X → ℂ} (hf : BoundedCompactSupport f) :
     Integrable (adjointCarlesonSum s f ·) :=

--- a/Carleson/TileExistence.lean
+++ b/Carleson/TileExistence.lean
@@ -56,29 +56,30 @@ lemma counting_balls {k : ℤ} (hk_lower : -S ≤ k) {Y : Set X}
     (hY : Y ⊆ ball o (4 * D ^ S - D ^ k))
     (hYdisjoint : Y.PairwiseDisjoint (ball · (D ^ k))) :
     (Set.encard Y).toENNReal ≤ C4_1_1 X := by
-  suffices (Set.encard Y).toENNReal * volume (ball o (4 * D^S)) ≤ (As (2 ^ a) (2 ^ J' X)) * volume (ball o (4 * D^S)) by
-    have volume_pos : 0 < volume (ball o (4 * D^S)) := by
+  suffices (Set.encard Y).toENNReal * volume (ball o (4 * D ^ S)) ≤
+      (As (2 ^ a) (2 ^ J' X)) * volume (ball o (4 * D ^ S)) by
+    have volume_pos : 0 < volume (ball o (4 * D ^ S)) := by
       apply measure_ball_pos volume o
       simp only [defaultD, Nat.ofNat_pos, mul_pos_iff_of_pos_left]
       exact zpow_pos (by positivity) S
     rw [← ENNReal.mul_le_mul_left volume_pos.ne.symm (by finiteness), mul_comm,mul_comm (volume _)]
     exact this
-  have val_ne_zero : (As (2 ^ a) (2 ^ J' X):ℝ≥0∞) ≠ 0 := by
-    exact_mod_cast (As_pos' (volume : Measure X) (2 ^J' X)).ne.symm
+  have val_ne_zero : (As (2 ^ a) (2 ^ J' X) : ℝ≥0∞) ≠ 0 := by
+    exact_mod_cast (As_pos' (volume : Measure X) (2 ^ J' X)).ne.symm
   calc
     (Y.encard).toENNReal * volume (ball o (4 * D ^ S))
-      = ∑' (y : Y), volume (ball o (4 * D^S)) := by rw [ENNReal.tsum_const_eq']
-    _ ≤ ∑' (y : Y), volume (ball (y : X) (8 * D ^ (2 * S) * D^k)) :=
+      = ∑' (y : Y), volume (ball o (4 * D ^ S)) := by rw [ENNReal.tsum_const_eq']
+    _ ≤ ∑' (y : Y), volume (ball (y : X) (8 * D ^ (2 * S) * D ^ k)) :=
       ENNReal.summable.tsum_le_tsum (fun ⟨y, hy⟩ ↦ volume.mono (ball_bound k hk_lower hY y hy))
         ENNReal.summable
-    _ ≤ ∑' (y : Y), (As (2 ^ a) (2 ^ J' X)) * volume (ball (y : X) (D^k)) := by
+    _ ≤ ∑' (y : Y), (As (2 ^ a) (2 ^ J' X)) * volume (ball (y : X) (D ^ k)) := by
       apply ENNReal.summable.tsum_le_tsum _ ENNReal.summable
       intro y hy
       rw_mod_cast [← twopow_J]
       apply measure_ball_le_same _ (by positivity) (le_refl _)
-    _ ≤ (As (2 ^ a) (2 ^ J' X)) * ∑' (y : Y), volume (ball (y : X) (D^k)):= by
+    _ ≤ (As (2 ^ a) (2 ^ J' X)) * ∑' (y : Y), volume (ball (y : X) (D ^ k)):= by
       rw [ENNReal.tsum_mul_left]
-    _ = (As (2 ^ a) (2 ^ J' X)) * volume (⋃ y ∈ Y, ball y (D^k)) := by
+    _ = (As (2 ^ a) (2 ^ J' X)) * volume (⋃ y ∈ Y, ball y (D ^ k)) := by
       rw [ENNReal.mul_right_inj val_ne_zero ENNReal.coe_ne_top]
       · rw [measure_biUnion _ hYdisjoint (fun y _ => measurableSet_ball)]
         apply hYdisjoint.countable_of_isOpen (fun y _ => isOpen_ball)
@@ -94,13 +95,14 @@ lemma counting_balls {k : ℤ} (hk_lower : -S ≤ k) {Y : Set X}
         simp only [mem_ball] at hY hz ⊢
         calc
           dist z o
-            ≤ dist z y + dist y o := dist_triangle z y o
-          _ < D^k + (4 * D^S - D^k) := add_lt_add hz hY
+          _ ≤ dist z y + dist y o := dist_triangle z y o
+          _ < D ^ k + (4 * D ^ S - D ^ k) := add_lt_add hz hY
           _ = 4 * D ^ S := by rw [add_sub_cancel]
 
 variable (X) in
 def property_set (k : ℤ) : Set (Set X) :=
-  {s| s ⊆ ball o (4 * D^S - D^k:ℝ) ∧ s.PairwiseDisjoint (fun y => ball y (D^k:ℝ)) ∧ (k = S → o ∈ s)}
+  {s | s ⊆ ball o (4 * D ^ S - D ^ k : ℝ) ∧
+       s.PairwiseDisjoint (fun y => ball y (D^k:ℝ)) ∧ (k = S → o ∈ s)}
 
 variable (X) in
 lemma property_set_nonempty (k : ℤ) : (if k = S then {o} else ∅) ∈ property_set X k := by
@@ -117,8 +119,8 @@ lemma property_set_nonempty (k : ℤ) : (if k = S then {o} else ∅) ∈ propert
 
 variable (X) in
 lemma chain_property_set_has_bound (k : ℤ) :
-    ∀ c ⊆ property_set X k, IsChain (· ⊆ ·) c → ∃ ub ∈ property_set X k,
-    ∀ s ∈ c, s ⊆ ub := by
+    ∀ c ⊆ property_set X k, IsChain (· ⊆ ·) c →
+      ∃ ub ∈ property_set X k, ∀ s ∈ c, s ⊆ ub := by
   intro c hc hchain
   use (⋃ s ∈ c,s) ∪ (if k = S then {o} else ∅)
   if h : c = ∅ then
@@ -466,7 +468,7 @@ mutual
 end
 
 lemma I3_prop_3_2 {k : ℤ} (hk : -S ≤ k) (y : Yk X k) :
-    I3 hk y ⊆ ball (y : X) (4*D^k) := by
+    I3 hk y ⊆ ball (y : X) (4 * D ^ k) := by
   intro x hx
   have : x ∈ I2 hk y := I3_subset_I2 hk y hx
   simp only [I2] at this
@@ -480,13 +482,13 @@ lemma I3_prop_3_2 {k : ℤ} (hk : -S ≤ k) (y : Yk X k) :
     simp only [mem_preimage, mem_iUnion, exists_prop] at this
     obtain ⟨y',hy',hyi3⟩ := this
     have : -S ≤ k - 1 := I_induction_proof hk hk_s
-    have : x ∈ ball (y' : X) (4 * D^(k-1)) := I3_prop_3_2 _ y' hyi3
+    have : x ∈ ball (y' : X) (4 * D ^ (k-1)) := I3_prop_3_2 _ y' hyi3
     rw [mem_ball] at this hy' ⊢
     calc
       dist x (y:X)
-        ≤ dist x (y' : X) + dist (y' : X) (y:X) := dist_triangle _ _ _
+        ≤ dist x (y' : X) + dist (y' : X) (y : X) := dist_triangle _ _ _
       _ <  4 * D ^ (k - 1) + 2 * D ^ k := add_lt_add this hy'
-      _ ≤ 1 * D ^ (k - 1 + 1) + 2 * D^ k := by
+      _ ≤ 1 * D ^ (k - 1 + 1) + 2 * D ^ k := by
         simp only [one_mul, add_le_add_iff_right]
         rw [zpow_add₀ (defaultD_pos a).ne.symm _ 1,zpow_one,mul_comm _ (D:ℝ)]
         gcongr
@@ -499,18 +501,18 @@ termination_by (S + k).toNat
 
 mutual
   lemma I2_prop_2 {k : ℤ} (hk : -S ≤ k) :
-      ball o (4 * D^S - 2 * D^k) ⊆ ⋃ (y:Yk X k), I2 hk y := by
+      ball o (4 * D ^ S - 2 * D ^ k) ⊆ ⋃ (y : Yk X k), I2 hk y := by
     simp only [I2, mem_preimage, iUnion_coe_set]
     if hk_s : k = -S then
       simp_rw [dif_pos hk_s]
       subst hk_s
       calc
-        ball o (4 * D^S - 2 * (D^(-S:ℤ)))
-          ⊆ ball o (4 * D^S - D^(-S:ℤ)) := by
+        ball o (4 * D ^ S - 2 * (D ^ (-S : ℤ)))
+          ⊆ ball o (4 * D ^ S - D ^ (-S : ℤ)) := by
             apply ball_subset_ball
             rw [two_mul,tsub_le_iff_right,sub_add_add_cancel,le_add_iff_nonneg_right]
             positivity
-        _ ⊆ ⋃ (i ∈ Yk X (-S)), ball i (2 * D^(-S:ℤ)) := cover_big_ball (-S:ℤ)
+        _ ⊆ ⋃ (i ∈ Yk X (-S)), ball i (2 * D ^ (-S : ℤ)) := cover_big_ball (-S : ℤ)
     else
       simp_rw [dif_neg hk_s]
       intro x hx
@@ -518,10 +520,10 @@ mutual
       have : ((2 * (S + (k - 1))).toNat : ℤ) + 1 < 2 * (S + k) := by
         rw [Int.toNat_of_nonneg (by linarith)]
         linarith
-      have hsub1 : ball o (4 * D^S - 2 * D^k) ⊆ ⋃ y, I3 (I_induction_proof hk hk_s) y := by
+      have hsub1 : ball o (4 * D ^ S - 2 * D ^ k) ⊆ ⋃ y, I3 (I_induction_proof hk hk_s) y := by
         calc
           ball o (4 * D ^ S - 2 * D ^ k)
-            ⊆ ball o (4 * D^S - 2 * D^(k-1)) := by
+            ⊆ ball o (4 * D ^ S - 2 * D ^ (k - 1)) := by
               apply ball_subset_ball
               simp only [tsub_le_iff_right]
               rw [sub_eq_add_neg,add_assoc]
@@ -532,26 +534,26 @@ mutual
           _ ⊆ ⋃ y, I3 _ y := I3_prop_2 _
       have hmem_i3 : x ∈ ⋃ y, I3 _ y := hsub1 hx
       simp only [mem_iUnion] at hmem_i3
-      obtain ⟨y',hy''⟩ := hmem_i3
-      have hy''' : x ∈ ball (y':X) (D^k) := by
-        apply (?_ : I3 _ y' ⊆ ball (y' : X) (D^k)) hy''
+      obtain ⟨y', hy''⟩ := hmem_i3
+      have hy''' : x ∈ ball (y' : X) (D ^ k) := by
+        apply (?_ : I3 _ y' ⊆ ball (y' : X) (D ^ k)) hy''
         calc
           I3 _ y'
-            ⊆ ball y' (4 * D ^(k-1)) := I3_prop_3_2 _ y'
-          _ ⊆ ball y' (D * D^(k-1)) :=
+            ⊆ ball y' (4 * D ^ (k - 1)) := I3_prop_3_2 _ y'
+          _ ⊆ ball y' (D * D ^ (k - 1)) :=
               ball_subset_ball (by gcongr; exact (four_le_realD X))
-          _ = ball (y': X) (D^k) := by
-            nth_rw 1 [← zpow_one (D:ℝ),← zpow_add₀ (defaultD_pos a).ne.symm,add_sub_cancel]
+          _ = ball (y': X) (D ^ k) := by
+            nth_rw 1 [← zpow_one (D : ℝ),← zpow_add₀ (defaultD_pos a).ne.symm, add_sub_cancel]
       rw [mem_ball_comm] at hy'''
-      have hyfin : (y' :X) ∈ ball o (4 * D^S - D^k) := by
+      have hyfin : (y' : X) ∈ ball o (4 * D ^ S - D ^ k) := by
         simp only [mem_ball] at hx hy''' ⊢
         calc
           dist ↑y' o
             ≤ dist (y' : X) x + dist x o := dist_triangle _ _ _
-          _ < D^k + (4 * D^S - 2 * D^k) := add_lt_add hy''' hx
+          _ < D ^ k + (4 * D ^ S - 2 * D ^ k) := add_lt_add hy''' hx
           _ ≤ 4 * D ^ S - D ^ k := by linarith
-      have hyfin' : (y' : X) ∈ ⋃ (y'' ∈ Yk X k), ball (y'') (2 * D^k) := cover_big_ball k hyfin
-      rw [← iUnion_coe_set (Yk X k) (fun z ↦ ball (z : X) (2 * D^k))] at hyfin'
+      have hyfin' : (y' : X) ∈ ⋃ (y'' ∈ Yk X k), ball (y'') (2 * D ^ k) := cover_big_ball k hyfin
+      rw [← iUnion_coe_set (Yk X k) (fun z ↦ ball (z : X) (2 * D ^ k))] at hyfin'
       simp only [mem_iUnion] at hyfin'
       obtain ⟨y2,hy2'⟩ := hyfin'
       simp only [mem_iUnion, exists_prop, exists_and_left]
@@ -559,7 +561,7 @@ mutual
   termination_by (2 * (S + k)).toNat
 
   lemma I3_prop_2 {k : ℤ} (hk : -S ≤ k) :
-      ball o (4 * D^S - 2 * D^k) ⊆ ⋃ (y:Yk X k), I3 hk y := by
+      ball o (4 * D ^ S - 2 * D ^ k) ⊆ ⋃ (y : Yk X k), I3 hk y := by
     intro x hx
     if hx_mem_Xk : x ∈ Xk hk then
       rw [Xk] at hx_mem_Xk
@@ -572,24 +574,23 @@ mutual
       simp only [mem_iUnion]
       have : x ∈ ⋃ (y : Yk X k), I2 hk y := I2_prop_2 hk hx
       simp only [mem_iUnion] at this
-      have : {i|x ∈ I2 hk i}.Nonempty := this
+      have : {i | x ∈ I2 hk i}.Nonempty := this
       have H := (@wellFounded_lt (Yk X k) _ _)
-      let y := H.min {i|x ∈ I2 hk i} this
+      let y := H.min {i | x ∈ I2 hk i} this
       have hy_i2 : x ∈ I2 hk y := H.min_mem {i|x ∈ I2 hk i} this
       have hy_is_min : ∀ y', x ∈ I2 hk y' → ¬ y' < y :=
-        fun y' hy' ↦ H.not_lt_min {i|x ∈ I2 hk i} this hy'
+        fun y' hy' ↦ H.not_lt_min {i | x ∈ I2 hk i} this hy'
       use y
       revert hy_i2 hy_is_min
       generalize y = y
       intro hy_i2 hy_min
       rw [I3]
       have hx_notMem_i1 : ∀ y',x ∉ I1 hk y' := by
-        simp only [Xk,mem_iUnion,not_exists] at hx_mem_Xk
+        simp only [Xk,mem_iUnion, not_exists] at hx_mem_Xk
         exact hx_mem_Xk
       simp only [mem_union, mem_diff, mem_iUnion, exists_prop, not_or, not_exists,
         not_and]
-      right
-      refine ⟨hy_i2,hx_mem_Xk, fun y' hy' ↦ ?_⟩
+      refine Or.inr ⟨hy_i2,hx_mem_Xk, fun y' hy' ↦ ?_⟩
       rw [I3]
       simp only [mem_union, mem_diff, mem_iUnion, exists_prop, not_or, not_exists, not_and]
       exact ⟨hx_notMem_i1 y', fun hy_i2' _ _ ↦ hy_min y' hy_i2' hy'⟩
@@ -597,15 +598,14 @@ mutual
 end
 
 lemma I3_prop_3_1 {k : ℤ} (hk : -S ≤ k) (y : Yk X k) :
-    ball (y:X) (2⁻¹ * D^k) ⊆ I3 hk y := by
-  rw [I3]
-  refine fun x hx => subset_union_left ((?_ : ball (y:X) (2⁻¹ * D^k) ⊆ I1 hk y) hx)
-  rw [I1]
+    ball (y : X) (2⁻¹ * D ^ k) ⊆ I3 hk y := by
+  rw [I3, I1]
+  apply subset_trans _ subset_union_left
   if hk_s : k = -S then
     rw [dif_pos hk_s]
     subst hk_s
     apply ball_subset_ball
-    nth_rw 2 [← one_mul (D^(-S:ℤ):ℝ)]
+    nth_rw 2 [← one_mul (D ^ (-S : ℤ) : ℝ)]
     gcongr; norm_num
   else
     rw [dif_neg hk_s]
@@ -638,21 +638,21 @@ lemma I3_prop_3_1 {k : ℤ} (hk : -S ≤ k) (y : Yk X k) :
             _ = D ^ k := by
               rw [← mul_assoc]
               norm_num
-        _ ⊆ ⋃ (y':Yk X (k - 1)), I3 (I_induction_proof hk hk_s) y' := I3_prop_2 (I_induction_proof hk hk_s)
+        _ ⊆ ⋃ (y' : Yk X (k - 1)), I3 (I_induction_proof hk hk_s) y' := I3_prop_2 (I_induction_proof hk hk_s)
     intro x hx
-    have : x ∈ ⋃ (y':Yk X (k - 1)), I3 _ y' := this hx
+    have : x ∈ ⋃ (y' : Yk X (k - 1)), I3 _ y' := this hx
     rw [mem_iUnion] at this
     obtain ⟨y',hy'⟩ := this
-    have : x ∈ ball (y':X) (4 * D^(k-1)) := I3_prop_3_2 _ y' hy'
-    have : (y':X) ∈ ball (y:X) (D^k) := by
+    have : x ∈ ball (y' : X) (4 * D ^ (k - 1)) := I3_prop_3_2 _ y' hy'
+    have : (y' : X) ∈ ball (y : X) (D ^ k) := by
       rw [mem_ball] at this hx ⊢
       rw [dist_comm] at this
       calc
-        dist (y':X) (y:X)
-          ≤ dist (y':X) x + dist x (y:X) := dist_triangle _ _ _
-        _ < 4 * D^(k-1) + 2⁻¹ * D^(k) := add_lt_add this hx
-        _ = 2⁻¹ * 8 * D^(k-1) + 2⁻¹ * D^k := by norm_num
-        _ ≤ 2⁻¹ * (D^k + D^k) := by
+        dist (y' : X) (y : X)
+          ≤ dist (y' : X) x + dist x (y : X) := dist_triangle _ _ _
+        _ < 4 * D ^ (k - 1) + 2⁻¹ * D ^ k := add_lt_add this hx
+        _ = 2⁻¹ * 8 * D ^ (k - 1) + 2⁻¹ * D ^ k := by norm_num
+        _ ≤ 2⁻¹ * (D ^ k + D ^ k) := by
           rw [mul_assoc, ← left_distrib]
           gcongr
           nth_rw 2 [← add_sub_cancel 1 k,]
@@ -676,7 +676,7 @@ lemma I3_nonempty {k : ℤ} (hk : -S ≤ k) (y : Yk X k) :
 
 -- the additional argument `hk` to get decent equality theorems
 lemma cover_by_cubes {l : ℤ} (hl : -S ≤ l) :
-    ∀ {k:ℤ}, l ≤ k → (hk : -S ≤ k) → ∀ y, I3 hk y ⊆ ⋃ (yl : Yk X l), I3 hl yl := by
+    ∀ {k : ℤ}, l ≤ k → (hk : -S ≤ k) → ∀ y, I3 hk y ⊆ ⋃ (yl : Yk X l), I3 hl yl := by
   apply Int.le_induction
   · intro _ y x hx
     rw [mem_iUnion]
@@ -693,10 +693,9 @@ lemma cover_by_cubes {l : ℤ} (hl : -S ≤ l) :
   exact hind
 
 lemma dyadic_property {l : ℤ} (hl : -S ≤ l) {k : ℤ} (hl_k : l ≤ k) :
-    (hk : -S ≤ k) → ∀ (y:Yk X k), ∀ (y':Yk X l),
+    (hk : -S ≤ k) → ∀ (y : Yk X k), ∀ (y' : Yk X l),
     ¬ Disjoint (I3 hl y') (I3 hk y) → I3 hl y' ⊆ I3 hk y := by
-  simp_rw [not_disjoint_iff]
-  simp only [forall_exists_index, and_imp]
+  simp_rw [not_disjoint_iff, forall_exists_index, and_imp]
   intro hk y y' x hxl hxk
   if hk_l : k = l then
     subst hk_l
@@ -706,18 +705,16 @@ lemma dyadic_property {l : ℤ} (hl : -S ≤ l) {k : ℤ} (hl_k : l ≤ k) :
     exact I3_prop_1 hk (And.intro hxl hxk)
   else
     have : l < k := lt_of_le_of_ne hl_k fun a ↦ hk_l (id a.symm)
-    have hl_k_m1 : l ≤ k-1 := by linarith
     have hk_not_neg_s : ¬ k = -S := by linarith
-    have : x ∈ ⋃ (y'': Yk X (k-1)), I3 (I_induction_proof hk hk_not_neg_s) y'' :=
+    have : x ∈ ⋃ (y'' : Yk X (k - 1)), I3 (I_induction_proof hk hk_not_neg_s) y'' :=
       cover_by_cubes (I_induction_proof hk hk_not_neg_s) (by linarith) hk y hxk
-
     simp only [mem_iUnion] at this
-    obtain ⟨y'',hy''⟩ := this
-    have : l + (-l + (k-1)).toNat < k := by
+    obtain ⟨y'', hy''⟩ := this
+    have : l + (-l + (k - 1)).toNat < k := by
       rw [Int.toNat_of_nonneg (by linarith)]
       linarith
     have : I3 hl y' ⊆ I3 (I_induction_proof hk hk_not_neg_s) y'' := by
-      apply dyadic_property hl hl_k_m1 (I_induction_proof hk hk_not_neg_s)
+      apply dyadic_property hl (by linarith) (I_induction_proof hk hk_not_neg_s)
       rw [not_disjoint_iff]
       use x
     apply this.trans
@@ -729,11 +726,10 @@ lemma dyadic_property {l : ℤ} (hl : -S ≤ l) {k : ℤ} (hl_k : l ≤ k) :
           not_and] at hxk
         rw [not_iff_false_intro hx_mem_Xk,false_and,and_false,or_false] at hxk
         exact hxk
-
       rw [I1] at hx_i1
       rw [dif_neg hk_not_neg_s] at hx_i1
       simp only [mem_preimage, mem_iUnion, exists_prop] at hx_i1
-      obtain ⟨u,hu,hu'⟩ := hx_i1
+      obtain ⟨u, hu, hu'⟩ := hx_i1
       have hxy'' : x ∈ I3 _ y'' := this hxl
       have : y'' = u := by
         apply I3_prop_1
@@ -753,8 +749,7 @@ lemma dyadic_property {l : ℤ} (hl : -S ≤ l) {k : ℤ} (hl_k : l ≤ k) :
         rw [I3] at hxk
         simp only [mem_union, mem_diff, mem_iUnion, exists_prop, not_or, not_exists,
           not_and] at hxk
-        rw [iff_false_intro (hx_notMem_i1 y),iff_true_intro hx_mem_Xk] at hxk
-        rw [false_or,true_and] at hxk
+        rw [iff_false_intro (hx_notMem_i1 y), iff_true_intro hx_mem_Xk, false_or, true_and] at hxk
         exact hxk
       have hx_mem_i2 := hx_mem_i2_and.left
       have hx_notMem_i3_u := hx_mem_i2_and.right
@@ -767,13 +762,12 @@ lemma dyadic_property {l : ℤ} (hl : -S ≤ l) {k : ℤ} (hl_k : l ≤ k) :
         rw [iff_true_intro (hx_notMem_i1 u),iff_true_intro hx_mem_Xk] at hx_notMem_i3_u
         rw [true_and,true_implies] at hx_notMem_i3_u
         intro h
-        obtain ⟨v,hv,hv'⟩ := hx_notMem_i3_u h
-
+        obtain ⟨v, hv, hv'⟩ := hx_notMem_i3_u h
         exact hx_mem_i2_and.right v (hv.trans hu) hv'
 
       rw [I2, dif_neg hk_not_neg_s] at hx_mem_i2
       simp only [mem_preimage, mem_iUnion, exists_prop] at hx_mem_i2
-      obtain ⟨u,hu,hxu⟩ := hx_mem_i2
+      obtain ⟨u, hu, hxu⟩ := hx_mem_i2
       obtain rfl : y'' = u := by
         apply I3_prop_1 (I_induction_proof hk hk_not_neg_s)
         use hy''
@@ -784,11 +778,11 @@ lemma dyadic_property {l : ℤ} (hl : -S ≤ l) {k : ℤ} (hl_k : l ≤ k) :
         apply hx_mem_Xk
         rw [Xk] at hx_xk' ⊢
         simp only [mem_iUnion] at hx_xk' ⊢
-        obtain ⟨u,hu⟩ := hx_xk'
+        obtain ⟨u, hu⟩ := hx_xk'
         use u
         rw [I1,dif_neg hk_not_neg_s] at hu ⊢
         simp only [mem_preimage, mem_iUnion, exists_prop] at hu ⊢
-        obtain ⟨u',hu',hu''⟩ := hu
+        obtain ⟨u', hu', hu''⟩ := hu
         use u',hu'
         obtain rfl : u' = y'' := I3_prop_1 (I_induction_proof hk hk_not_neg_s) (And.intro hu'' hx_i3')
         exact hxu
@@ -801,7 +795,7 @@ lemma dyadic_property {l : ℤ} (hl : -S ≤ l) {k : ℤ} (hl_k : l ≤ k) :
           exact mem_inter hx' hcontra
         exact this
       simp only [mem_union, mem_diff, mem_iUnion, exists_prop, not_or, not_exists,
-        not_and,iff_true_intro hx_not_xk,true_and]
+        not_and,iff_true_intro hx_not_xk, true_and]
       right
       constructor
       · rw [I2, dif_neg hk_not_neg_s]
@@ -817,7 +811,7 @@ lemma dyadic_property {l : ℤ} (hl : -S ≤ l) {k : ℤ} (hl_k : l ≤ k) :
       rw [I3]
       simp only [mem_union, mem_diff, mem_iUnion, exists_prop, not_or, not_exists, not_and,
         not_forall]
-      rw [iff_true_intro hx_not_xk,iff_true_intro hx_not_i1',true_and,true_implies]
+      rw [iff_true_intro hx_not_xk, iff_true_intro hx_not_i1', true_and, true_implies]
       intro hx_i2'
       by_contra
       apply hx_notMem_i2_u u hu
@@ -835,7 +829,7 @@ lemma dyadic_property {l : ℤ} (hl : -S ≤ l) {k : ℤ} (hl_k : l ≤ k) :
 structure ClosenessProperty {k1 k2 : ℤ} (hk1 : -S ≤ k1) (hk2 : -S ≤ k2)
     (y1 : Yk X k1) (y2 : Yk X k2) : Prop where
   I3_subset : I3 hk1 y1 ⊆ I3 hk2 y2
-  I3_infdist_lt : EMetric.infEdist (y1:X) (I3 hk2 y2)ᶜ < (6 * D^k1:ℝ≥0∞)
+  I3_infdist_lt : EMetric.infEdist (y1 : X) (I3 hk2 y2)ᶜ < (6 * D ^ k1 : ℝ≥0∞)
 
 local macro "clProp(" hkl:term ", " y1:term " | " hkr:term ", " y2:term ")" : term =>
  `(ClosenessProperty $hkl $hkr $y1 $y2)
@@ -844,8 +838,7 @@ lemma transitive_boundary' {k1 k2 k3 : ℤ} (hk1 : -S ≤ k1) (hk2 : -S ≤ k2) 
   (hk1_2 : k1 < k2) (hk2_3 : k2 ≤ k3) (y1 : Yk X k1) (y2 : Yk X k2) (y3 : Yk X k3)
     (x : X) (hx : x ∈ I3 hk1 y1 ∩ I3 hk2 y2 ∩ I3 hk3 y3) :
     clProp(hk1,y1|hk3,y3) → (clProp(hk1,y1|hk2,y2) ∧ clProp(hk2,y2|hk3,y3)) := by
-  rintro ⟨_,hx'⟩
-  -- simp only [mem_inter_iff, mem_compl_iff] at hx
+  rintro ⟨_, hx'⟩
   have hi3_1_2 : I3 hk1 y1 ⊆ I3 hk2 y2 := by
     apply dyadic_property hk1 hk1_2.le hk2 y2 y1
     rw [not_disjoint_iff]
@@ -854,7 +847,6 @@ lemma transitive_boundary' {k1 k2 k3 : ℤ} (hk1 : -S ≤ k1) (hk2 : -S ≤ k2) 
     apply dyadic_property hk2 hk2_3 hk3 y3 y2
     rw [not_disjoint_iff]
     exact ⟨x, hx.left.right, hx.right⟩
-  -- simp only [mem_inter_iff, mem_compl_iff] at hx' ⊢
   have hx_4k2 : x ∈ ball (y2 : X) (4 * D ^ k2) := I3_prop_3_2 hk2 y2 hx.left.right
   have hx_4k2' : x ∈ ball (y1 : X) (4 * D ^ k1) := I3_prop_3_2 hk1 y1 hx.left.left
   have hd_nzero : (D : ℝ≥0∞) ≠ 0 := by
@@ -875,36 +867,36 @@ lemma transitive_boundary' {k1 k2 k3 : ℤ} (hk1 : -S ≤ k1) (hk2 : -S ≤ k2) 
     rw [ENNReal.ofReal_mul (by norm_num), ← ENNReal.ofReal_rpow_of_pos (defaultD_pos a),
       ENNReal.ofReal_ofNat,ENNReal.ofReal_natCast,ENNReal.rpow_intCast] at hx_4k2 hx_4k2'
     calc
-      EMetric.infEdist (y2:X) (I3 hk3 y3)ᶜ
-        ≤ edist (y2 : X) (y1:X) + EMetric.infEdist (y1:X) (I3 hk3 y3)ᶜ :=
+      EMetric.infEdist (y2 : X) (I3 hk3 y3)ᶜ
+        ≤ edist (y2 : X) (y1 : X) + EMetric.infEdist (y1 : X) (I3 hk3 y3)ᶜ :=
           EMetric.infEdist_le_edist_add_infEdist
-      _ = EMetric.infEdist (y1:X) (I3 hk3 y3)ᶜ + edist (y1 : X) (y2:X) := by
+      _ = EMetric.infEdist (y1 : X) (I3 hk3 y3)ᶜ + edist (y1 : X) (y2 : X) := by
         rw [add_comm,edist_comm]
-      _ ≤ EMetric.infEdist (y1:X) (I3 hk3 y3)ᶜ +
+      _ ≤ EMetric.infEdist (y1 : X) (I3 hk3 y3)ᶜ +
           (edist (y1:X) x + edist x y2) := by
         rw [ENNReal.add_le_add_iff_left hx'.ne_top]
         exact edist_triangle (↑y1) x ↑y2
-      _ < EMetric.infEdist (y1:X) (I3 hk3 y3)ᶜ + edist (y1:X) x + 4 * D^k2 := by
+      _ < EMetric.infEdist (y1 : X) (I3 hk3 y3)ᶜ + edist (y1 : X) x + 4 * D ^ k2 := by
         rw [← add_assoc, ENNReal.add_lt_add_iff_left (by finiteness)]
         exact hx_4k2
-      _ < 6 * D^k1 + 4 * D^k1 + 4 * D^k2 := by
+      _ < 6 * D ^ k1 + 4 * D ^ k1 + 4 * D ^ k2 := by
         rw [ENNReal.add_lt_add_iff_right]
         · apply ENNReal.add_lt_add hx' hx_4k2'
         · finiteness
-      _ ≤ 2 * D^k2 + 4 * D^k2 := by
-        rw [← right_distrib 6 4 (D^k1:ℝ≥0∞)]
+      _ ≤ 2 * D ^ k2 + 4 * D ^ k2 := by
+        rw [← right_distrib 6 4 (D ^ k1 : ℝ≥0∞)]
         have hz : (6 + 4 : ℝ≥0∞) = 2 * 5 := by norm_num
         rw [hz, ENNReal.add_le_add_iff_right, mul_assoc]
         · gcongr
           calc
-            (5 * D ^ k1:ℝ≥0∞)
-              ≤ D * D^k1 := by
+            (5 * D ^ k1 : ℝ≥0∞)
+              ≤ D * D ^ k1 := by
                 gcongr
                 rw [← ENNReal.ofReal_ofNat,← ENNReal.ofReal_natCast,
                   ENNReal.ofReal_le_ofReal_iff realD_nonneg]
                 exact five_le_realD X
             _ ≤ D ^ k2 := by
-              nth_rw 1 [← zpow_one (D:ℝ≥0∞)]
+              nth_rw 1 [← zpow_one (D : ℝ≥0∞)]
               simp_rw [← ENNReal.rpow_intCast]
               rw [← ENNReal.rpow_add _ _ hd_nzero (by finiteness),← Int.cast_add]
               apply ENNReal.rpow_le_rpow_of_exponent_le
@@ -946,12 +938,12 @@ set_option hygiene false in
 scoped notation "K'" => @const_K a
 end ShortVariables
 
-lemma K_pos : 0 < (K':ℝ) := by
+lemma K_pos : 0 < (K' : ℝ) := by
   rw [const_K]
   simp only [Nat.cast_pow, Nat.cast_ofNat, Nat.ofNat_pos, pow_pos]
 
 variable (X) in
-def C4_1_7 [ProofData a q K σ₁ σ₂ F G] : ℝ≥0 := As (defaultA a) (2^4)
+def C4_1_7 [ProofData a q K σ₁ σ₂ F G] : ℝ≥0 := As (defaultA a) (2 ^ 4)
 
 variable (X) in
 lemma C4_1_7_eq : C4_1_7 X = 2 ^ (4 * a) := by
@@ -961,49 +953,47 @@ lemma C4_1_7_eq : C4_1_7 X = 2 ^ (4 * a) := by
   group
 
 lemma volume_tile_le_volume_ball (k : ℤ) (hk : -S ≤ k) (y : Yk X k) :
-    volume (I3 hk y) ≤ C4_1_7 X * volume (ball (y:X) (4⁻¹ * D^k)) := by
+    volume (I3 hk y) ≤ C4_1_7 X * volume (ball (y : X) (4⁻¹ * D ^ k)) := by
   calc
     volume (I3 hk y)
-      ≤ volume (ball (y:X) (2^4 * (4⁻¹ * D^k))) := by
+      ≤ volume (ball (y : X) (2 ^ 4 * (4⁻¹ * D ^ k))) := by
         gcongr
         convert I3_prop_3_2 hk y using 2
         ring
-    _ ≤ C4_1_7 X * volume (ball (y:X) (4⁻¹ * D^k:ℝ)):= by
+    _ ≤ C4_1_7 X * volume (ball (y : X) (4⁻¹ * D ^ k : ℝ)):= by
       rw [C4_1_7]
-      exact measure_ball_le_same (y:X) (by linarith) (le_refl _)
+      exact measure_ball_le_same (y : X) (by linarith) (le_refl _)
 
 lemma le_s {k : ℤ} (hk_mK : -S ≤ k - K') (k' : Ioc (k - K') k) : (-S : ℤ) ≤ k' := by
   linarith [k'.property.left]
 
 lemma small_boundary' (k : ℤ) (hk : -S ≤ k) (hk_mK : -S ≤ k - K') (y : Yk X k) :
-    ∑' (z:Yk X (k-K')), volume (⋃ (_ : clProp(hk_mK,z|hk,y)), (I3 hk_mK z))
+    ∑' (z : Yk X (k - K')), volume (⋃ (_ : clProp(hk_mK,z|hk,y)), (I3 hk_mK z))
       ≤ 2⁻¹ * volume (I3 hk y) := by
-  -- have hioc_fin' : (Set.Ioc (k-K') k).Finite := by exact finite_Ioc (k - ↑K') k
   suffices
-    (K') * ∑' (z:Yk X (k-K')), volume (⋃ (_:clProp(hk_mK,z|hk,y)),I3 hk_mK z)
+    (K') * ∑' (z : Yk X (k - K')), volume (⋃ (_:clProp(hk_mK,z|hk,y)),I3 hk_mK z)
       ≤ C4_1_7 X * volume (I3 hk y) by
     rw [C4_1_7_eq X] at this
     dsimp only [const_K] at this
     nth_rw 1 [pow_add 2 (4 * a) 1] at this
-    rw [pow_one 2,Nat.cast_mul,Nat.cast_two] at this
-    rw [mul_comm _ 2,mul_assoc] at this
-    rw [ENNReal.mul_le_iff_le_inv (by norm_num) (by norm_num)] at this
-    rw [← mul_assoc,mul_comm 2⁻¹ _,mul_assoc] at this
+    rw [pow_one 2, Nat.cast_mul, Nat.cast_two, mul_comm _ 2, mul_assoc,
+      ENNReal.mul_le_iff_le_inv (by norm_num) (by norm_num), ← mul_assoc,mul_comm 2⁻¹ _,
+      mul_assoc] at this
     simp only [Nat.cast_pow, Nat.cast_ofNat, ENNReal.coe_pow, ENNReal.coe_ofNat] at this
     rw [← ENNReal.mul_le_mul_left]
     · exact this
     · exact (NeZero.ne (2 ^ (4 * a)))
     · finiteness
-  letI : Countable (Yk X (k-K')) := (Yk_countable X (k-K')).to_subtype
+  letI : Countable (Yk X (k - K')) := (Yk_countable X (k - K')).to_subtype
   calc
     K' * ∑' (z : ↑(Yk X (k - K'))), volume (⋃ (_ : clProp(hk_mK,z|hk,y)), I3 hk_mK z)
-      = ∑ (_:Ioc (k-K') k),
-        ∑'(z:Yk X (k-K')),volume (⋃ (_ : clProp(hk_mK,z|hk,y)), I3 hk_mK z) := by
+      = ∑ (_ : Ioc (k - K') k),
+        ∑'(z : Yk X (k - K')),volume (⋃ (_ : clProp(hk_mK,z|hk,y)), I3 hk_mK z) := by
         rw [Finset.sum_const]
         simp only [Finset.card_univ, Fintype.card_ofFinset, Int.card_Ioc, sub_sub_cancel,
           Int.toNat_natCast, nsmul_eq_mul]
-    _ = ∑ (_:Ioc (k-K') k), volume (
-        ⋃ (z:Yk X (k-K')),⋃ (_:clProp(hk_mK,z|hk,y)),I3 hk_mK z) := by
+    _ = ∑ (_ : Ioc (k - K') k), volume (
+        ⋃ (z : Yk X (k - K')),⋃ (_ : clProp(hk_mK,z|hk,y)),I3 hk_mK z) := by
       apply Finset.sum_congr (rfl)
       intro x
       simp only [Finset.mem_univ, true_implies]
@@ -1026,8 +1016,9 @@ lemma small_boundary' (k : ℤ) (hk : -S ≤ k) (hk_mK : -S ≤ k - K') (y : Yk 
         else
           rw [if_neg h]
           exact MeasurableSet.empty
-    _ ≤ ∑ (k':Ioc (k-K') k), volume (
-        ⋃ (z ∈ {z':Yk X k'|clProp((le_s hk_mK k'),z'|hk,y)}), I3 (le_s hk_mK k') z) := by
+    _ ≤ ∑ (k' : Ioc (k - K') k),
+          volume (⋃ (z ∈ {z' : Yk X k' | clProp((le_s hk_mK k'),z'|hk,y) }),
+            I3 (le_s hk_mK k') z) := by
       apply Finset.sum_le_sum
       simp only [Finset.mem_univ, mem_setOf_eq, true_implies]
       intro k'
@@ -1038,7 +1029,7 @@ lemma small_boundary' (k : ℤ) (hk : -S ≤ k) (hk_mK : -S ≤ k - K') (y : Yk 
       have : x ∈ ⋃ z, I3 (le_s hk_mK k') z:=
         cover_by_cubes (le_s hk_mK k') (k'.property.right) hk y this
       simp only [mem_iUnion] at this
-      obtain ⟨y',hy'⟩ := this
+      obtain ⟨y', hy'⟩ := this
       simp only [mem_iUnion, exists_prop]
       use y'
       constructor
@@ -1048,8 +1039,8 @@ lemma small_boundary' (k : ℤ) (hk : -S ≤ k) (hk_mK : -S ≤ k - K') (y : Yk 
           exact And.intro (And.intro hx hy') this
         · exact hz
       exact hy'
-    _ = ∑ (k':Ioc (k-K') k), ∑'(z:Yk X k'),
-        volume (⋃ (_ : clProp((le_s hk_mK k'),z|hk,y)), I3 (le_s hk_mK k') z) := by
+    _ = ∑ (k' : Ioc (k - K') k), ∑' (z : Yk X k'),
+          volume (⋃ (_ : clProp((le_s hk_mK k'),z|hk,y)), I3 (le_s hk_mK k') z) := by
       apply Finset.sum_congr (rfl)
       intro k'
       simp only [Finset.mem_univ, true_implies]
@@ -1067,70 +1058,65 @@ lemma small_boundary' (k : ℤ) (hk : -S ≤ k) (hk_mK : -S ≤ k - K') (y : Yk 
       apply MeasurableSet.iUnion
       intro _
       exact I3_measurableSet (le_s hk_mK k') i
-    _ ≤ ∑ (k':Ioc (k-K') k),
-        ∑'(z:Yk X k'), C4_1_7 X * volume (⋃ (_ : clProp((le_s hk_mK k'),z|hk,y)),
-        ball (z:X) (4⁻¹ * D^(k':ℤ))) := by
+    _ ≤ ∑ (k' : Ioc (k - K') k), ∑' (z : Yk X k'), C4_1_7 X *
+          volume (⋃ (_ : clProp((le_s hk_mK k'),z|hk,y)), ball (z : X) (4⁻¹ * D ^ (k' : ℤ))) := by
       apply Finset.sum_le_sum
       intro k'
       simp only [Finset.mem_univ, true_implies]
       apply ENNReal.summable.tsum_le_tsum _ (ENNReal.summable)
       intro z
       letI : Decidable (clProp(le_s hk_mK k',z|hk,y)) := Classical.propDecidable _
-      simp_rw [iUnion_eq_if,apply_ite volume,measure_empty]
-      simp only [mul_ite, mul_zero]
+      simp_rw [iUnion_eq_if,apply_ite volume,measure_empty, mul_ite, mul_zero]
       if h : clProp(le_s hk_mK k',z|hk,y) then
-        rw [if_pos h,if_pos h]
+        simp_rw [if_pos h]
         exact volume_tile_le_volume_ball (↑k') (le_s hk_mK k') z
       else
-        rw [if_neg h,if_neg h]
-    _ = C4_1_7 X * ∑ (k' : Ioc (k-K') k),
-        ∑'(z:Yk X k'), volume (⋃ (_:clProp((le_s hk_mK k'),z|hk,y)),ball (z:X) (4⁻¹*D^(k':ℤ))) := by
+        repeat rw [if_neg h]
+    _ = C4_1_7 X * ∑ (k' : Ioc (k - K') k), ∑' (z : Yk X k'),
+          volume (⋃ (_ : clProp((le_s hk_mK k'),z|hk,y)), ball (z : X) (4⁻¹ * D ^ (k' : ℤ))) := by
       rw [Finset.mul_sum]
       apply Finset.sum_congr (rfl)
-      simp only [Finset.mem_univ, true_implies,]
+      simp only [Finset.mem_univ, true_implies]
       intro k'
       rw [ENNReal.tsum_mul_left]
-    _ = C4_1_7 X * ∑ (k' : Ioc (k-K') k),
-        volume (⋃ (z:Yk X k'),⋃ (_:clProp((le_s hk_mK k'),z|hk,y)),ball (z:X) (4⁻¹*D^(k':ℤ))) := by
+    _ = C4_1_7 X * ∑ (k' : Ioc (k - K') k),
+          volume (⋃ (z : Yk X k'), ⋃ (_ : clProp((le_s hk_mK k'),z|hk,y)),
+            ball (z : X) (4⁻¹ * D ^ (k' : ℤ))) := by
       congr
       ext k'
       symm
       letI := (Yk_countable X k').to_subtype
-      apply measure_iUnion
-      · intro i i' hneq
-        simp only [disjoint_iUnion_right, disjoint_iUnion_left]
-        intro _ _
-        apply Disjoint.mono
-        · trans ball (i:X) (2⁻¹ * D^(k':ℤ))
-          · apply ball_subset_ball
-            gcongr
-            apply le_of_mul_le_mul_right _ (by norm_num : (0:ℝ) < 4)
-            norm_num
-          apply I3_prop_3_1
-          have := k'.property.left
+      apply measure_iUnion _ <| fun _ ↦ MeasurableSet.iUnion <| fun _ ↦ measurableSet_ball
+      intro i i' hneq
+      simp only [disjoint_iUnion_right, disjoint_iUnion_left]
+      intro _ _
+      apply Disjoint.mono
+      · trans ball (i : X) (2⁻¹ * D ^ (k' : ℤ))
+        · apply ball_subset_ball
+          gcongr
           linarith
-        · trans ball (i':X) (2⁻¹ * D^(k':ℤ))
-          · apply ball_subset_ball
-            gcongr
-            norm_num
-          apply I3_prop_3_1
-          have := k'.property.left
-          linarith
-        rw [Set.disjoint_iff]
-        intro x hx
-        apply hneq
-        apply I3_prop_1
-        exact hx
-      intro i
-      apply MeasurableSet.iUnion
-      intro _
-      exact measurableSet_ball
-    _ ≤ C4_1_7 X * ∑' (k' : Ioc (k-K') k),
-        volume (⋃ (z:Yk X k'),⋃ (_:clProp((le_s hk_mK k'),z|hk,y)),ball (z:X) (4⁻¹*D^(k':ℤ))) := by
+        apply I3_prop_3_1
+        have := k'.property.left
+        linarith
+      · trans ball (i' : X) (2⁻¹ * D ^ (k' : ℤ))
+        · apply ball_subset_ball
+          gcongr
+          norm_num
+        apply I3_prop_3_1
+        have := k'.property.left
+        linarith
+      rw [Set.disjoint_iff]
+      intro x hx
+      apply hneq
+      apply I3_prop_1
+      exact hx
+    _ ≤ C4_1_7 X * ∑' (k' : Ioc (k - K') k),
+          volume (⋃ (z : Yk X k'), ⋃ (_:clProp((le_s hk_mK k'),z|hk,y)),
+            ball (z : X) (4⁻¹ * D ^ (k' : ℤ))) := by
       gcongr
       exact ENNReal.sum_le_tsum Finset.univ
-    _ = C4_1_7 X * volume (⋃ (k' : Ioc (k-K') k),
-        ⋃ (z:Yk X k'),⋃ (_:clProp((le_s hk_mK k'),z|hk,y)),ball (z:X) (4⁻¹*D^(k':ℤ))) := by
+    _ = C4_1_7 X * volume (⋃ (k' : Ioc (k - K') k), ⋃ (z:Yk X k'),
+          ⋃ (_ : clProp((le_s hk_mK k'),z|hk,y)), ball (z : X) (4⁻¹ * D ^ (k' : ℤ))) := by
       congr
       symm
       apply measure_iUnion
@@ -1185,11 +1171,7 @@ lemma small_boundary' (k : ℤ) (hk : -S ≤ k) (hk_mK : -S ≤ k - K') (y : Yk 
         exact fun ⦃x y⦄ a ↦ id (Disjoint.symm a)
       intro k'
       letI := (Yk_countable X k').to_subtype
-      apply MeasurableSet.iUnion
-      intro b
-      apply MeasurableSet.iUnion
-      intro _
-      exact measurableSet_ball
+      apply MeasurableSet.iUnion <| fun _ ↦ MeasurableSet.iUnion <| fun _ ↦ measurableSet_ball
     _ ≤ C4_1_7 X * volume (I3 hk y) := by
       gcongr
       simp only [iUnion_subset_iff]
@@ -1201,16 +1183,15 @@ lemma small_boundary' (k : ℤ) (hk : -S ≤ k) (hk_mK : -S ≤ k - K') (y : Yk 
       norm_num
 
 lemma small_boundary (k : ℤ) (hk : -S ≤ k) (hk_mK : -S ≤ k - K') (y : Yk X k) :
-    ∑' (z:Yk X (k-K')), ∑ᶠ(_ : clProp(hk_mK,z|hk,y)), volume (I3 hk_mK z)
+    ∑' (z : Yk X (k - K')), ∑ᶠ (_ : clProp(hk_mK,z|hk,y)), volume (I3 hk_mK z)
       ≤ 2⁻¹ * volume (I3 hk y) := by
   calc
-    ∑' (z : Yk X (k - K')),
-      ∑ᶠ (_ : clProp(hk_mK,z|hk,y)), volume (I3 hk_mK z)
-    _ = ∑' (z: Yk X (k-K')), volume (⋃ (_:clProp(hk_mK,z|hk,y)),I3 hk_mK z) := by
+    ∑' (z : Yk X (k - K')), ∑ᶠ (_ : clProp(hk_mK,z|hk,y)), volume (I3 hk_mK z)
+    _ = ∑' (z : Yk X (k - K')), volume (⋃ (_ : clProp(hk_mK,z|hk,y)), I3 hk_mK z) := by
       apply tsum_congr
       intro z
       letI : Decidable clProp(hk_mK,z|hk,y):= Classical.propDecidable _
-      rw [finsum_eq_if,iUnion_eq_if]
+      rw [finsum_eq_if, iUnion_eq_if]
       if h : clProp(hk_mK,z|hk,y) then
         simp_rw [if_pos h]
       else
@@ -1230,8 +1211,8 @@ lemma le_s_2' (n : ℕ) {k : ℤ} (hk_mn1K : -S ≤ k - (n + 1 : ℕ) * K') : (-
   positivity
 
 lemma boundary_sum_eq {k : ℤ} (hk : -S ≤ k) {k' : ℤ} (hk' : -S ≤ k') (y : Yk X k) :
-    ∑'(y':Yk X k'),∑ᶠ(_:clProp(hk',y'|hk,y)),volume (I3 hk' y') =
-      volume (⋃ (y':Yk X k'),⋃(_:clProp(hk',y'|hk,y)),I3 hk' y') := by
+    ∑'(y' : Yk X k'), ∑ᶠ (_ : clProp(hk',y'|hk,y)), volume (I3 hk' y') =
+      volume (⋃ (y' : Yk X k'), ⋃ (_ : clProp(hk',y'|hk,y)), I3 hk' y') := by
   letI := (Yk_countable X k').to_subtype
   rw [measure_iUnion]
   · apply tsum_congr
@@ -1241,19 +1222,18 @@ lemma boundary_sum_eq {k : ℤ} (hk : -S ≤ k) {k' : ℤ} (hk' : -S ≤ k') (y 
     if h : clProp(hk',y'|hk,y) then
       simp_rw [if_pos h]
     else
-      simp_rw [if_neg h,measure_empty]
+      simp_rw [if_neg h, measure_empty]
   · intro i i' hneq
     simp only [disjoint_iUnion_right, disjoint_iUnion_left]
     rw [Set.disjoint_iff]
     intro _ _ x hx
     exact hneq (I3_prop_1 _ hx)
-  intro y'
-  exact MeasurableSet.iUnion (fun _ => I3_measurableSet hk' y')
+  exact fun y' ↦ MeasurableSet.iUnion (fun _ ↦ I3_measurableSet hk' y')
 
-lemma smaller_boundary :∀ (n:ℕ),∀ {k:ℤ}, (hk : -S ≤ k) → (hk_mnK : -S ≤ k - n * K') → ∀(y:Yk X k),
-    ∑' (y' : Yk X (k - n * K')), ∑ᶠ (_ : clProp(hk_mnK,y'|hk,y)), volume (I3 hk_mnK y') ≤
-      2⁻¹^n * volume (I3 hk y) := by
-  intro n
+lemma smaller_boundary (n : ℕ) :
+    ∀ {k : ℤ}, (hk : -S ≤ k) → (hk_mnK : -S ≤ k - n * K') → ∀ (y : Yk X k),
+      ∑' (y' : Yk X (k - n * K')), ∑ᶠ (_ : clProp(hk_mnK,y'|hk,y)), volume (I3 hk_mnK y') ≤
+        2⁻¹ ^ n * volume (I3 hk y) := by
   induction n
   · intro k hk hk_mnK y
     rw [boundary_sum_eq hk hk_mnK y]
@@ -1265,16 +1245,17 @@ lemma smaller_boundary :∀ (n:ℕ),∀ {k:ℤ}, (hk : -S ≤ k) → (hk_mnK : -
   intro k hk hk_mnK y
   rw [boundary_sum_eq hk hk_mnK y]
   calc
-    volume (⋃ (y'':Yk X (k - (n + 1:ℕ) * K')),
-        ⋃ (_:clProp(hk_mnK,y''|hk,y)), I3 hk_mnK y'')
-      ≤ volume (⋃ (y':Yk X (k-K')),⋃(_:clProp(le_s_2' n hk_mnK,y'|hk,y)),
-        ⋃ (y'':Yk X (k-(n+1:ℕ)*K')),⋃(_:clProp(hk_mnK,y''|le_s_2' n hk_mnK,y')), I3 hk_mnK y'') := by
+    volume (⋃ (y'' : Yk X (k - (n + 1 : ℕ) * K')),
+      ⋃ (_:clProp(hk_mnK,y''|hk,y)), I3 hk_mnK y'')
+    ≤ volume (⋃ (y' : Yk X (k - K')), ⋃ (_ : clProp(le_s_2' n hk_mnK,y'|hk,y)),
+        ⋃ (y'' : Yk X (k - (n + 1 : ℕ) * K')),
+          ⋃ (_ : clProp(hk_mnK,y''|le_s_2' n hk_mnK,y')), I3 hk_mnK y'') := by
       apply volume.mono
       simp only [iUnion_subset_iff]
       intro y'' hy'' x hx
       simp only [mem_iUnion, exists_prop]
       have hx_y: x ∈ I3 hk y := hy''.I3_subset hx
-      have : x ∈ ⋃ (y':Yk X (k-K')),I3 (le_s_2' n hk_mnK) y' :=
+      have : x ∈ ⋃ (y' : Yk X (k - K')), I3 (le_s_2' n hk_mnK) y' :=
         cover_by_cubes (le_s_2' n hk_mnK) (by linarith) hk y hx_y
       simp only [mem_iUnion] at this
       obtain ⟨y', hx_y'⟩ := this
@@ -1290,19 +1271,19 @@ lemma smaller_boundary :∀ (n:ℕ),∀ {k:ℤ}, (hk : -S ≤ k) → (hk_mnK : -
         · simp only [mem_inter_iff, and_assoc]
           use hx
       use hz.right, y'', hz.left
-    _ = ∑'(y':Yk X (k-K')),∑ᶠ (_:clProp(le_s_2' n hk_mnK,y'|hk,y)),
-      volume (⋃ (y'':Yk X (k-(n+1:ℕ)*K')),⋃(_:clProp(hk_mnK,y''|le_s_2' n hk_mnK,y')),
-        I3 hk_mnK y'') := by
-      letI := (Yk_countable X (k-K')).to_subtype
+    _ = ∑' (y' : Yk X (k - K')), ∑ᶠ (_ : clProp(le_s_2' n hk_mnK,y'|hk,y)),
+          volume (⋃ (y'' : Yk X (k - (n + 1 : ℕ) * K')),
+            ⋃ (_ : clProp(hk_mnK,y''|le_s_2' n hk_mnK,y')), I3 hk_mnK y'') := by
+      letI := (Yk_countable X (k - K')).to_subtype
       rw [measure_iUnion]
       · apply tsum_congr
         intro y'
         letI : Decidable clProp(le_s_2' n hk_mnK,y'|hk,y) := Classical.propDecidable _
-        rw [iUnion_eq_if,finsum_eq_if]
+        rw [iUnion_eq_if, finsum_eq_if]
         if h : clProp(le_s_2' n hk_mnK,y'|hk,y) then
           simp_rw [if_pos h]
         else
-          simp_rw [if_neg h,measure_empty]
+          simp_rw [if_neg h, measure_empty]
       · intro i i' hneq
         simp only [disjoint_iUnion_right, disjoint_iUnion_left]
         intro _ y1 hy1i _ y2 hy2i'
@@ -1317,35 +1298,35 @@ lemma smaller_boundary :∀ (n:ℕ),∀ {k:ℤ}, (hk : -S ≤ k) → (hk_mnK : -
       letI := (Yk_countable X (k-(n+1:ℕ)*K')).to_subtype
       apply MeasurableSet.iUnion
       intro y''
-      apply MeasurableSet.iUnion (fun _ => I3_measurableSet hk_mnK y'')
-    _ = ∑'(y':Yk X (k-K')),∑ᶠ (_:clProp(le_s_2' n hk_mnK,y'|hk,y)),
-        ∑' (y'': Yk X (k - (n+1:ℕ) * K')),∑ᶠ(_:clProp(hk_mnK,y''|le_s_2' n hk_mnK,y')),
-        volume (I3 hk_mnK y'') := by
+      apply MeasurableSet.iUnion (fun _ ↦ I3_measurableSet hk_mnK y'')
+    _ = ∑' (y' : Yk X (k - K')), ∑ᶠ (_ : clProp(le_s_2' n hk_mnK,y'|hk,y)),
+          ∑' (y'': Yk X (k - (n + 1 : ℕ) * K')), ∑ᶠ (_ : clProp(hk_mnK,y''|le_s_2' n hk_mnK,y')),
+            volume (I3 hk_mnK y'') := by
       apply tsum_congr
       intro y'
       apply finsum_congr
       intro hcly'
       rw [boundary_sum_eq (le_s_2' n hk_mnK) hk_mnK y']
-    _ = ∑'(y':Yk X (k-K')),∑ᶠ (_:clProp(le_s_2' n hk_mnK,y'|hk,y)),
-        ∑' (y'': Yk X ((k - K') - n * K')),∑ᶠ(_:clProp(le_s_1' n hk_mnK,y''|le_s_2' n hk_mnK,y')),
-        volume (I3 (le_s_1' n hk_mnK) y'') := by
-      have : k - (n + 1:ℕ) * K' = (k - K') - n * K' := by
+    _ = ∑' (y' : Yk X (k - K')), ∑ᶠ (_ : clProp(le_s_2' n hk_mnK,y'|hk,y)),
+          ∑' (y'' : Yk X ((k - K') - n * K')), ∑ᶠ (_ : clProp(le_s_1' n hk_mnK,y''|le_s_2' n hk_mnK,y')),
+            volume (I3 (le_s_1' n hk_mnK) y'') := by
+      have : k - (n + 1 : ℕ) * K' = (k - K') - n * K' := by
         rw [Nat.cast_add, Nat.cast_one,add_comm,right_distrib,one_mul,Int.sub_sub]
       congr! 8
-    _ ≤ ∑'(y':Yk X (k-K')),∑ᶠ (_:clProp(le_s_2' n hk_mnK,y'|hk,y)),
-        2⁻¹ ^n * volume (I3 (le_s_2' n hk_mnK) y') := by
+    _ ≤ ∑' (y' : Yk X (k - K')), ∑ᶠ (_ : clProp(le_s_2' n hk_mnK,y'|hk,y)),
+          2⁻¹ ^ n * volume (I3 (le_s_2' n hk_mnK) y') := by
       apply ENNReal.summable.tsum_le_tsum _ (ENNReal.summable)
       intro y'
       letI : Decidable clProp(le_s_2' n hk_mnK,y'|hk,y) := Classical.propDecidable _
-      rw [finsum_eq_if,finsum_eq_if]
+      rw [finsum_eq_if, finsum_eq_if]
       if h : clProp(le_s_2' n hk_mnK,y'|hk,y) then
         simp_rw [if_pos h]
         apply hinduction
       else
         simp_rw [if_neg h]
         exact le_refl _
-    _ = 2⁻¹^n * ∑'(y':Yk X (k-K')),∑ᶠ (_:clProp(le_s_2' n hk_mnK,y'|hk,y)),
-        volume (I3 (le_s_2' n hk_mnK) y') := by
+    _ = 2⁻¹ ^ n * ∑' (y' : Yk X (k - K')), ∑ᶠ (_ : clProp(le_s_2' n hk_mnK,y'|hk,y)),
+          volume (I3 (le_s_2' n hk_mnK) y') := by
       rw [← ENNReal.tsum_mul_left]
       apply tsum_congr
       intro y'
@@ -1354,12 +1335,12 @@ lemma smaller_boundary :∀ (n:ℕ),∀ {k:ℤ}, (hk : -S ≤ k) → (hk_mnK : -
       if h : clProp(le_s_2' n hk_mnK,y'|hk,y) then
         simp_rw [if_pos h]
       else
-        simp_rw [if_neg h,mul_zero]
-    _ ≤ 2⁻¹ ^n * (2⁻¹ * volume (I3 hk y)) := by
+        simp_rw [if_neg h, mul_zero]
+    _ ≤ 2⁻¹ ^ n * (2⁻¹ * volume (I3 hk y)) := by
       gcongr
       apply _root_.small_boundary
     _ = 2⁻¹ ^ (n + 1) * volume (I3 hk y) := by
-      rw [pow_add,pow_one,mul_assoc]
+      rw [pow_add, pow_one, mul_assoc]
 
 section ProofData
 include q K σ₁ σ₂ F G
@@ -1377,22 +1358,22 @@ theorem prefloor_nonneg (ht : t ∈ Ioo 0 1) :
   rw [Real.logb_nonpos_iff (one_lt_realD X) ht.left]
   exact ht.right.le
 
-lemma const_n_prop_1 (ht : t ∈ Ioo 0 1) : D^(const_n a ht * K') ≤ t⁻¹ := by
+variable (X) in
+lemma const_n_prop_1 (ht : t ∈ Ioo 0 1) : D ^ (const_n a ht * K') ≤ t⁻¹ := by
   simp only [mem_Ioo] at ht
-  rw [← Real.rpow_logb (defaultD_pos a) (one_lt_realD X).ne.symm (inv_pos.mpr ht.left)]
-  rw [← Real.rpow_natCast,Real.rpow_le_rpow_left_iff (one_lt_realD X)]
+  rw [← Real.rpow_logb (defaultD_pos a) (one_lt_realD X).ne.symm (inv_pos.mpr ht.left),
+    ← Real.rpow_natCast,Real.rpow_le_rpow_left_iff (one_lt_realD X)]
   simp only [Nat.cast_mul, Real.logb_inv]
-  rw [← le_div_iff₀ (K_pos)]
-  rw [const_n]
+  rw [← le_div_iff₀ (K_pos), const_n]
   exact Nat.floor_le (prefloor_nonneg X ht)
 
 variable (X) in
 lemma const_n_prop_2 (ht : t ∈ Ioo 0 1) (k : ℤ) : t * D ^ k ≤ D ^ (k - const_n a ht * K') := by
   let _ : MulPosReflectLE ℝ := inferInstance -- perf: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/performance.20example.20with.20type-class.20inference
-  rw [sub_eq_neg_add, zpow_add₀ (defaultD_pos a).ne.symm]
-  rw [mul_le_mul_right (zpow_pos (defaultD_pos a) _)]
-  rw [zpow_neg, le_inv_comm₀ ht.left (zpow_pos (defaultD_pos a) _)]
-  exact (@const_n_prop_1 X) ht
+  rw [sub_eq_neg_add, zpow_add₀ (defaultD_pos a).ne.symm,
+    mul_le_mul_right (zpow_pos (defaultD_pos a) _), zpow_neg,
+    le_inv_comm₀ ht.left (zpow_pos (defaultD_pos a) _)]
+  exact const_n_prop_1 X ht
 
 variable (X) in
 lemma const_n_is_max (ht : t ∈ Ioo 0 1) (n : ℕ) : D ^ (n * K') ≤ t⁻¹ → n ≤ const_n a ht := by
@@ -1401,8 +1382,7 @@ lemma const_n_is_max (ht : t ∈ Ioo 0 1) (n : ℕ) : D ^ (n * K') ≤ t⁻¹ �
   rw [← Real.rpow_natCast,Real.rpow_le_rpow_left_iff (one_lt_realD X)]
   simp only [Nat.cast_mul, Real.logb_inv]
   rw [← le_div_iff₀ (K_pos), const_n]
-  intro h
-  exact Nat.le_floor h
+  exact fun h ↦ Nat.le_floor h
 
 variable (X) in
 lemma const_n_prop_3 (ht : t ∈ Ioo 0 1) :
@@ -1412,25 +1392,20 @@ lemma const_n_prop_3 (ht : t ∈ Ioo 0 1) :
   nth_rw 3 [← one_mul K']
   rw [← right_distrib]
   nth_rw 1 [← Real.rpow_logb (defaultD_pos a) (one_lt_realD X).ne.symm ht.left]
-  rw [← Real.rpow_neg (realD_nonneg)]
-  rw [← Real.rpow_natCast, Real.rpow_le_rpow_left_iff (one_lt_realD X)]
+  rw [← Real.rpow_neg (realD_nonneg), ← Real.rpow_natCast, Real.rpow_le_rpow_left_iff (one_lt_realD X)]
   push_cast
   rw [← div_le_iff₀ (K_pos)]
-  exact (Nat.lt_floor_add_one (-Real.logb (↑D) t / ↑const_K)).le
+  exact Nat.lt_floor_add_one (-Real.logb (↑D) t / ↑const_K) |>.le
 
 variable (X) in
 lemma const_n_nonneg (ht : t ∈ Ioo 0 1) : 0 ≤ const_n a ht := by
   apply const_n_is_max X ht 0
   simp only [zero_mul, pow_zero]
-  rw [one_le_inv_iff₀]
-  use ht.left, ht.right.le
-
-variable (X) in
-lemma two_le_a : 2 ≤ a := by linarith [four_le_a X]
+  exact one_le_inv_iff₀.mpr <| ⟨ht.left, ht.right.le⟩
 
 variable (X) in
 lemma kappa_le_log2D_inv_mul_K_inv : κ ≤ (Real.logb 2 D * K')⁻¹ := by
-  have : 2 ≤ a := two_le_a X
+  have : 2 ≤ a := by linarith [four_le_a X]
   have 𝕔_pos : 0 < 𝕔 := by linarith [seven_le_c]
   rw [defaultD]
   simp only [Nat.cast_pow, Nat.cast_ofNat, mul_inv_rev]
@@ -1442,13 +1417,13 @@ lemma kappa_le_log2D_inv_mul_K_inv : κ ≤ (Real.logb 2 D * K')⁻¹ := by
     ← Real.rpow_natCast 2]
   norm_num
   calc
-    (2 : ℝ) * 𝕔 * ↑a ^ 2 * 2 ^ (4 * ↑a:ℝ)
-      ≤ 2^8 * (2^(a:ℝ))^2 * 2 ^ (4 * a:ℝ) := by
+    (2 : ℝ) * 𝕔 * a ^ 2 * 2 ^ (4 * a : ℝ)
+      ≤ 2 ^ 8 * (2 ^ (a : ℝ)) ^ 2 * 2 ^ (4 * a : ℝ) := by
       gcongr
       · norm_cast
         linarith [c_le_100]
-      · exact (Real.self_lt_two_rpow (a:ℝ)).le
-    _ ≤ 2 ^ (4 * a:ℝ) * 2^(2*a:ℝ) * 2^(4*a:ℝ) := by
+      · exact (Real.self_lt_two_rpow (a : ℝ)).le
+    _ ≤ 2 ^ (4 * a : ℝ) * 2 ^ (2 * a : ℝ) * 2 ^ (4 * a : ℝ) := by
       gcongr
       · rw [← Real.rpow_natCast, Real.rpow_le_rpow_left_iff (by norm_num)]
         norm_num
@@ -1456,41 +1431,42 @@ lemma kappa_le_log2D_inv_mul_K_inv : κ ≤ (Real.logb 2 D * K')⁻¹ := by
         · norm_num
         rw [mul_le_mul_left (by norm_num)]
         exact Nat.ofNat_le_cast.mpr this
-      · rw [← Real.rpow_natCast,← Real.rpow_mul (by norm_num),mul_comm]
+      · rw [← Real.rpow_natCast, ← Real.rpow_mul (by norm_num), mul_comm]
         simp only [Nat.cast_ofNat, le_refl]
-    _ ≤ 2 ^ (10 * a:ℝ) := by
-      simp_rw [← Real.rpow_add (by norm_num : 0 < (2:ℝ)),← right_distrib]
+    _ ≤ 2 ^ (10 * a : ℝ) := by
+      simp_rw [← Real.rpow_add (by norm_num : 0 < (2 : ℝ)), ← right_distrib]
       norm_num
 
 end ProofData
 
 lemma boundary_measure {k : ℤ} (hk : -S ≤ k) (y : Yk X k) {t : ℝ≥0} (ht : t ∈ Set.Ioo 0 1)
     (htD : (D ^ (-S : ℤ) : ℝ) ≤ t * D ^ k) :
-    volume ({x|x ∈ I3 hk y ∧ EMetric.infEdist x (I3 hk y)ᶜ ≤ (↑t * ↑D ^ k)}) ≤ 2 * t^κ * volume (I3 hk y) := by
-  have hconst_n : -S ≤ k-const_n a ht * K' := by
-    suffices (D^ (-S:ℤ) : ℝ) ≤ D ^ (k-const_n a ht * K' : ℤ) by
+    volume ({x | x ∈ I3 hk y ∧ EMetric.infEdist x (I3 hk y)ᶜ ≤ (↑t * ↑D ^ k)}) ≤
+      2 * t ^ κ * volume (I3 hk y) := by
+  have hconst_n : -S ≤ k - const_n a ht * K' := by
+    suffices (D ^ (-S : ℤ) : ℝ) ≤ D ^ (k - const_n a ht * K' : ℤ) by
       simp_rw [← Real.rpow_intCast] at this
       rw [Real.rpow_le_rpow_left_iff (one_lt_realD X)] at this
       simp only [Int.cast_le] at this
       exact this
     exact htD.trans (const_n_prop_2 X ht k)
-  have hconst_n_k : k-const_n a ht * K' ≤ k := by
+  have hconst_n_k : k - const_n a ht * K' ≤ k := by
     simp only [tsub_le_iff_right, le_add_iff_nonneg_right]
     positivity
   simp only [mem_Ioo] at ht
   calc
-    volume ({x|x ∈ I3 hk y ∧ EMetric.infEdist x (I3 hk y)ᶜ ≤ (↑t * ↑D ^ k)})
-      ≤ volume (⋃ (y':Yk X (k-const_n a ht *K')),⋃(_:clProp(hconst_n,y'|hk,y)),
-        I3 hconst_n y') := by
+    volume ({x | x ∈ I3 hk y ∧ EMetric.infEdist x (I3 hk y)ᶜ ≤ (↑t * ↑D ^ k)})
+    _ ≤ volume (⋃ (y' : Yk X (k - const_n a ht *K')), ⋃ (_ : clProp(hconst_n,y'|hk,y)),
+          I3 hconst_n y') := by
       apply volume.mono
       intro x
       simp only [mem_setOf_eq, NNReal.val_eq_coe, and_imp]
       intro hxi3 hxb'
-      have : x ∈ ⋃(y':Yk X (k-const_n a ht * K')),I3 hconst_n y' :=
+      have : x ∈ ⋃ (y' : Yk X (k - const_n a ht * K')), I3 hconst_n y' :=
         cover_by_cubes hconst_n hconst_n_k hk y hxi3
       simp only [mem_iUnion] at this ⊢
-      obtain ⟨y',hy'⟩ := this
-      have hxy' : x ∈ ball (y':X) (4 * D^(k - const_n a ht * K')) := by
+      obtain ⟨y', hy'⟩ := this
+      have hxy' : x ∈ ball (y' : X) (4 * D ^ (k - const_n a ht * K')) := by
         apply I3_prop_3_2
         exact hy'
       refine ⟨y', ⟨?_, ?_⟩, hy'⟩
@@ -1504,15 +1480,13 @@ lemma boundary_measure {k : ℤ} (hk : -S ≤ k) (y : Yk X k) {t : ℝ≥0} (ht 
         rw [← ENNReal.ofReal_natCast,ENNReal.ofReal_pos]
         exact defaultD_pos a
       calc
-        EMetric.infEdist (y':X) (I3 hk y)ᶜ
-          ≤ EMetric.infEdist (x:X) (I3 hk y)ᶜ + edist (y':X) x:=
+        EMetric.infEdist (y' : X) (I3 hk y)ᶜ
+        _ ≤ EMetric.infEdist (x:X) (I3 hk y)ᶜ + edist (y':X) x :=
           EMetric.infEdist_le_infEdist_add_edist
         _ < t * D^k + 4 * D^(k-const_n a ht * K') := by
           apply ENNReal.add_lt_add_of_le_of_lt _ hxb' hxy'
-          apply LT.lt.ne
-          apply lt_of_le_of_lt hxb'
+          apply (hxb'.trans_lt _).ne
           finiteness
-          -- add_lt_add_of_le_of_lt hxb' hxy'
         _ ≤ D ^ (k - const_n a ht * K') + 4 * D ^ (k - const_n a ht * K') := by
           rw [ENNReal.add_le_add_iff_right]
           · have := const_n_prop_2 X ht k
@@ -1521,8 +1495,9 @@ lemma boundary_measure {k : ℤ} (hk : -S ≤ k) (y : Yk X k) {t : ℝ≥0} (ht 
             simp_rw [← Real.rpow_intCast] at this
             rw [← ENNReal.ofReal_le_ofReal_iff (by positivity),
               ENNReal.ofReal_mul (by exact ht.left.le), ENNReal.ofReal_coe_nnreal,
-              ← ENNReal.ofReal_rpow_of_pos (defaultD_pos a),← ENNReal.ofReal_rpow_of_pos (defaultD_pos a),
-              ENNReal.ofReal_natCast, ENNReal.rpow_intCast, ENNReal.rpow_intCast] at this
+              ← ENNReal.ofReal_rpow_of_pos (defaultD_pos a),
+              ← ENNReal.ofReal_rpow_of_pos (defaultD_pos a), ENNReal.ofReal_natCast,
+              ENNReal.rpow_intCast, ENNReal.rpow_intCast] at this
             exact this
           finiteness
         _ ≤ 6 * ↑D ^ (k - const_n a ht * ↑const_K) := by
@@ -1533,11 +1508,11 @@ lemma boundary_measure {k : ℤ} (hk : -S ≤ k) (y : Yk X k) {t : ℝ≥0} (ht 
             rw [← ENNReal.rpow_intCast]
             exact ENNReal.rpow_pos this (by finiteness)
           finiteness
-    _ = ∑' (y' : Yk X (k - const_n a ht * K')), ∑ᶠ(_ :clProp(hconst_n, y'|hk, y)),
-      volume (I3 hconst_n y') := by rw [boundary_sum_eq hk hconst_n y]
-    _ ≤ 2⁻¹^(const_n a ht) * volume (I3 hk y) := by apply smaller_boundary
-    _ ≤ 2 * ↑t ^ κ * volume (I3 hk y) := by
-      refine mul_le_mul' ?h₁ (le_refl _)
+    _ = ∑' (y' : Yk X (k - const_n a ht * K')), ∑ᶠ(_ : clProp(hconst_n, y'|hk, y)),
+          volume (I3 hconst_n y') := by rw [boundary_sum_eq hk hconst_n y]
+    _ ≤ 2⁻¹ ^ (const_n a ht) * volume (I3 hk y) := by apply smaller_boundary
+    _ ≤ 2 * t ^ κ * volume (I3 hk y) := by
+      refine mul_le_mul' ?_ (le_refl _)
       suffices hsuf : ((2⁻¹ ^ (const_n a ht) : ℝ≥0) : ℝ≥0∞) ≤ (2 * t ^ κ : ℝ≥0) by
         push_cast at hsuf
         rw [ENNReal.coe_rpow_def]
@@ -1549,25 +1524,25 @@ lemma boundary_measure {k : ℤ} (hk : -S ≤ k) (y : Yk X k) {t : ℝ≥0} (ht 
         rw [if_neg this]
         exact hsuf
       rw [ENNReal.coe_le_coe]
-      suffices hsuf: (2⁻¹ ^ const_n a ht:ℝ) ≤ 2 * ↑t ^ κ by
+      suffices hsuf : (2⁻¹ ^ const_n a ht : ℝ) ≤ 2 * t ^ κ by
         exact hsuf -- TIL: things in ℝ≥0 are very defeq to things in ℝ
       calc
-        (2⁻¹ ^ const_n a ht:ℝ)
-        _ = 2 ^ (-const_n a ht:ℝ) := by
+        (2⁻¹ ^ const_n a ht : ℝ)
+        _ = 2 ^ (-const_n a ht : ℝ) := by
           rw [Real.rpow_neg (by norm_num), ← Real.rpow_natCast,Real.inv_rpow (by norm_num)]
-        _ = (D ^ ((Real.logb 2 D)⁻¹)) ^ (-const_n a ht:ℝ) := by
+        _ = (D ^ ((Real.logb 2 D)⁻¹)) ^ (-const_n a ht : ℝ) := by
           rw [Real.inv_logb, Real.rpow_logb (defaultD_pos a) (one_lt_realD X).ne' (by norm_num)]
-        _ = D ^ ((const_n a ht * K':ℝ) * -(Real.logb 2 D * K' :ℝ)⁻¹) := by
+        _ = D ^ ((const_n a ht * K' : ℝ) * -(Real.logb 2 D * K' : ℝ)⁻¹) := by
           rw [← Real.rpow_mul realD_nonneg]
           congr 1
-          rw [mul_neg,mul_neg]
+          rw [mul_neg, mul_neg]
           congr 1
           rw [mul_inv, mul_assoc, mul_comm (K' : ℝ), mul_assoc, inv_mul_cancel₀ K_pos.ne',
             mul_one, mul_comm]
         _ = (D ^ (const_n a ht * K' : ℝ) : ℝ)⁻¹ ^ (Real.logb 2 D * K' : ℝ)⁻¹ := by
-          rw [Real.rpow_mul (realD_nonneg), Real.rpow_neg (by positivity)]
-          rw [Real.inv_rpow (by positivity)]
-        _ ≤ (t * D ^(K':ℝ)) ^ (Real.logb 2 D * K' :ℝ)⁻¹ := by
+          rw [Real.rpow_mul (realD_nonneg), Real.rpow_neg (by positivity),
+            Real.inv_rpow (by positivity)]
+        _ ≤ (t * D ^(K' : ℝ)) ^ (Real.logb 2 D * K' : ℝ)⁻¹ := by
           rw [Real.rpow_le_rpow_iff]
           · rw [inv_le_comm₀]
             · rw [← Nat.cast_mul, Real.rpow_natCast, Real.rpow_natCast]
@@ -1580,13 +1555,13 @@ lemma boundary_measure {k : ℤ} (hk : -S ≤ k) (y : Yk X k) {t : ℝ≥0} (ht 
           · positivity
           · rw [inv_pos,mul_pos_iff_of_pos_right (K_pos)]
             exact Real.logb_pos (by norm_num) (one_lt_realD X)
-        _ = 2 * t ^ (Real.logb 2 D * K':ℝ)⁻¹ := by
-          rw [Real.mul_rpow,mul_comm, ← Real.rpow_mul (realD_nonneg), mul_comm (K':ℝ)]
-          · rw [mul_inv, mul_assoc, inv_mul_cancel₀ K_pos.ne', mul_one, Real.inv_logb]
-            rw [Real.rpow_logb (defaultD_pos a) (one_lt_realD X).ne' (by norm_num)]
+        _ = 2 * t ^ (Real.logb 2 D * K' : ℝ)⁻¹ := by
+          rw [Real.mul_rpow,mul_comm, ← Real.rpow_mul (realD_nonneg), mul_comm (K' : ℝ)]
+          · rw [mul_inv, mul_assoc, inv_mul_cancel₀ K_pos.ne', mul_one, Real.inv_logb,
+              Real.rpow_logb (defaultD_pos a) (one_lt_realD X).ne' (by norm_num)]
           · exact ht.left.le
           positivity
-        _ ≤ (2 * t ^ κ:ℝ) := by
+        _ ≤ (2 * t ^ κ : ℝ) := by
           rw [mul_le_mul_left (by linarith)]
           have : (t : ℝ) ∈ Ioo 0 1 := ht
           rw [mem_Ioo] at this
@@ -1595,27 +1570,24 @@ lemma boundary_measure {k : ℤ} (hk : -S ≤ k) (y : Yk X k) {t : ℝ≥0} (ht 
 
 lemma boundary_measure' {k : ℤ} (hk : -S ≤ k) (y : Yk X k) {t : ℝ≥0} (ht : t ∈ Set.Ioo 0 1)
     (htD : (D ^ (-S : ℤ) : ℝ) ≤ t * D ^ k) :
-    volume.real ({x|x ∈ I3 hk y ∧ EMetric.infEdist x (I3 hk y)ᶜ ≤ (↑t * ↑D ^ k)}) ≤ 2 * t^κ * volume.real (I3 hk y) := by
+    volume.real ({x | x ∈ I3 hk y ∧ EMetric.infEdist x (I3 hk y)ᶜ ≤ (↑t * ↑D ^ k)}) ≤
+      2 * t ^ κ * volume.real (I3 hk y) := by
   dsimp only [Measure.real]
   calc
-    (volume ({x|x ∈ I3 hk y ∧ EMetric.infEdist x (I3 hk y)ᶜ ≤ (↑t * ↑D ^ k)})).toReal
-    _ ≤ ((2:ℝ≥0∞) * t ^ κ:ℝ≥0∞).toReal * (volume (I3 hk y)).toReal := by
+    volume ({x | x ∈ I3 hk y ∧ EMetric.infEdist x (I3 hk y)ᶜ ≤ (↑t * ↑D ^ k)}) |>.toReal
+    _ ≤ ((2 : ℝ≥0∞) * t ^ κ : ℝ≥0∞).toReal * (volume (I3 hk y)).toReal := by
         rw [← ENNReal.toReal_mul]
         rw [ENNReal.toReal_le_toReal]
         · exact boundary_measure hk y ht htD
-        · apply LT.lt.ne
-          apply lt_of_le_of_lt (volume.mono inter_subset_left)
-          apply lt_of_le_of_lt
-          · apply volume.mono (I3_prop_3_2 hk y)
-          · simp only [OuterMeasure.measureOf_eq_coe, Measure.coe_toOuterMeasure]
-            finiteness
+        · apply ne_of_lt
+          apply volume.mono inter_subset_left |>.trans_lt
+          apply volume.mono (I3_prop_3_2 hk y) |>.trans_lt
+          simp only [OuterMeasure.measureOf_eq_coe, Measure.coe_toOuterMeasure]
+          finiteness
         apply ENNReal.mul_ne_top
         · have : 0 ≤ κ := κ_nonneg
           finiteness
-        apply LT.lt.ne
-        apply lt_of_le_of_lt
-        · apply volume.mono (I3_prop_3_2 hk y)
-        · exact measure_ball_lt_top
+        exact volume.mono (I3_prop_3_2 hk y) |>.trans_lt measure_ball_lt_top |>.ne
     _ = 2 * t ^ κ * (volume (I3 hk y)).toReal := by
       congr
       rw [ENNReal.toReal_mul]
@@ -1630,7 +1602,7 @@ structure 𝓓 where
   hk : -S ≤ k
   hk_max : k ≤ S
   y : Yk X k
-  hsub : I3 hk y ⊆ I3 (by trans 0 <;> simp : (-S:ℤ) ≤ S) ⟨o,o_mem_Yk_S⟩
+  hsub : I3 hk y ⊆ I3 (by trans 0 <;> simp : (-S : ℤ) ≤ S) ⟨o,o_mem_Yk_S⟩
 
 variable (X) in
 def max_𝓓 : 𝓓 X where
@@ -1643,7 +1615,7 @@ def max_𝓓 : 𝓓 X where
 def 𝓓.coe (z : 𝓓 X) : Set X := I3 z.hk z.y
 
 variable (X) in
-def forget_map (x : 𝓓 X) : (k : Set.Icc (-S:ℤ) S) × (Yk X k) := ⟨⟨x.k,And.intro x.hk x.hk_max⟩,x.y⟩
+def forget_map (x : 𝓓 X) : (k : Set.Icc (-S : ℤ) S) × (Yk X k) := ⟨⟨x.k,And.intro x.hk x.hk_max⟩,x.y⟩
 
 lemma forget_map_inj : Function.Injective (forget_map X) := by
   intro x1 x2 h
@@ -1653,7 +1625,7 @@ lemma forget_map_inj : Function.Injective (forget_map X) := by
 
 variable (X) in
 lemma 𝓓_finite : Finite (𝓓 X) := by
-  have foo (k : Set.Icc (-S : ℤ) S): Finite (Yk X k) :=
+  have _ (k : Set.Icc (-S : ℤ) S) : Finite (Yk X k) :=
     Set.Finite.to_subtype (Yk_finite k.property.left)
   apply Finite.of_injective (forget_map X) forget_map_inj
 
@@ -1670,7 +1642,7 @@ def grid_existence : GridStructure X D κ S o where
   inj := fun ⟨k,hk,hk_max,y,hsub⟩ ⟨k2,hk2,hk2_max,y2,hsub'⟩ h => by
     simp only [Prod.mk.injEq, 𝓓.mk.injEq] at h hsub hsub' ⊢
     dsimp [𝓓.coe] at h hsub hsub'
-    obtain ⟨hl,hr⟩ := h
+    obtain ⟨hl, hr⟩ := h
     subst hr
     simp only [heq_eq_eq, true_and]
     apply I3_prop_1 hk2 (x := y)
@@ -1702,7 +1674,7 @@ def grid_existence : GridStructure X D κ S o where
     have : i.coe ⊆ ⋃ y', I3 hl.left y' := cover_by_cubes hl.left hl.right.le i.hk i.y
     specialize this hx
     simp only [mem_iUnion] at this
-    obtain ⟨y',hy'⟩ := this
+    obtain ⟨y', hy'⟩ := this
     have : I3 (hl.left) y' ⊆ (max_𝓓 X).coe := by
       apply dyadic_property
       · exact hl.right.le.trans i.hk_max
@@ -1738,12 +1710,12 @@ def grid_existence : GridStructure X D κ S o where
       exact defaultD_pos a
     else
       trans volume.real i.coe
-      · apply measureReal_mono (fun x hx => hx.left) (LT.lt.ne (lt_of_le_of_lt
-          (volume.mono (I3_prop_3_2 i.hk i.y)) _))
+      · apply measureReal_mono (fun x hx => hx.left) <|
+          volume.mono (I3_prop_3_2 i.hk i.y) |>.trans_lt _ |>.ne
         simp only [OuterMeasure.measureOf_eq_coe, Measure.coe_toOuterMeasure]
         exact measure_ball_lt_top
       apply le_mul_of_one_le_left (measureReal_nonneg)
-      have : 1 ≤ (t:ℝ) ^κ := Real.one_le_rpow (le_of_not_gt ht') κ_nonneg
+      have : 1 ≤ (t : ℝ) ^ κ := Real.one_le_rpow (le_of_not_gt ht') κ_nonneg
       linarith
   coeGrid_measurable {i} := I3_measurableSet i.hk i.y
 

--- a/Carleson/TileStructure.lean
+++ b/Carleson/TileStructure.lean
@@ -335,15 +335,14 @@ lemma subset_lowerCubes {𝔓' : Set (𝔓 X)} : 𝔓' ⊆ lowerCubes 𝔓' := f
 /-- This density is defined to live in `ℝ≥0∞`. Use `ENNReal.toReal` to get a real number. -/
 def dens₁ (𝔓' : Set (𝔓 X)) : ℝ≥0∞ :=
   ⨆ (p' ∈ 𝔓') (l ≥ (2 : ℝ≥0)), l ^ (-a : ℝ) *
-  ⨆ (p ∈ lowerCubes 𝔓') (_h2 : smul l p' ≤ smul l p),
-  volume (E₂ l p) / volume (𝓘 p : Set X)
+    ⨆ (p ∈ lowerCubes 𝔓') (_h2 : smul l p' ≤ smul l p),
+      volume (E₂ l p) / volume (𝓘 p : Set X)
 
 lemma dens₁_mono {𝔓₁ 𝔓₂ : Set (𝔓 X)} (h : 𝔓₁ ⊆ 𝔓₂) :
     dens₁ 𝔓₁ ≤ dens₁ 𝔓₂ := by
   simp only [dens₁, iSup_le_iff]
   intro p hp r hr
-  refine le_iSup₂_of_le p (h hp) ?_
-  apply ENNReal.mul_le_of_le_div'
+  apply le_iSup₂_of_le p (h hp) <| ENNReal.mul_le_of_le_div' ?_
   simp only [iSup_le_iff]
   intro q hq hqr
   rw [ENNReal.le_div_iff_mul_le (by left; simp)]
@@ -358,7 +357,7 @@ lemma dens₁_mono {𝔓₁ 𝔓₂ : Set (𝔓 X)} (h : 𝔓₁ ⊆ 𝔓₂) :
 /-- This density is defined to live in `ℝ≥0∞`. Use `ENNReal.toReal` to get a real number. -/
 def dens₂ (𝔓' : Set (𝔓 X)) : ℝ≥0∞ :=
   ⨆ (p ∈ 𝔓') (r ≥ 4 * (D ^ 𝔰 p : ℝ)),
-  volume (F ∩ ball (𝔠 p) r) / volume (ball (𝔠 p) r)
+    volume (F ∩ ball (𝔠 p) r) / volume (ball (𝔠 p) r)
 
 lemma le_dens₂ (𝔓' : Set (𝔓 X)) {p : 𝔓 X} (hp : p ∈ 𝔓') {r : ℝ} (hr : r ≥ 4 * (D ^ 𝔰 p : ℝ)) :
     volume (F ∩ ball (𝔠 p) r) / volume (ball (𝔠 p) r) ≤ dens₂ 𝔓' :=
@@ -375,19 +374,16 @@ lemma dens₁_le_one {𝔓' : Set (𝔓 X)} : dens₁ 𝔓' ≤ 1 := by
   intros i _ j hj
   gcongr
   · calc
-    (j : ℝ≥0∞) ^ (-(a : ℝ)) ≤ 2 ^ (-(a : ℝ)) := by
-      apply ENNReal.rpow_le_rpow_of_nonpos
-      · simp_rw [neg_nonpos, Nat.cast_nonneg']
-      exact_mod_cast hj
+    (j : ℝ≥0∞) ^ (-(a : ℝ)) ≤ 2 ^ (-(a : ℝ)) :=
+      ENNReal.rpow_le_rpow_of_nonpos (by simp_rw [neg_nonpos, Nat.cast_nonneg'])
+        (by exact_mod_cast hj)
     _ ≤ 2 ^ (0 : ℝ) :=
       ENNReal.rpow_le_rpow_of_exponent_le (by norm_num) (neg_nonpos.mpr (Nat.cast_nonneg' _))
     _ = 1 := by norm_num
   simp only [iSup_le_iff, and_imp]
   intros i' _ _ _ _
-  calc
-  volume (E₂ j i') / volume (𝓘 i' : Set X) ≤ volume (𝓘 i' : Set X) / volume (𝓘 i' : Set X) := by
-    gcongr
-    apply E₂_subset
+  calc volume (E₂ j i') / volume (𝓘 i' : Set X)
+  _ ≤ volume (𝓘 i' : Set X) / volume (𝓘 i' : Set X) := by gcongr; apply E₂_subset
   _ ≤ 1 := ENNReal.div_self_le_one
 
 lemma volume_E₂_le_dens₁_mul_volume {𝔓' : Set (𝔓 X)} (mp : p ∈ lowerCubes 𝔓') (mp' : p' ∈ 𝔓')
@@ -396,7 +392,7 @@ lemma volume_E₂_le_dens₁_mul_volume {𝔓' : Set (𝔓 X)} (mp : p ∈ lower
   have vpos : volume (𝓘 p : Set X) ≠ 0 := (volume_coeGrid_pos (defaultD_pos' a)).ne'
   rw [← ENNReal.div_le_iff_le_mul (.inl vpos) (.inl volume_coeGrid_lt_top.ne),
     ← ENNReal.rpow_natCast, ← neg_neg (a : ℝ), ENNReal.rpow_neg, ← ENNReal.div_eq_inv_mul]
-  have plt : (l : ℝ≥0∞) ^ (-(a : ℝ)) ≠ ⊤ := by aesop
+  have plt : (l : ℝ≥0∞) ^ (-(a : ℝ)) ≠ ⊤ := by finiteness
   rw [ENNReal.le_div_iff_mul_le (by simp) (.inl plt), mul_comm, dens₁]
   refine le_iSup₂_of_le p' mp' (le_iSup₂_of_le l hl ?_); gcongr
   exact le_iSup₂_of_le p mp (le_iSup_of_le sp le_rfl)
@@ -423,7 +419,7 @@ lemma stackSize_inter_add_stackSize_sdiff :
   stackSize_setOf_add_stackSize_setOf_not
 
 lemma stackSize_sdiff_eq (x : X) :
-  stackSize (C \ C') x = stackSize C x - stackSize (C ∩ C') x := by
+    stackSize (C \ C') x = stackSize C x - stackSize (C ∩ C') x := by
   exact Nat.eq_sub_of_add_eq' stackSize_inter_add_stackSize_sdiff
 
 lemma stackSize_congr (h : ∀ p ∈ C, x ∈ (𝓘 p : Set X) ↔ x' ∈ (𝓘 p : Set X)) :
@@ -439,8 +435,8 @@ lemma stackSize_mono (h : C ⊆ C') : stackSize C x ≤ stackSize C' x := by
 
 open scoped Classical in
 -- Simplify the cast of `stackSize C x` from `ℕ` to `ℝ`
-lemma stackSize_real (C : Set (𝔓 X)) (x : X) : (stackSize C x : ℝ) =
-    ∑ p with p ∈ C, (𝓘 p : Set X).indicator (1 : X → ℝ) x := by
+lemma stackSize_real (C : Set (𝔓 X)) (x : X) :
+    (stackSize C x : ℝ) = ∑ p with p ∈ C, (𝓘 p : Set X).indicator (1 : X → ℝ) x := by
   rw [stackSize, Nat.cast_sum]
   refine Finset.sum_congr rfl (fun u _ ↦ ?_)
   by_cases hx : x ∈ (𝓘 u : Set X) <;> simp [hx]
@@ -468,7 +464,7 @@ lemma stackSize_le_one_of_pairwiseDisjoint {C : Set (𝔓 X)} {x : X}
     linarith
 
 lemma eq_empty_of_forall_stackSize_zero (s : Set (𝔓 X)) :
-  (∀ x, stackSize s x = 0) → s = ∅ := by
+    (∀ x, stackSize s x = 0) → s = ∅ := by
   intro h
   dsimp [stackSize] at h
   simp only [Finset.sum_eq_zero_iff, Finset.mem_filter_univ,

--- a/Carleson/ToMathlib/Topology/Algebra/Support.lean
+++ b/Carleson/ToMathlib/Topology/Algebra/Support.lean
@@ -1,0 +1,14 @@
+import Mathlib.Topology.Algebra.Support
+
+section DivisionMonoid
+
+variable {α β : Type*} [TopologicalSpace α] [DivisionMonoid β]
+variable {f f' : α → β}
+
+/- PR after HasCompactMulSupport.inv' -/
+
+@[to_additive]
+theorem HasCompactMulSupport.div (hf : HasCompactMulSupport f) (hf' : HasCompactMulSupport f') :
+    HasCompactMulSupport (f / f') := hf.comp₂_left hf' (div_one 1)
+
+end DivisionMonoid


### PR DESCRIPTION
More cleanup, this time the base folder. Main focus was to ensure all ToMathlib elements were caught, and to fix (whitespace) style of the statements. In some files the proofs can be further optimized as well but IMO that does not have the priority at this moment.

The reason to omit `Psi.lean` is because it contains a lot of stuff formalized using `norm` instead of `enorm` and it might be better to refactor into `enorm` entirely (as the `enorm` versions are used downstream).
And that seemed like a task better put in a separate PR.