### PR TITLE
chore: complete the bump to 4.29.0

### DIFF
--- a/Carleson/Antichain/AntichainOperator.lean
+++ b/Carleson/Antichain/AntichainOperator.lean
@@ -276,7 +276,7 @@ lemma dens1_antichain_sq (h𝔄 : IsAntichain (· ≤ ·) 𝔄)
           hg.enorm.aemeasurable).restrict
       congr 1; simp_rw [← mul_assoc]
       rw [← lintegral_biUnion_finset _ (fun _ _ ↦ measurableSet_E)]
-      · simp
+      · simp only [Finset.mem_filter, Finset.mem_univ, true_and]
       · intro p mp p' mp' hn
         simp_rw [Finset.coe_filter, Finset.mem_univ, true_and, setOf_mem_eq] at mp mp'
         exact not_not.mp ((tile_disjointness h𝔄 mp mp').mt hn)

--- a/Carleson/Antichain/AntichainTileCount.lean
+++ b/Carleson/Antichain/AntichainTileCount.lean
@@ -200,7 +200,7 @@ lemma stack_density (𝔄 : Set (𝔓 X)) (ϑ : Θ X) (N : ℕ) (L : Grid X) :
           · refine le_iSup₂_of_le p (mem_lowerCubes.mpr ⟨p, hp, le_refl _⟩) ?_
             refine le_iSup_of_le (le_refl _) ?_
             gcongr
-            · simp only [NNReal.coe_ofNat, subset_refl]
+            · simp
             · rw [hIL]
     let p : 𝔓 X := h𝔄'.choose
     have hp : p ∈ 𝔄' := h𝔄'.choose_spec
@@ -254,10 +254,9 @@ lemma stack_density (𝔄 : Set (𝔓 X)) (ϑ : Θ X) (N : ℕ) (L : Grid X) :
         contrapose! hcap
         refine ⟨hcap, ⟨(hex q hq).choose, ⟨(hex q hq).choose_spec.1, ?_⟩⟩⟩
         constructor <;> simp only [mem_ball]
-        · rw [dist_comm (α := WithFunctionDistance (𝔠 p) (D ^ 𝔰 p / 4)) _ (𝒬 q)]
+        · rw [dist_comm]
           exact (hex q hq).choose_spec.2
-        · rw [dist_comm (α := WithFunctionDistance (𝔠 p) (D ^ 𝔰 p / 4)) _ (𝒬 q')]
-          rw [←hfq, hf, hfq']
+        · rw [dist_comm, ← hfq, hf, hfq']
           exact (hex q' hq').choose_spec.2
     -- Ineq. 6.3.16
     calc ∑ p ∈ (𝔄_aux 𝔄 ϑ N).toFinset with 𝓘 p = L, volume (E p ∩ G)

--- a/Carleson/Antichain/AntichainTileCount.lean
+++ b/Carleson/Antichain/AntichainTileCount.lean
@@ -183,11 +183,9 @@ lemma stack_density (𝔄 : Set (𝔓 X)) (ϑ : Θ X) (N : ℕ) (L : Grid X) :
       calc volume (E p ∩ G)
         _ ≤ volume (E₂ 2 p) := by
           gcongr; intro x hx
-          have hQ : Q x ∈ ball_(p) (𝒬 p) 1 := subset_cball hx.1.2.1
-          simp only [E₂, TileLike.toSet, smul_fst, smul_snd, mem_inter_iff, mem_preimage]
           refine ⟨⟨hx.1.1, hx.2⟩, ?_⟩
-          apply @ball_subset_ball (WithFunctionDistance (𝔠 p) (↑D ^ 𝔰 p / 4)) instPseudoMetricSpaceWithFunctionDistance _ 1 2 (by norm_num)
-          exact hQ
+          apply @ball_subset_ball _ instPseudoMetricSpaceWithFunctionDistance _ 1 2 (by norm_num)
+          exact subset_cball hx.1.2.1
         _ ≤ 2^a * dens₁ (𝔄' : Set (𝔓 X)) * volume (L : Set X) := by
           have hIL : 𝓘 p = L := by simp_rw [← hp.2]
           have h2a : ((2 : ℝ≥0∞) ^ a)⁻¹ = 2^(-(a : ℤ)) := by

--- a/Carleson/Antichain/AntichainTileCount.lean
+++ b/Carleson/Antichain/AntichainTileCount.lean
@@ -143,7 +143,8 @@ open Classical in
 lemma biUnion_𝔄_aux {𝔄 : Set (𝔓 X)} {ϑ : Θ X} :
     ∃ N, (Finset.range N).biUnion (fun N ↦ (𝔄_aux 𝔄 ϑ N).toFinset) = 𝔄.toFinset := by
   rcases 𝔄.eq_empty_or_nonempty with rfl | h𝔄
-  · use 0; simp
+  · use 0
+    simp only [Finset.range_zero, Finset.biUnion_empty, Set.toFinset_empty]
   · let f (p : 𝔓 X) := ⌊Real.logb 2 (1 + dist_(p) (𝒬 p) ϑ)⌋₊
     obtain ⟨p₀, mp₀, hp₀⟩ := 𝔄.toFinset.exists_max_image f (Aesop.toFinset_nonempty_of_nonempty h𝔄)
     use f p₀ + 1; ext p
@@ -183,8 +184,10 @@ lemma stack_density (𝔄 : Set (𝔓 X)) (ϑ : Θ X) (N : ℕ) (L : Grid X) :
         _ ≤ volume (E₂ 2 p) := by
           gcongr; intro x hx
           have hQ : Q x ∈ ball_(p) (𝒬 p) 1 := subset_cball hx.1.2.1
-          simp only [E₂, TileLike.toSet, smul_fst, smul_snd, mem_inter_iff, mem_preimage, mem_ball]
-          exact ⟨⟨hx.1.1, hx.2⟩, lt_trans hQ one_lt_two⟩
+          simp only [E₂, TileLike.toSet, smul_fst, smul_snd, mem_inter_iff, mem_preimage]
+          refine ⟨⟨hx.1.1, hx.2⟩, ?_⟩
+          apply @ball_subset_ball (WithFunctionDistance (𝔠 p) (↑D ^ 𝔰 p / 4)) instPseudoMetricSpaceWithFunctionDistance _ 1 2 (by norm_num)
+          exact hQ
         _ ≤ 2^a * dens₁ (𝔄' : Set (𝔓 X)) * volume (L : Set X) := by
           have hIL : 𝓘 p = L := by simp_rw [← hp.2]
           have h2a : ((2 : ℝ≥0∞) ^ a)⁻¹ = 2^(-(a : ℤ)) := by
@@ -192,31 +195,15 @@ lemma stack_density (𝔄 : Set (𝔓 X)) (ϑ : Θ X) (N : ℕ) (L : Grid X) :
           rw [← ENNReal.div_le_iff (ne_of_gt (hIL ▸ volume_coeGrid_pos (defaultD_pos a)))
             (by finiteness), ← ENNReal.div_le_iff' (NeZero.ne (2 ^ a)) (by finiteness),
             ENNReal.div_eq_inv_mul, h2a, dens₁]
-          refine le_iSup₂_of_le p hp ?_--fun c hc ↦ ?_
-          rw [WithTop.le_iff_forall]
-          intro c hc
-          have h2c : 2 ^ (-(a : ℤ)) * (volume (E₂ 2 p) / volume (L : Set X)) ≤ (c : WithTop ℝ≥0) := by
-            simp only [← hc]
-            refine le_iSup₂_of_le 2 (le_refl _) ?_
-            rw [WithTop.le_iff_forall]
-            intro d hd
-            have h2d : 2 ^ (-(a : ℤ)) * (volume (E₂ 2 p) / volume (L : Set X)) ≤
-                (d : WithTop ℝ≥0)  := by
-              rw [← hd]
-              gcongr
-              · norm_cast
-              · refine le_iSup₂_of_le p (mem_lowerCubes.mpr ⟨p, hp, le_refl _⟩) ?_
-                rw [WithTop.le_iff_forall]
-                intro r hr
-                have h2r : (volume (E₂ 2 p) / volume (L : Set X)) ≤ (r : WithTop ℝ≥0)  := by
-                  rw [← hr]
-                  refine le_iSup_of_le (le_refl _) ?_
-                  gcongr
-                  · simp only [NNReal.coe_ofNat, subset_refl]
-                  · rw [hIL]
-                exact ENNReal.le_coe_iff.mp h2r
-            exact ENNReal.le_coe_iff.mp h2d
-          exact ENNReal.le_coe_iff.mp h2c
+          refine le_iSup₂_of_le p hp ?_
+          refine le_iSup₂_of_le 2 le_rfl ?_
+          gcongr
+          · norm_cast
+          · refine le_iSup₂_of_le p (mem_lowerCubes.mpr ⟨p, hp, le_refl _⟩) ?_
+            refine le_iSup_of_le (le_refl _) ?_
+            gcongr
+            · simp only [NNReal.coe_ofNat, subset_refl]
+            · rw [hIL]
     let p : 𝔓 X := h𝔄'.choose
     have hp : p ∈ 𝔄' := h𝔄'.choose_spec
     -- Ineq. 6.3.19
@@ -268,12 +255,12 @@ lemma stack_density (𝔄 : Set (𝔓 X)) (ϑ : Θ X) (N : ℕ) (L : Grid X) :
         specialize hcap q q' hq hq'
         contrapose! hcap
         refine ⟨hcap, ⟨(hex q hq).choose, ⟨(hex q hq).choose_spec.1, ?_⟩⟩⟩
-        simp only [mem_ball, mem_inter_iff]
-        rw [dist_comm (α := WithFunctionDistance (𝔠 p) ((D : ℝ) ^ 𝔰 p / 4)) _ (𝒬 q),
-          dist_comm (α := WithFunctionDistance (𝔠 p) ((D : ℝ) ^ 𝔰 p / 4)) _ (𝒬 q')]
-        use (hex q hq).choose_spec.2
-        rw [← hfq, hf, hfq']
-        exact (hex q' hq').choose_spec.2
+        constructor <;> simp only [mem_ball]
+        · rw [dist_comm (α := WithFunctionDistance (𝔠 p) (D ^ 𝔰 p / 4)) _ (𝒬 q)]
+          exact (hex q hq).choose_spec.2
+        · rw [dist_comm (α := WithFunctionDistance (𝔠 p) (D ^ 𝔰 p / 4)) _ (𝒬 q')]
+          rw [←hfq, hf, hfq']
+          exact (hex q' hq').choose_spec.2
     -- Ineq. 6.3.16
     calc ∑ p ∈ (𝔄_aux 𝔄 ϑ N).toFinset with 𝓘 p = L, volume (E p ∩ G)
       _ = ∑ p ∈ 𝔄'.toFinset, volume (E p ∩ G) := heq
@@ -295,7 +282,12 @@ lemma stack_density (𝔄 : Set (𝔓 X)) (ϑ : Θ X) (N : ℕ) (L : Grid X) :
             _ ⊆ 𝔄 := sep_subset _ _
         gcongr
         exact dens₁_mono hss
-  · simp [heq, Set.not_nonempty_iff_eq_empty.mp h𝔄']
+  · rw [heq]
+    have : 𝔄'.toFinset = ∅ := by
+      rw [Set.toFinset_eq_empty]
+      exact not_nonempty_iff_eq_empty.mp h𝔄'
+    rw [this, Finset.sum_empty]
+    exact zero_le _
 
 open Classical in
 /-- We prove inclusion 6.3.24 for every `p ∈ (𝔄_aux 𝔄 ϑ N)` with `𝔰 p' < 𝔰 p` such that
@@ -411,7 +403,7 @@ private lemma 𝔄_min_sum_le :
           simp only [𝓛_min, Subtype.exists, exists_prop, toFinset_setOf, Finset.mem_filter,
             Finset.mem_univ, true_and, and_true]
           exact ⟨⟨p, (mem_toFinset.mp hp), rfl⟩, fun _ hL ↦ hL.2.symm⟩
-        simp [h1]
+        simp only [Finset.sum_const, h1, one_smul]
       · intro L p
         refine ⟨fun ⟨hL, hp⟩ ↦ ?_, fun ⟨hL, hp⟩ ↦ ?_⟩
         · simp only [𝔄_min, mem_setOf_eq, mem_toFinset,Finset.mem_filter] at hL hp ⊢
@@ -456,7 +448,7 @@ lemma I_p_subset_union_L (p : 𝔄' 𝔄 ϑ N) : (𝓘 (p : 𝔓 X) : Set X) ⊆
       intro x hx
       -- Apply (2.0.7)
       obtain ⟨I, hI, hxI⟩ := Grid.exists_containing_subcube (i := 𝓘 (p : 𝔓 X)) (-S)
-        (by simp [mem_Icc, le_refl, scale_mem_Icc.1]) hx
+        (by simp [mem_Icc, scale_mem_Icc.1]) hx
       have hsI : s I ≤ s (𝓘 (p : 𝔓 X)) := hI ▸ scale_mem_Icc.1
       simp only [Grid.le_def, mem_setOf_eq, mem_iUnion, exists_prop]
       exact ⟨I, ⟨hI, Or.resolve_right (GridStructure.fundamental_dyadic' hsI)
@@ -505,7 +497,10 @@ lemma union_L'_eq_union_I_p : ⋃ (L ∈ 𝓛' 𝔄 ϑ N), L = ⋃ (p ∈ 𝔄' 
   obtain ⟨L, hL, hLx⟩ := hx
   obtain ⟨M, lM, maxM⟩ := (𝓛 𝔄 ϑ N).toFinset.exists_le_maximal (mem_toFinset.mpr hL)
   refine ⟨M, ?_, lM.1 hLx⟩
-  simpa [𝓛', mem_setOf_eq, mem_toFinset] using maxM
+  constructor
+  · exact mem_toFinset.mp maxM.1
+  · intro y hy hy'
+    exact maxM.2 (mem_toFinset.mpr hy) hy'
 
 variable {𝔄 ϑ N}
 
@@ -570,7 +565,7 @@ lemma exists_larger_grid : ∃ (L' : Grid X), L ≤ L' ∧ s L' = s L + 1 := by
   have hSL : SL.Nonempty := SL_nonempty hL
   set q := p' hL
   have hq' : q ∈ SL := ((Finset.exists_minimalFor 𝔰 SL (SL_nonempty hL)).choose_spec).1
-  simp only [defaultA, defaultD.eq_1, defaultκ.eq_1, Grid.le_def, Antichain.SL, SL] at hq'
+  simp only [defaultA, defaultD.eq_1, defaultκ.eq_1, Antichain.SL, SL] at hq'
   have hqL : ¬ 𝓘 q ≤ L := not_I_p'_le_L hL
   simp only [Grid.le_def, not_and_or, not_le] at hqL
   have : s L < 𝔰 q  := s_L_le_s_p' hL
@@ -592,7 +587,8 @@ private lemma L'_not_mem : ¬ L' hL ∈ 𝓛 𝔄 ϑ N := by
   have hL2 := hL
   by_contra h
   have := hL2.2 h (L_le_L' hL)
-  simp [Grid.le_def, s_L'_eq] at this
+  simp only [Grid.le_def, s_L'_eq] at this
+  linarith
 
 private lemma L'_le_I_p' : L' hL ≤ 𝓘 (p' hL : 𝔓 X) := by
   have hle : s (L' hL) ≤ s (𝓘 (p' hL)) := by rw [s_L'_eq]; exact s_L_le_s_p' hL
@@ -666,13 +662,12 @@ private lemma eq_6_3_35 : ϑ.val ∈ ball_(p'' hL) (𝒬 (p'' hL)) (2 ^ (N + 1))
 
 -- Eq. 6.3.37
 private lemma eq_6_3_37 : ϑ.val ∈ ball_(pΘ hL) (𝒬 (pΘ hL)) (2 ^ (N + 1)) := by
-  simp only [pΘ]
-  split_ifs with h
-  · convert eq_6_3_35 hL <;> rw [if_pos h]
+  by_cases h : 𝓘 (p'' hL) = L' hL
+  · rw [pΘ, if_pos h]
+    exact eq_6_3_35 hL
   · have h1 : (1 : ℝ) ≤ (2 ^ (N + 1)) := by exact_mod_cast Nat.one_le_two_pow
     apply ball_subset_ball (α := WithFunctionDistance _ _) h1
     convert subset_cball (theta_mem_Omega_pΘ hL h)
-    simp only [pΘ, if_neg h]
 
 -- Ineq. 6.3.36
 private lemma ineq_6_3_36 : smul (2^(N + 3)) (p'' hL) ≤ smul (2^(N + 3)) (pΘ hL) := by
@@ -681,9 +676,9 @@ private lemma ineq_6_3_36 : smul (2^(N + 3)) (p'' hL) ≤ smul (2^(N + 3)) (pΘ 
     rw [heq']
   · have hpθ : ϑ.val ∈ ball_(pΘ hL) (𝒬 (pΘ hL)) (2 ^ (N + 1)) := eq_6_3_37 hL
     have hp'' : ϑ.val ∈ ball_(p'' hL) (𝒬 (p'' hL)) (2 ^ (N + 1)) := eq_6_3_35 hL
-    simp only [mem_ball] at hpθ hp''
-    rw [dist_comm (α := WithFunctionDistance _ _)] at hpθ hp''
-    apply tile_reach (le_of_lt hp'') (le_of_lt hpθ)
+    apply tile_reach (N := N + 1) (ϑ := ↑ϑ)
+    · rw [dist_comm]; exact le_of_lt hp''
+    · rw [dist_comm]; exact le_of_lt hpθ
     · rw [I_pΘ_eq_L']; exact I_p''_le_L' hL
     · simp only [𝔰, I_pΘ_eq_L']
       exact (Grid.lt_def.mp (lt_of_le_of_ne (I_p''_le_L' hL) heq)).2
@@ -726,7 +721,8 @@ private lemma ineq_6_3_39 (h𝔄 : IsAntichain (· ≤ ·) 𝔄) :
           Subtype.exists, exists_and_left, exists_prop, and_imp, Subtype.forall, mem_setOf_eq,
           forall_exists_index] at hL2
         by_cases hp' : 𝓘 p = L' hL
-        · simp [if_pos hp']
+        · rw [if_pos hp']
+          exact zero_le _
         · have hs : 𝔰 (pΘ hL) < 𝔰 p := by
             have hpL' : (L' hL : Set X)  ∩ (𝓘 p : Set X) ≠ ∅ := by
               simp only [← Set.nonempty_iff_ne_empty] at hpL ⊢

--- a/Carleson/Antichain/Basic.lean
+++ b/Carleson/Antichain/Basic.lean
@@ -198,7 +198,7 @@ lemma maximal_bound_antichain {𝔄 : Set (𝔓 X)} (h𝔄 : IsAntichain (· ≤
       refine lintegral_mono fun y ↦ ?_
       rw [enorm_mul]; gcongr
       by_cases hy : Ks (𝔰 p.1) x y = 0
-      · simp [hy]
+      · simp only [hy, enorm_zero, zero_le]
       · exact norm_Ks_le' _ hxE hy -- Composition of ineq. 6.1.6, 6.1.7, 6.1.8
     _ = 2 ^ (5 * a + (𝕔 + 1) * a ^ 3 + a) *
         ⨍⁻ y in ball (𝔠 p.1) (8 * D ^ 𝔰 p.1), ‖f y‖ₑ ∂volume := by

--- a/Carleson/Antichain/TileCorrelation.lean
+++ b/Carleson/Antichain/TileCorrelation.lean
@@ -397,11 +397,8 @@ lemma I12_le (ha : 4 ≤ a) {p p' : 𝔓 X} (hle : 𝔰 p' ≤ 𝔰 p) {g : X �
   rw [← ENNReal.rpow_le_rpow_iff_of_neg hneg] at h623
   have h0 : ((2 : ℝ≥0∞) ^ (8 * a)) ^ (-(2 * a ^ 2 + a ^ 3 : ℝ)⁻¹) ≠ 0 := by simp
   have h210 : (2 : ℝ≥0∞) ^ (1 : ℝ) ≠ 0 := by rw [ENNReal.rpow_one]; exact two_ne_zero
-  rw [
-    ENNReal.mul_rpow_of_ne_top (by finiteness) (by finiteness),
-    mul_comm,
-    ← ENNReal.le_div_iff_mul_le (.inl h0) (.inl (by finiteness))
-  ] at h623
+  rw [ENNReal.mul_rpow_of_ne_top (by finiteness) (by finiteness), mul_comm,
+    ← ENNReal.le_div_iff_mul_le (.inl h0) (.inl (by finiteness))] at h623
   apply h623.trans
   rw [ENNReal.div_eq_inv_mul, mul_comm _ 2]
   gcongr

--- a/Carleson/Antichain/TileCorrelation.lean
+++ b/Carleson/Antichain/TileCorrelation.lean
@@ -313,9 +313,7 @@ open GridStructure
 lemma complex_exp_lintegral {p : 𝔓 X} {g : X → ℂ} (y : X) :
     conj (∫ y1 in E p, conj (Ks (𝔰 p) y1 y) * exp (I * (Q y1 y1 - Q y1 y)) * g y1) =
     ∫ y1 in E p, Ks (𝔰 p) y1 y * exp (I * (-Q y1 y1 + Q y1 y)) * conj (g y1) := by
-  rw [show conj (∫ y1 in E p, conj (Ks (𝔰 p) y1 y) * exp (I * (Q y1 y1 - Q y1 y)) * g y1) =
-    ∫ y1 in E p, conj (conj (Ks (𝔰 p) y1 y) * exp (I * (Q y1 y1 - Q y1 y)) * g y1) from
-    integral_conj.symm]
+  rw [show conj (∫ _ in _, _) = ∫ y1 in _, conj (_ * g y1) from integral_conj.symm]
   simp only [map_mul, RingHomCompTriple.comp_apply, RingHom.id_apply]
   congr; ext x; rw [← exp_conj]; congr
   simp only [map_mul, conj_I, map_sub, conj_ofReal]

--- a/Carleson/Antichain/TileCorrelation.lean
+++ b/Carleson/Antichain/TileCorrelation.lean
@@ -313,7 +313,7 @@ open GridStructure
 lemma complex_exp_lintegral {p : 𝔓 X} {g : X → ℂ} (y : X) :
     conj (∫ y1 in E p, conj (Ks (𝔰 p) y1 y) * exp (I * (Q y1 y1 - Q y1 y)) * g y1) =
     ∫ y1 in E p, Ks (𝔰 p) y1 y * exp (I * (-Q y1 y1 + Q y1 y)) * conj (g y1) := by
-  rw [show conj (∫ _ in _, _) = ∫ y1 in _, conj (_ * g y1) from integral_conj.symm]
+  erw [← integral_conj]
   simp only [map_mul, RingHomCompTriple.comp_apply, RingHom.id_apply]
   congr; ext x; rw [← exp_conj]; congr
   simp only [map_mul, conj_I, map_sub, conj_ofReal]
@@ -604,17 +604,12 @@ lemma bound_6_2_26_aux {p p' : 𝔓 X} {g : X → ℂ} :
     congr; ext y
     simp_rw [mul_add I, mul_sub I, sub_eq_add_neg, exp_add]
     ring_nf
-  have hx1 : ‖exp (I * Q x.1 x.1)‖ₑ = 1 := enorm_exp_I_mul_ofReal _
-  have hx2 : ‖exp (I * -Q x.2 x.2)‖ₑ = 1 := mod_cast enorm_exp_I_mul_ofReal _
   simp only [I12, enorm_mul]
-  have key2 : ∫ (y : X), conj (Ks (𝔰 p') x.1 y) * exp (I * (Q x.1 x.1 - Q x.1 y)) * g x.1 *
-      (Ks (𝔰 p) x.2 y * exp (I * (-Q x.2 x.2 + Q x.2 y)) * conj (g x.2)) =
-      (∫ (y : X), conj (Ks (𝔰 p') x.1 y) * exp (I * -Q x.1 y) *
-        (Ks (𝔰 p) x.2 y * exp (I * Q x.2 y))) *
-      (exp (I * Q x.1 x.1) * exp (I * -Q x.2 x.2) * g x.1 * conj (g x.2)) := by
-    rw [heq]; exact integral_mul_const _ _
-  rw [key2, enorm_mul, enorm_mul, enorm_mul, enorm_mul, hx1, hx2, RCLike.enorm_conj,
-      one_mul, one_mul, ← mul_assoc]
+  erw [
+    heq, integral_mul_const, enorm_mul, enorm_mul, enorm_mul, enorm_mul, enorm_exp_I_mul_ofReal,
+    show ‖exp (_)‖ₑ = 1 from mod_cast enorm_exp_I_mul_ofReal _,
+    RCLike.enorm_conj, one_mul, one_mul, ← mul_assoc
+  ]
   simp only [mul_neg, correlation]
   congr; ext y
   rw [mul_add I, exp_add]
@@ -629,27 +624,15 @@ lemma bound_6_2_26 {p p' : 𝔓 X} {g : X → ℂ}
       ∫ y1 in E p, Ks (𝔰 p) y1 y * exp (I * (-Q y1 y1 + Q y1 y)) * conj (g y1) :=
     complex_exp_lintegral
   simp_rw [adjointCarleson, haux]
-  have key : ∀ y, (∫ y1 in E p', conj (Ks (𝔰 p') y1 y) * exp (I * (Q y1 y1 - Q y1 y)) * g y1) *
-      (∫ y1 in E p, Ks (𝔰 p) y1 y * exp (I * (-Q y1 y1 + Q y1 y)) * conj (g y1)) =
-      ∫ z in E p' ×ˢ E p,
-        conj (Ks (𝔰 p') z.1 y) * exp (I * (Q z.1 z.1 - Q z.1 y)) * g z.1 *
-        (Ks (𝔰 p) z.2 y * exp (I * (-Q z.2 z.2 + Q z.2 y)) * conj (g z.2)) := fun y =>
-    (setIntegral_prod_mul
-      (fun z1 ↦ conj (Ks (𝔰 p') z1 y) * exp (I * (Q z1 z1 - Q z1 y)) * g z1)
-      (fun z2 ↦ Ks (𝔰 p) z2 y * exp (I * (-Q z2 z2 + Q z2 y)) * conj (g z2))
-      (E p') (E p)).symm
-  simp_rw [key]; rw [← setIntegral_univ]
+  simp_rw [show ∀ y, (∫ y1 in E p', conj (Ks (𝔰 p') y1 y) * exp (I * (Q y1 y1 - Q y1 y)) * g y1) * (∫ y1 in E p, Ks (𝔰 p) y1 y * exp (I * (-Q y1 y1 + Q y1 y)) * conj (g y1)) = _ from fun y => (setIntegral_prod_mul ..).symm]
+  rw [← setIntegral_univ]
   let f := fun (x, z1, z2) ↦
     conj (Ks (𝔰 p') z1 x) * exp (I * (Q z1 z1 - Q z1 x)) * g z1 *
     (Ks (𝔰 p) z2 x * exp (I * (-Q z2 z2 + Q z2 x)) * conj (g z2))
   have hf : IntegrableOn f (univ ×ˢ E p' ×ˢ E p) (volume.prod (volume.prod volume)) :=
     (boundedCompactSupport_aux_6_2_26 hg hg1).integrable.integrableOn
-  have hf' : IntegrableOn (f ·.swap) ((E p' ×ˢ E p) ×ˢ univ) ((volume.prod volume).prod volume) :=
-    hf.swap
-  change ‖∫ (x : X) in univ,
-      ∫ (z : X × X) in E p' ×ˢ E p, f (x, z) ∂(volume.prod volume) ∂volume‖ₑ ≤ _
-  rw [← setIntegral_prod _ hf, ← setIntegral_prod_swap, setIntegral_prod _ hf', restrict_univ]
-  simp_rw [Prod.swap_prod_mk, ← bound_6_2_26_aux]
+  erw [← setIntegral_prod _ hf, ← setIntegral_prod_swap, setIntegral_prod _ (hf.swap), restrict_univ]
+  simp_rw [← bound_6_2_26_aux]
   exact enorm_integral_le_lintegral_enorm _
 
 -- We assume 6.2.23.

--- a/Carleson/Antichain/TileCorrelation.lean
+++ b/Carleson/Antichain/TileCorrelation.lean
@@ -399,12 +399,11 @@ lemma I12_le (ha : 4 ≤ a) {p p' : 𝔓 X} (hle : 𝔰 p' ≤ 𝔰 p) {g : X �
   rw [← ENNReal.rpow_le_rpow_iff_of_neg hneg] at h623
   have h0 : ((2 : ℝ≥0∞) ^ (8 * a)) ^ (-(2 * a ^ 2 + a ^ 3 : ℝ)⁻¹) ≠ 0 := by simp
   have h210 : (2 : ℝ≥0∞) ^ (1 : ℝ) ≠ 0 := by rw [ENNReal.rpow_one]; exact two_ne_zero
-  rw [ENNReal.mul_rpow_of_ne_top (Ne.symm (not_eq_of_beq_eq_false rfl))
-      (ENNReal.add_ne_top.mpr ⟨ENNReal.one_ne_top, edist_ne_top _ _⟩),
-    mul_comm, ← ENNReal.le_div_iff_mul_le (.inl h0)
-      (.inl (ENNReal.rpow_ne_top_of_ne_zero
-        (ENNReal.pow_ne_zero (by norm_num) _)
-        (ENNReal.pow_ne_top (by norm_num))))] at h623
+  rw [
+    ENNReal.mul_rpow_of_ne_top (by finiteness) (by finiteness),
+    mul_comm,
+    ← ENNReal.le_div_iff_mul_le (.inl h0) (.inl (by finiteness))
+  ] at h623
   apply h623.trans
   rw [ENNReal.div_eq_inv_mul, mul_comm _ 2]
   gcongr

--- a/Carleson/Antichain/TileCorrelation.lean
+++ b/Carleson/Antichain/TileCorrelation.lean
@@ -603,16 +603,15 @@ lemma bound_6_2_26_aux {p p' : 𝔓 X} {g : X → ℂ} :
     simp_rw [mul_add I, mul_sub I, sub_eq_add_neg, exp_add]
     ring_nf
   simp only [I12, enorm_mul]
-  rw [
-    heq, integral_mul_const, enorm_mul, enorm_mul, enorm_mul, enorm_mul, enorm_exp_I_mul_ofReal,
+  rw [heq, integral_mul_const, enorm_mul, enorm_mul, enorm_mul, enorm_mul, enorm_exp_I_mul_ofReal,
     show ‖exp (_)‖ₑ = 1 from mod_cast enorm_exp_I_mul_ofReal _,
-    RCLike.enorm_conj, one_mul, one_mul, ← mul_assoc
-  ]
+    RCLike.enorm_conj, one_mul, one_mul, ← mul_assoc]
   simp only [mul_neg, correlation]
   congr; ext y
   rw [mul_add I, exp_add]
   ring_nf
 
+set_option backward.isDefEq.respectTransparency false in
 lemma bound_6_2_26 {p p' : 𝔓 X} {g : X → ℂ}
     (hg : Measurable g) (hg1 : ∀ x, ‖g x‖ ≤ G.indicator 1 x) :
     ‖∫ y, adjointCarleson p' g y * conj (adjointCarleson p g y)‖ₑ ≤
@@ -621,8 +620,7 @@ lemma bound_6_2_26 {p p' : 𝔓 X} {g : X → ℂ}
       conj (∫ y1 in E p, conj (Ks (𝔰 p) y1 y) * exp (I * (Q y1 y1 - Q y1 y)) * g y1) =
       ∫ y1 in E p, Ks (𝔰 p) y1 y * exp (I * (-Q y1 y1 + Q y1 y)) * conj (g y1) :=
     complex_exp_lintegral
-  simp_rw [adjointCarleson, haux]
-  simp_rw [show ∀ y, (∫ y1 in E p', conj (Ks (𝔰 p') y1 y) * exp (I * (Q y1 y1 - Q y1 y)) * g y1) * (∫ y1 in E p, Ks (𝔰 p) y1 y * exp (I * (-Q y1 y1 + Q y1 y)) * conj (g y1)) = _ from fun y => (setIntegral_prod_mul ..).symm]
+  simp_rw [adjointCarleson, haux, ← setIntegral_prod_mul]
   rw [← setIntegral_univ]
   let f := fun (x, z1, z2) ↦
     conj (Ks (𝔰 p') z1 x) * exp (I * (Q z1 z1 - Q z1 x)) * g z1 *

--- a/Carleson/Antichain/TileCorrelation.lean
+++ b/Carleson/Antichain/TileCorrelation.lean
@@ -310,11 +310,11 @@ lemma C6_1_5_bound (ha : 4 ≤ a) :
 
 open GridStructure
 
+set_option backward.isDefEq.respectTransparency false in
 lemma complex_exp_lintegral {p : 𝔓 X} {g : X → ℂ} (y : X) :
     conj (∫ y1 in E p, conj (Ks (𝔰 p) y1 y) * exp (I * (Q y1 y1 - Q y1 y)) * g y1) =
     ∫ y1 in E p, Ks (𝔰 p) y1 y * exp (I * (-Q y1 y1 + Q y1 y)) * conj (g y1) := by
-  erw [← integral_conj]
-  simp only [map_mul, RingHomCompTriple.comp_apply, RingHom.id_apply]
+  simp only [← integral_conj, map_mul, RingHomCompTriple.comp_apply, RingHom.id_apply]
   congr; ext x; rw [← exp_conj]; congr
   simp only [map_mul, conj_I, map_sub, conj_ofReal]
   ring
@@ -584,6 +584,7 @@ lemma boundedCompactSupport_aux_6_2_26 {p p' : 𝔓 X} {g : X → ℂ}
     · exact .inl (.inr (eq_zero_of_notMem_closedBall hg1 hx))
     · exact .inr (.inr (eq_zero_of_notMem_closedBall hg1 hx))
 
+set_option backward.isDefEq.respectTransparency false in
 lemma bound_6_2_26_aux {p p' : 𝔓 X} {g : X → ℂ} :
     let f := fun (x, z1, z2) ↦
       conj (Ks (𝔰 p') z1 x) * exp (I * (Q z1 z1 - Q z1 x)) * g z1 *
@@ -602,7 +603,7 @@ lemma bound_6_2_26_aux {p p' : 𝔓 X} {g : X → ℂ} :
     simp_rw [mul_add I, mul_sub I, sub_eq_add_neg, exp_add]
     ring_nf
   simp only [I12, enorm_mul]
-  erw [
+  rw [
     heq, integral_mul_const, enorm_mul, enorm_mul, enorm_mul, enorm_mul, enorm_exp_I_mul_ofReal,
     show ‖exp (_)‖ₑ = 1 from mod_cast enorm_exp_I_mul_ofReal _,
     RCLike.enorm_conj, one_mul, one_mul, ← mul_assoc

--- a/Carleson/Antichain/TileCorrelation.lean
+++ b/Carleson/Antichain/TileCorrelation.lean
@@ -95,7 +95,7 @@ private lemma e625 {s₁ s₂ : ℤ} {x₁ x₂ y y' : X} (hy' : y ≠ y') (hs :
       rw [mul_comm (volume _), edist_comm]
     _ ≤ 2 ^ ((2 * 𝕔 + 4 + 𝕔 / 4) * a ^ 3) / (volume (ball x₁ (D ^ s₁)) *
         volume (ball x₂ (D ^ s₂))) * (2 * (edist y y' ^ τ / (D ^ s₁) ^ τ)) := by
-      simp only [two_mul, defaultA, defaultD, Nat.cast_pow, Nat.cast_ofNat, defaultτ]
+      simp only [two_mul, defaultD, Nat.cast_pow, Nat.cast_ofNat, defaultτ]
       gcongr
       exact_mod_cast one_le_realD _
     _ = 2 ^ ((2 * 𝕔 + 4 + 𝕔 / 4) * a ^ 3) * 2 / (volume (ball x₁ (D ^ s₁)) *
@@ -171,7 +171,7 @@ lemma range_support {p : 𝔓 X} {g : X → ℂ} {y : X} (hpy : adjointCarleson 
   have hyx : dist y x ≤ 1 / 2 * D ^ 𝔰 p := by -- 6.2.14
     have hK : Ks (𝔰 p) x y ≠ 0 := by
       by_contra h0
-      simp [h0] at hx0
+      simp only [h0, map_zero, zero_mul, ne_eq, not_true] at hx0
     rw [dist_comm]
     convert (dist_mem_Icc_of_Ks_ne_zero hK).2 using 1
     ring
@@ -313,7 +313,10 @@ open GridStructure
 lemma complex_exp_lintegral {p : 𝔓 X} {g : X → ℂ} (y : X) :
     conj (∫ y1 in E p, conj (Ks (𝔰 p) y1 y) * exp (I * (Q y1 y1 - Q y1 y)) * g y1) =
     ∫ y1 in E p, Ks (𝔰 p) y1 y * exp (I * (-Q y1 y1 + Q y1 y)) * conj (g y1) := by
-  simp only [← integral_conj, map_mul, RingHomCompTriple.comp_apply, RingHom.id_apply]
+  rw [show conj (∫ y1 in E p, conj (Ks (𝔰 p) y1 y) * exp (I * (Q y1 y1 - Q y1 y)) * g y1) =
+    ∫ y1 in E p, conj (conj (Ks (𝔰 p) y1 y) * exp (I * (Q y1 y1 - Q y1 y)) * g y1) from
+    integral_conj.symm]
+  simp only [map_mul, RingHomCompTriple.comp_apply, RingHom.id_apply]
   congr; ext x; rw [← exp_conj]; congr
   simp only [map_mul, conj_I, map_sub, conj_ofReal]
   ring
@@ -396,8 +399,12 @@ lemma I12_le (ha : 4 ≤ a) {p p' : 𝔓 X} (hle : 𝔰 p' ≤ 𝔰 p) {g : X �
   rw [← ENNReal.rpow_le_rpow_iff_of_neg hneg] at h623
   have h0 : ((2 : ℝ≥0∞) ^ (8 * a)) ^ (-(2 * a ^ 2 + a ^ 3 : ℝ)⁻¹) ≠ 0 := by simp
   have h210 : (2 : ℝ≥0∞) ^ (1 : ℝ) ≠ 0 := by rw [ENNReal.rpow_one]; exact two_ne_zero
-  rw [ENNReal.mul_rpow_of_ne_top (Ne.symm (not_eq_of_beq_eq_false rfl)) (by simp [edist_dist]),
-    mul_comm, ← ENNReal.le_div_iff_mul_le (.inl h0) (.inr (by simp [edist_dist]))] at h623
+  rw [ENNReal.mul_rpow_of_ne_top (Ne.symm (not_eq_of_beq_eq_false rfl))
+      (ENNReal.add_ne_top.mpr ⟨ENNReal.one_ne_top, edist_ne_top _ _⟩),
+    mul_comm, ← ENNReal.le_div_iff_mul_le (.inl h0)
+      (.inl (ENNReal.rpow_ne_top_of_ne_zero
+        (ENNReal.pow_ne_zero (by norm_num) _)
+        (ENNReal.pow_ne_top (by norm_num))))] at h623
   apply h623.trans
   rw [ENNReal.div_eq_inv_mul, mul_comm _ 2]
   gcongr
@@ -603,9 +610,15 @@ lemma bound_6_2_26_aux {p p' : 𝔓 X} {g : X → ℂ} :
   have hx1 : ‖exp (I * Q x.1 x.1)‖ₑ = 1 := enorm_exp_I_mul_ofReal _
   have hx2 : ‖exp (I * -Q x.2 x.2)‖ₑ = 1 := mod_cast enorm_exp_I_mul_ofReal _
   simp only [I12, enorm_mul]
-  simp_rw [heq, integral_mul_const, enorm_mul, RCLike.enorm_conj, ← mul_assoc]
-  rw [hx1, hx2]
-  simp only [mul_neg, mul_one, correlation]
+  have key2 : ∫ (y : X), conj (Ks (𝔰 p') x.1 y) * exp (I * (Q x.1 x.1 - Q x.1 y)) * g x.1 *
+      (Ks (𝔰 p) x.2 y * exp (I * (-Q x.2 x.2 + Q x.2 y)) * conj (g x.2)) =
+      (∫ (y : X), conj (Ks (𝔰 p') x.1 y) * exp (I * -Q x.1 y) *
+        (Ks (𝔰 p) x.2 y * exp (I * Q x.2 y))) *
+      (exp (I * Q x.1 x.1) * exp (I * -Q x.2 x.2) * g x.1 * conj (g x.2)) := by
+    rw [heq]; exact integral_mul_const _ _
+  rw [key2, enorm_mul, enorm_mul, enorm_mul, enorm_mul, hx1, hx2, RCLike.enorm_conj,
+      one_mul, one_mul, ← mul_assoc]
+  simp only [mul_neg, correlation]
   congr; ext y
   rw [mul_add I, exp_add]
   ring_nf
@@ -618,7 +631,17 @@ lemma bound_6_2_26 {p p' : 𝔓 X} {g : X → ℂ}
       conj (∫ y1 in E p, conj (Ks (𝔰 p) y1 y) * exp (I * (Q y1 y1 - Q y1 y)) * g y1) =
       ∫ y1 in E p, Ks (𝔰 p) y1 y * exp (I * (-Q y1 y1 + Q y1 y)) * conj (g y1) :=
     complex_exp_lintegral
-  simp_rw [adjointCarleson, haux, ← setIntegral_prod_mul]; rw [← setIntegral_univ]
+  simp_rw [adjointCarleson, haux]
+  have key : ∀ y, (∫ y1 in E p', conj (Ks (𝔰 p') y1 y) * exp (I * (Q y1 y1 - Q y1 y)) * g y1) *
+      (∫ y1 in E p, Ks (𝔰 p) y1 y * exp (I * (-Q y1 y1 + Q y1 y)) * conj (g y1)) =
+      ∫ z in E p' ×ˢ E p,
+        conj (Ks (𝔰 p') z.1 y) * exp (I * (Q z.1 z.1 - Q z.1 y)) * g z.1 *
+        (Ks (𝔰 p) z.2 y * exp (I * (-Q z.2 z.2 + Q z.2 y)) * conj (g z.2)) := fun y =>
+    (setIntegral_prod_mul
+      (fun z1 ↦ conj (Ks (𝔰 p') z1 y) * exp (I * (Q z1 z1 - Q z1 y)) * g z1)
+      (fun z2 ↦ Ks (𝔰 p) z2 y * exp (I * (-Q z2 z2 + Q z2 y)) * conj (g z2))
+      (E p') (E p)).symm
+  simp_rw [key]; rw [← setIntegral_univ]
   let f := fun (x, z1, z2) ↦
     conj (Ks (𝔰 p') z1 x) * exp (I * (Q z1 z1 - Q z1 x)) * g z1 *
     (Ks (𝔰 p) z2 x * exp (I * (-Q z2 z2 + Q z2 x)) * conj (g z2))
@@ -626,6 +649,8 @@ lemma bound_6_2_26 {p p' : 𝔓 X} {g : X → ℂ}
     (boundedCompactSupport_aux_6_2_26 hg hg1).integrable.integrableOn
   have hf' : IntegrableOn (f ·.swap) ((E p' ×ˢ E p) ×ˢ univ) ((volume.prod volume).prod volume) :=
     hf.swap
+  change ‖∫ (x : X) in univ,
+      ∫ (z : X × X) in E p' ×ˢ E p, f (x, z) ∂(volume.prod volume) ∂volume‖ₑ ≤ _
   rw [← setIntegral_prod _ hf, ← setIntegral_prod_swap, setIntegral_prod _ hf', restrict_univ]
   simp_rw [Prod.swap_prod_mk, ← bound_6_2_26_aux]
   exact enorm_integral_le_lintegral_enorm _

--- a/Carleson/Classical/Approximation.lean
+++ b/Carleson/Classical/Approximation.lean
@@ -63,34 +63,21 @@ lemma fourierCoeffOn_bound {f : ℝ → ℂ} (f_continuous : Continuous f) :
     ∃ C, ∀ n, ‖fourierCoeffOn Real.two_pi_pos f n‖ ≤ C := by
   obtain ⟨C, f_bounded⟩ := continuous_bounded f_continuous.continuousOn
   refine ⟨C, fun n ↦ ?_⟩
-  simp only [fourierCoeffOn_eq_integral, sub_zero, one_div, mul_inv_rev, Complex.real_smul,
-    Complex.norm_real, Complex.norm_mul, norm_eq_abs, abs_mul, abs_inv, Nat.abs_ofNat]
-  field_simp
-  rw [abs_of_nonneg pi_pos.le, mul_comm π]
-  calc
-    _ = ‖∫ (x : ℝ) in (0 : ℝ)..(2 * π), (starRingEnd ℂ) (Complex.exp (2 * π * Complex.I * n * x / (2 * π))) * f x‖ := by simp
-    _ = ‖∫ (x : ℝ) in (0 : ℝ)..(2 * π), (starRingEnd ℂ) (Complex.exp (Complex.I * n * x)) * f x‖ := by
-      congr with x
-      congr
-      ring_nf
-      rw [mul_comm, ←mul_assoc, ← mul_assoc, ← mul_assoc, inv_mul_cancel₀]
-      · ring
-      · simp [pi_pos.ne.symm]
-    _ ≤ ∫ (x : ℝ) in (0 : ℝ)..(2 * π), ‖(starRingEnd ℂ) (Complex.exp (Complex.I * n * x)) * f x‖ :=
-      intervalIntegral.norm_integral_le_integral_norm Real.two_pi_pos.le
-    _ = ∫ (x : ℝ) in (0 : ℝ)..(2 * π), ‖(Complex.exp (Complex.I * n * x)) * f x‖ := by simp
-    _ = ∫ (x : ℝ) in (0 : ℝ)..(2 * π), ‖f x‖ := by
-      congr with x
-      simp only [norm_mul]
-      rw_mod_cast [mul_assoc, mul_comm Complex.I, Complex.norm_exp_ofReal_mul_I]
-      ring
-    _ ≤ ∫ (_ : ℝ) in (0 : ℝ)..(2 * π), C := by
-      refine intervalIntegral.integral_mono_on Real.two_pi_pos.le ?_ intervalIntegrable_const
-        fun x hx ↦ f_bounded x hx
-      /-Could specify `aestronglyMeasurable` and `intervalIntegrable` intead of `f_continuous`. -/
-      exact IntervalIntegrable.intervalIntegrable_norm_iff f_continuous.aestronglyMeasurable |>.mpr
-        (f_continuous.intervalIntegrable ..)
-    _ = _ := by simp
+  rw [fourierCoeffOn_eq_integral, norm_smul, sub_zero, Real.norm_of_nonneg (by positivity),
+      one_div, inv_mul_le_iff₀ Real.two_pi_pos]
+  calc ‖∫ (x : ℝ) in (0 : ℝ)..2 * π, fourier (-n) (↑x : AddCircle (2 * π)) • f x‖
+      ≤ ∫ (x : ℝ) in (0 : ℝ)..2 * π, ‖fourier (-n) (↑x : AddCircle (2 * π)) • f x‖ :=
+        intervalIntegral.norm_integral_le_integral_norm Real.two_pi_pos.le
+    _ = ∫ (x : ℝ) in (0 : ℝ)..2 * π, ‖f x‖ := by
+        apply intervalIntegral.integral_congr (fun x _ ↦ ?_)
+        simp only [norm_smul, fourier_apply, Circle.norm_coe, one_mul]
+    _ ≤ ∫ (_ : ℝ) in (0 : ℝ)..2 * π, C :=
+        intervalIntegral.integral_mono_on Real.two_pi_pos.le
+          (f_continuous.norm.intervalIntegrable 0 (2 * π))
+          intervalIntegrable_const
+          (fun x hx ↦ f_bounded x hx)
+    _ = 2 * π * C := by
+        rw [intervalIntegral.integral_const, smul_eq_mul, sub_zero]
 
 /-TODO: Assumptions might be weakened. -/
 lemma periodic_deriv {𝕜 : Type} [NontriviallyNormedField 𝕜] {F : Type} [NormedAddCommGroup F] [NormedSpace 𝕜 F]

--- a/Carleson/Classical/Basic.lean
+++ b/Carleson/Classical/Basic.lean
@@ -86,18 +86,15 @@ local notation "S_" => partialFourierSum
 
 @[simp]
 lemma fourierCoeffOn_mul {a b : ℝ} {hab : a < b} {f : ℝ → ℂ} {c : ℂ} {n : ℤ} :
-    fourierCoeffOn hab (fun x ↦ c * f x) n = c * (fourierCoeffOn hab f n):= by
-  simp only [fourierCoeffOn_eq_integral, one_div, fourier_apply, neg_smul, fourier_neg',
-    fourier_coe_apply', mul_comm, Complex.ofReal_sub, smul_eq_mul, mul_assoc,
-    intervalIntegral.integral_const_mul, Complex.real_smul, Complex.ofReal_inv]
-  ring
+    fourierCoeffOn hab (fun x ↦ c * f x) n = c * (fourierCoeffOn hab f n):=
+  fourierCoeffOn.const_mul f c n hab
 
 @[simp]
 lemma fourierCoeffOn_neg {a b : ℝ} {hab : a < b} {f : ℝ → ℂ} {n : ℤ} :
     fourierCoeffOn hab (-f) n = - (fourierCoeffOn hab f n):= by
   simp only [fourierCoeffOn_eq_integral, one_div, fourier_apply, neg_smul, fourier_neg',
     fourier_coe_apply', Complex.ofReal_sub, Pi.neg_apply, smul_eq_mul, mul_neg,
-    intervalIntegral.integral_neg, smul_neg, Complex.real_smul, Complex.ofReal_inv]
+    intervalIntegral.integral_neg, smul_neg]
 
 @[simp]
 lemma fourierCoeffOn_add {a b : ℝ} {hab : a < b} {f g : ℝ → ℂ} {n : ℤ}
@@ -105,12 +102,11 @@ lemma fourierCoeffOn_add {a b : ℝ} {hab : a < b} {f g : ℝ → ℂ} {n : ℤ}
     (hg : IntervalIntegrable g MeasureTheory.volume a b) :
     fourierCoeffOn hab (f + g) n = fourierCoeffOn hab f n + fourierCoeffOn hab g n:= by
   simp only [fourierCoeffOn_eq_integral, one_div, fourier_apply, neg_smul, fourier_neg',
-    fourier_coe_apply', Complex.ofReal_sub, Pi.add_apply, smul_eq_mul, mul_add, Complex.real_smul,
-    Complex.ofReal_inv]
-  rw [← mul_add, ← intervalIntegral.integral_add]
-  · ring_nf
-    exact hf.continuousOn_mul (Continuous.continuousOn (by fun_prop))
-  · exact hg.continuousOn_mul (Continuous.continuousOn (by fun_prop))
+    fourier_coe_apply', Complex.ofReal_sub, Pi.add_apply, smul_eq_mul, mul_add]
+  rw [intervalIntegral.integral_add
+    (by ring_nf; exact hf.continuousOn_mul (Continuous.continuousOn (by fun_prop)))
+    (by ring_nf; exact hg.continuousOn_mul (Continuous.continuousOn (by fun_prop))),
+    smul_add]
 
 @[simp]
 lemma fourierCoeffOn_sub {a b : ℝ} {hab : a < b} {f g : ℝ → ℂ} {n : ℤ}

--- a/Carleson/Classical/Basic.lean
+++ b/Carleson/Classical/Basic.lean
@@ -86,7 +86,7 @@ local notation "S_" => partialFourierSum
 
 @[simp]
 lemma fourierCoeffOn_mul {a b : ℝ} {hab : a < b} {f : ℝ → ℂ} {c : ℂ} {n : ℤ} :
-    fourierCoeffOn hab (fun x ↦ c * f x) n = c * (fourierCoeffOn hab f n):=
+    fourierCoeffOn hab (fun x ↦ c * f x) n = c * (fourierCoeffOn hab f n) :=
   fourierCoeffOn.const_mul f c n hab
 
 @[simp]

--- a/Carleson/Classical/Basic.lean
+++ b/Carleson/Classical/Basic.lean
@@ -92,9 +92,7 @@ lemma fourierCoeffOn_mul {a b : ℝ} {hab : a < b} {f : ℝ → ℂ} {c : ℂ} {
 @[simp]
 lemma fourierCoeffOn_neg {a b : ℝ} {hab : a < b} {f : ℝ → ℂ} {n : ℤ} :
     fourierCoeffOn hab (-f) n = - (fourierCoeffOn hab f n):= by
-  simp only [fourierCoeffOn_eq_integral, one_div, fourier_apply, neg_smul, fourier_neg',
-    fourier_coe_apply', Complex.ofReal_sub, Pi.neg_apply, smul_eq_mul, mul_neg,
-    intervalIntegral.integral_neg, smul_neg]
+  simp [fourierCoeffOn_eq_integral]
 
 @[simp]
 lemma fourierCoeffOn_add {a b : ℝ} {hab : a < b} {f g : ℝ → ℂ} {n : ℤ}

--- a/Carleson/Classical/Basic.lean
+++ b/Carleson/Classical/Basic.lean
@@ -103,7 +103,7 @@ lemma fourierCoeffOn_add {a b : ℝ} {hab : a < b} {f g : ℝ → ℂ} {n : ℤ}
     fourier_coe_apply', Complex.ofReal_sub, Pi.add_apply, smul_eq_mul, mul_add]
   rw [intervalIntegral.integral_add
     (by ring_nf; exact hf.continuousOn_mul (by fun_prop))
-    (by ring_nf; exact hg.continuousOn_mul (Continuous.continuousOn (by fun_prop))),
+    (by ring_nf; exact hg.continuousOn_mul (by fun_prop)),
     smul_add]
 
 @[simp]

--- a/Carleson/Classical/Basic.lean
+++ b/Carleson/Classical/Basic.lean
@@ -102,7 +102,7 @@ lemma fourierCoeffOn_add {a b : ℝ} {hab : a < b} {f g : ℝ → ℂ} {n : ℤ}
   simp only [fourierCoeffOn_eq_integral, one_div, fourier_apply, neg_smul, fourier_neg',
     fourier_coe_apply', Complex.ofReal_sub, Pi.add_apply, smul_eq_mul, mul_add]
   rw [intervalIntegral.integral_add
-    (by ring_nf; exact hf.continuousOn_mul (Continuous.continuousOn (by fun_prop)))
+    (by ring_nf; exact hf.continuousOn_mul (by fun_prop))
     (by ring_nf; exact hg.continuousOn_mul (Continuous.continuousOn (by fun_prop))),
     smul_add]
 

--- a/Carleson/Classical/CarlesonOnTheRealLine.lean
+++ b/Carleson/Classical/CarlesonOnTheRealLine.lean
@@ -221,14 +221,25 @@ lemma integer_ball_cover {x : ℝ} {R R' : ℝ} {f : WithFunctionDistance x R} :
   rw [coveredByBalls_iff]
   by_cases! R'pos : 0 ≥ R'
   · -- trivial case
-    refine ⟨{f}, by norm_num, ?_⟩
-    simp only [Finset.mem_singleton, Set.iUnion_iUnion_eq_left]
-    rw [Metric.ball_eq_empty.mpr R'pos, Set.subset_empty_iff, Metric.ball_eq_empty]
+    refine ⟨{f}, Finset.card_singleton f ▸ by norm_num, ?_⟩
+    have hunion : (⋃ x_1 ∈ ({f} : Finset (WithFunctionDistance x R)), ball_{x, R} x_1 R') = ball_{x, R} f R' := by
+      ext y
+      simp only [Set.mem_iUnion, exists_prop]
+      constructor
+      · rintro ⟨i, hi, hb⟩; rwa [Finset.mem_singleton.mp hi] at hb
+      · intro h; exact ⟨f, Finset.mem_singleton_self f, h⟩
+    rw [hunion, Metric.ball_eq_empty.mpr R'pos, Set.subset_empty_iff, Metric.ball_eq_empty]
     linarith
   by_cases! Rpos : 0 ≥ R
   · -- trivial case
-    refine ⟨{f}, by norm_num, ?_⟩
-    simp only [Finset.mem_singleton, Set.iUnion_iUnion_eq_left]
+    refine ⟨{f}, Finset.card_singleton f ▸ by norm_num, ?_⟩
+    have hunion : (⋃ x_1 ∈ ({f} : Finset (WithFunctionDistance x R)), ball_{x, R} x_1 R') = ball_{x, R} f R' := by
+      ext y
+      simp only [Set.mem_iUnion, exists_prop]
+      constructor
+      · rintro ⟨i, hi, hb⟩; rwa [Finset.mem_singleton.mp hi] at hb
+      · intro h; exact ⟨f, Finset.mem_singleton_self f, h⟩
+    rw [hunion]
     convert Set.subset_univ _
     ext g
     refine ⟨by simp, ?_⟩
@@ -253,8 +264,7 @@ lemma integer_ball_cover {x : ℝ} {R R' : ℝ} {f : WithFunctionDistance x R} :
   by_cases! h : φ ≤ f - R' / (2 * R)
   · use m₁
     constructor
-    · rw [balls_def]
-      simp
+    · apply Finset.mem_insert_self
     rw [dist_integer_linear_eq]
     calc 2 * max R 0 * |↑φ - ↑m₁|
       _ = 2 * R * |↑φ - ↑m₁| := by
@@ -293,8 +303,7 @@ lemma integer_ball_cover {x : ℝ} {R R' : ℝ} {f : WithFunctionDistance x R} :
   by_cases! h' : φ < f + R' / (2 * R)
   · use m₂
     constructor
-    · rw [balls_def]
-      simp
+    · exact Finset.mem_insert.mpr (Or.inr (Finset.mem_insert_self m₂ _))
     rw [m₂def, dist_comm]
     rw [dist_integer_linear_eq]
     calc 2 * max R 0 * |↑f - ↑φ|
@@ -309,7 +318,9 @@ lemma integer_ball_cover {x : ℝ} {R R' : ℝ} {f : WithFunctionDistance x R} :
       _ = R' := by field_simp
   use m₃
   constructor
-  · simp [balls_def]
+  · apply Finset.mem_insert.mpr; right
+    apply Finset.mem_insert.mpr; right
+    exact Finset.mem_singleton.mpr m₃def
   rw [dist_integer_linear_eq]
   calc 2 * max R 0 * |↑φ - ↑m₃|
     _ = 2 * R * (↑φ - ↑m₃) := by

--- a/Carleson/Classical/CarlesonOperatorReal.lean
+++ b/Carleson/Classical/CarlesonOperatorReal.lean
@@ -85,7 +85,7 @@ lemma carlesonOperatorReal_measurable {f : ℝ → ℂ} (f_measurable : Measurab
              = fun x ↦ ⨆ (r : ℝ) (_ : r ∈ Set.Ioo 0 1), G x r := by
     ext
     congr with r
-    rw [iSup_and, Gdef, Fdef]
+    simp_rw [iSup_and', ← Set.mem_Ioo, Gdef, Fdef]
     congr
     rw [← integral_indicator annulus_measurableSet]
   rw [hFG]
@@ -252,7 +252,9 @@ lemma carlesonOperatorReal_mul {f : ℝ → ℂ} {x : ℝ} {a : ℝ} (ha : 0 < a
   congr with rle1
   norm_cast
   rw [← Real.enorm_eq_ofReal ha.le]
-  simp_rw [mul_assoc, integral_const_mul, enorm_mul, ← mul_assoc]
+  simp_rw [mul_assoc]
+  rw [show ∫ y in {y : ℝ | dist x y ∈ Set.Ioo r 1}, ↑(1 / a) * (f y * (K x y * Complex.exp (Complex.I * (↑n * ↑y)))) = ↑(1 / a) * ∫ y in {y : ℝ | dist x y ∈ Set.Ioo r 1}, f y * (K x y * Complex.exp (Complex.I * (↑n * ↑y))) from integral_const_mul _ _]
+  rw [enorm_mul, ← mul_assoc]
   rw [← enorm_norm (Complex.ofReal (1 / a)), Complex.norm_real, enorm_norm, ← enorm_mul,
     mul_one_div_cancel ha.ne', enorm_one, one_mul]
 

--- a/Carleson/Classical/CarlesonOperatorReal.lean
+++ b/Carleson/Classical/CarlesonOperatorReal.lean
@@ -252,11 +252,13 @@ lemma carlesonOperatorReal_mul {f : ℝ → ℂ} {x : ℝ} {a : ℝ} (ha : 0 < a
   congr with rle1
   norm_cast
   rw [← Real.enorm_eq_ofReal ha.le]
-  simp_rw [mul_assoc]
-  rw [show ∫ y in {y : ℝ | dist x y ∈ Set.Ioo r 1}, ↑(1 / a) * (f y * (K x y * Complex.exp (Complex.I * (↑n * ↑y)))) = ↑(1 / a) * ∫ y in {y : ℝ | dist x y ∈ Set.Ioo r 1}, f y * (K x y * Complex.exp (Complex.I * (↑n * ↑y))) from integral_const_mul _ _]
-  rw [enorm_mul, ← mul_assoc]
-  rw [← enorm_norm (Complex.ofReal (1 / a)), Complex.norm_real, enorm_norm, ← enorm_mul,
-    mul_one_div_cancel ha.ne', enorm_one, one_mul]
+  simp_rw [
+    mul_assoc,
+    show ∫ _ in _, _ = _ * ∫ y in _, f y * _ from integral_const_mul _ _,
+    enorm_mul, ← mul_assoc,
+    ← enorm_norm (Complex.ofReal (1 / a)), Complex.norm_real, enorm_norm, ← enorm_mul,
+    mul_one_div_cancel ha.ne', enorm_one, one_mul
+  ]
 
 lemma carlesonOperatorReal_eq_of_restrict_interval {f : ℝ → ℂ} {a b : ℝ} {x : ℝ} (hx : x ∈ Set.Icc a b) : T f x = T ((Set.Ioo (a - 1) (b + 1)).indicator f) x := by
   simp_rw [carlesonOperatorReal]

--- a/Carleson/Classical/ControlApproximationEffect.lean
+++ b/Carleson/Classical/ControlApproximationEffect.lean
@@ -350,21 +350,9 @@ lemma le_CarlesonOperatorReal {g : ℝ → ℂ} (hg : IntervalIntegrable g volum
               ring
         _ =   ‖∫ y in {y | dist x y ∈ Set.Ioo r 1}, g y * K x y * exp (I * n * y)‖ₑ
             + ‖∫ y in {y | dist x y ∈ Set.Ioo r 1}, (conj ∘ g) y * K x y * exp (I * n * y)‖ₑ := by
-          congr 1
-          · rw [
-              integral_const_mul _ _,
-              enorm_mul,
-              show (-↑n * ↑x : ℂ) = ((-↑n * ↑x : ℝ) : ℂ) by norm_cast,
-              enorm_exp_I_mul_ofReal,
-              one_mul
-            ]
-          · rw [
-              integral_const_mul _ _,
-              enorm_mul,
-              show (-↑n * ↑x : ℂ) = ((-↑n * ↑x : ℝ) : ℂ) by norm_cast,
-              enorm_exp_I_mul_ofReal,
-              one_mul
-            ]
+          congr 1 <;>
+          rw [integral_const_mul, enorm_mul, show (-n * x : ℂ) = ((-n * x : ℝ) : ℂ) by norm_cast,
+            enorm_exp_I_mul_ofReal, one_mul]
     _ ≤ T g x + T (conj ∘ g) x := by
       simp_rw [carlesonOperatorReal]
       apply iSup₂_le

--- a/Carleson/Classical/ControlApproximationEffect.lean
+++ b/Carleson/Classical/ControlApproximationEffect.lean
@@ -28,7 +28,7 @@ lemma ENNReal.le_on_subset {X : Type} [MeasurableSpace X] (μ : Measure X) {f g 
     simp only [Set.mem_union, Set.mem_inter_iff, Set.mem_preimage, Set.mem_Ici]
     by_contra! hx'
     absurd le_refl a
-    push_neg
+    push Not
     calc a
       _ ≤ f x + g x := h x hx
       _ < a / 2 + a / 2 := by
@@ -41,7 +41,7 @@ lemma ENNReal.le_on_subset {X : Type} [MeasurableSpace X] (μ : Measure X) {f g 
   have : μ E ≤ 2 * μ Ef ∨ μ E ≤ 2 * μ Eg := by
     by_contra! hEfg
     absurd le_refl (2 * μ E)
-    push_neg
+    push Not
     calc 2 * μ E
     _ ≤ 2 * μ (Ef ∪ Eg) := by
       gcongr
@@ -201,14 +201,14 @@ lemma domain_reformulation {g : ℝ → ℂ} (hg : IntervalIntegrable g volume (
       · trivial
       · dsimp at h₀ h₁
         rw [Real.dist_eq, Set.mem_Ioo] at h₀ h₁
-        push_neg at h₁
+        push Not at h₁
         rw [k_of_one_le_abs (h₁ h₀.1)]
         simp
       · rw [k_of_one_le_abs]
         · simp
         dsimp at h₀ h₂
         rw [Real.dist_eq, Set.mem_Ioo] at h₀ h₂
-        push_neg at h₀
+        push Not at h₀
         exact le_trans' (h₀ h₂.1) (by linarith [Real.two_le_pi])
       · trivial
 

--- a/Carleson/Classical/ControlApproximationEffect.lean
+++ b/Carleson/Classical/ControlApproximationEffect.lean
@@ -32,9 +32,7 @@ lemma ENNReal.le_on_subset {X : Type} [MeasurableSpace X] (μ : Measure X) {f g 
     calc a
       _ ≤ f x + g x := h x hx
       _ < a / 2 + a / 2 := by
-        gcongr
-        · exact hx'.1 hx
-        · exact hx'.2 hx
+        exact ENNReal.add_lt_add (hx'.1 hx) (hx'.2 hx)
       _ = a := by
         ring_nf
         apply ENNReal.div_mul_cancel <;> norm_num
@@ -50,9 +48,7 @@ lemma ENNReal.le_on_subset {X : Type} [MeasurableSpace X] (μ : Measure X) {f g 
       exact measure_union_le _ _
     _ = 2 * μ Ef + 2 * μ Eg := by ring
     _ < μ E + μ E := by
-      gcongr
-      · exact hEfg.1
-      · exact hEfg.2
+      exact ENNReal.add_lt_add hEfg.1 hEfg.2
     _ = 2 * μ E := by ring
   rcases this with hEf | hEg
   · refine ⟨Ef, Set.inter_subset_left, hE.inter (hf measurableSet_Ici), hEf, Or.inl ?_⟩
@@ -347,12 +343,30 @@ lemma le_CarlesonOperatorReal {g : ℝ → ℂ} (hg : IntervalIntegrable g volum
             + ‖∫ y in {y | dist x y ∈ Set.Ioo r 1}, exp (I * (-n * x)) * ((conj ∘ g) y * K x y * exp (I * n * y))‖ₑ := by
             congr 1
             · congr! 3 with y; ring
-            · rw [← RCLike.enorm_conj, ← integral_conj]; congr! 3 with _ y; simp; ring
+            · rw [
+                ← RCLike.enorm_conj,
+                ← show _ = (starRingEnd ℂ) (∫ y in _, _) from integral_conj
+              ]
+              congr! 3 with _ y
+              simp
+              ring
         _ =   ‖∫ y in {y | dist x y ∈ Set.Ioo r 1}, g y * K x y * exp (I * n * y)‖ₑ
             + ‖∫ y in {y | dist x y ∈ Set.Ioo r 1}, (conj ∘ g) y * K x y * exp (I * n * y)‖ₑ := by
-          congr 1 <;>
-          rw [integral_const_mul, enorm_mul, show (-n * x : ℂ) = (-n * x : ℝ) by norm_cast,
-            enorm_exp_I_mul_ofReal, one_mul]
+          congr 1
+          · rw [
+              show ∫ y in _, _ = _ * ∫ y in _, g y * K x y * _ from integral_const_mul _ _,
+              enorm_mul,
+              show (-↑n * ↑x : ℂ) = ((-↑n * ↑x : ℝ) : ℂ) by norm_cast,
+              enorm_exp_I_mul_ofReal,
+              one_mul
+            ]
+          · rw [
+              show ∫ y in _, _ = _ * ∫ y in _, (conj ∘ g) y * K x y * _ from integral_const_mul _ _,
+              enorm_mul,
+              show (-↑n * ↑x : ℂ) = ((-↑n * ↑x : ℝ) : ℂ) by norm_cast,
+              enorm_exp_I_mul_ofReal,
+              one_mul
+            ]
     _ ≤ T g x + T (conj ∘ g) x := by
       simp_rw [carlesonOperatorReal]
       apply iSup₂_le

--- a/Carleson/Classical/ControlApproximationEffect.lean
+++ b/Carleson/Classical/ControlApproximationEffect.lean
@@ -352,14 +352,14 @@ lemma le_CarlesonOperatorReal {g : ℝ → ℂ} (hg : IntervalIntegrable g volum
             + ‖∫ y in {y | dist x y ∈ Set.Ioo r 1}, (conj ∘ g) y * K x y * exp (I * n * y)‖ₑ := by
           congr 1
           · rw [
-              show ∫ y in _, _ = _ * ∫ y in _, g y * K x y * _ from integral_const_mul _ _,
+              integral_const_mul _ _,
               enorm_mul,
               show (-↑n * ↑x : ℂ) = ((-↑n * ↑x : ℝ) : ℂ) by norm_cast,
               enorm_exp_I_mul_ofReal,
               one_mul
             ]
           · rw [
-              show ∫ y in _, _ = _ * ∫ y in _, (conj ∘ g) y * K x y * _ from integral_const_mul _ _,
+              integral_const_mul _ _,
               enorm_mul,
               show (-↑n * ↑x : ℂ) = ((-↑n * ↑x : ℝ) : ℂ) by norm_cast,
               enorm_exp_I_mul_ofReal,

--- a/Carleson/Classical/ControlApproximationEffect.lean
+++ b/Carleson/Classical/ControlApproximationEffect.lean
@@ -343,10 +343,7 @@ lemma le_CarlesonOperatorReal {g : ℝ → ℂ} (hg : IntervalIntegrable g volum
             + ‖∫ y in {y | dist x y ∈ Set.Ioo r 1}, exp (I * (-n * x)) * ((conj ∘ g) y * K x y * exp (I * n * y))‖ₑ := by
             congr 1
             · congr! 3 with y; ring
-            · rw [
-                ← RCLike.enorm_conj,
-                ← show _ = (starRingEnd ℂ) (∫ y in _, _) from integral_conj
-              ]
+            · erw [← RCLike.enorm_conj, ← integral_conj]
               congr! 3 with _ y
               simp
               ring

--- a/Carleson/Classical/ControlApproximationEffect.lean
+++ b/Carleson/Classical/ControlApproximationEffect.lean
@@ -223,6 +223,7 @@ lemma intervalIntegrable_mul_dirichletKernel'_specific {x : ℝ} (hx : x ∈ Set
 
 attribute [gcongr] iSup_congr
 
+set_option backward.isDefEq.respectTransparency false in
 lemma le_CarlesonOperatorReal {g : ℝ → ℂ} (hg : IntervalIntegrable g volume (-π) (3 * π)) {N : ℕ} {x : ℝ} (hx : x ∈ Set.Icc 0 (2 * π)) :
     ‖∫ (y : ℝ) in x - π..x + π, g y * ((max (1 - |x - y|) 0) * dirichletKernel' N (x - y))‖ₑ
     ≤ T g x + T (conj ∘ g) x := by
@@ -343,7 +344,7 @@ lemma le_CarlesonOperatorReal {g : ℝ → ℂ} (hg : IntervalIntegrable g volum
             + ‖∫ y in {y | dist x y ∈ Set.Ioo r 1}, exp (I * (-n * x)) * ((conj ∘ g) y * K x y * exp (I * n * y))‖ₑ := by
             congr 1
             · congr! 3 with y; ring
-            · erw [← RCLike.enorm_conj, ← integral_conj]
+            · rw [← RCLike.enorm_conj, ← integral_conj]
               congr! 3 with _ y
               simp
               ring

--- a/Carleson/Classical/DirichletKernel.lean
+++ b/Carleson/Classical/DirichletKernel.lean
@@ -175,9 +175,10 @@ lemma partialFourierSum_eq_conv_dirichletKernel {f : ℝ → ℂ} {x : ℝ}
       rw [partialFourierSum]
     _ = ∑ n ∈ Icc (-(N : ℤ)) N, (1 / (2 * π - 0)) • ((∫ (y : ℝ) in (0 : ℝ)..2 * π, (fourier (-n) ↑y • f y)) * (fourier n) ↑x) := by
       congr 1 with n
-      rw [fourierCoeffOn_eq_integral, smul_mul_assoc]
+      rw [fourierCoeffOn_eq_integral, smul_mul_assoc]; rfl
     _ = (1 / (2 * π)) * ∑ n ∈ Icc (-(N : ℤ)) N, ((∫ (y : ℝ) in (0 : ℝ)..2 * π, (fourier (-n) ↑y • f y)) * (fourier n) ↑x) := by
-      rw_mod_cast [← smul_sum, real_smul, sub_zero]
+      rw [show ∑ n ∈ Icc (-(N : ℤ)) ↑N, (1 / (2 * π - 0) : ℝ) • ((∫ (y : ℝ) in (0 : ℝ)..2 * π, (fourier (-n)) ↑y • f y) * (fourier n) ↑x) = (1 / (2 * π - 0) : ℝ) • ∑ n ∈ Icc (-(N : ℤ)) ↑N, ((∫ (y : ℝ) in (0 : ℝ)..2 * π, (fourier (-n)) ↑y • f y) * (fourier n) ↑x) from (Finset.smul_sum ..).symm]
+      rw_mod_cast [real_smul, sub_zero]
     _ = (1 / (2 * π)) * ∑ n ∈ Icc (-(N : ℤ)) N, ((∫ (y : ℝ) in (0 : ℝ)..2 * π, (fourier (-n) ↑y • f y) * (fourier n) ↑x)) := by
       congr with n
       exact (intervalIntegral.integral_mul_const _ _).symm

--- a/Carleson/Classical/Helper.lean
+++ b/Carleson/Classical/Helper.lean
@@ -42,7 +42,7 @@ lemma IntegrableOn.sub {α : Type*} {β : Type*} {m : MeasurableSpace α} {μ : 
 lemma ConditionallyCompleteLattice.le_biSup {α : Type*} [ConditionallyCompleteLinearOrder α]
     {ι : Type*} {f : ι → α} {s : Set ι} {a : α} (hfs : BddAbove (f '' s)) (ha : ∃ i ∈ s, f i = a) :
     a ≤ ⨆ i ∈ s, f i := by
-  apply ConditionallyCompleteLattice.le_csSup
+  apply le_csSup
   · --TODO: improve this
     rw [bddAbove_def] at *
     rcases hfs with ⟨x, hx⟩

--- a/Carleson/Classical/HilbertStrongType.lean
+++ b/Carleson/Classical/HilbertStrongType.lean
@@ -427,12 +427,18 @@ lemma approxHilbertTransform_eq_dirichletApprox {f : ℝ → ℂ} (hf : MemLp f 
   · apply IntervalIntegrable.mul_continuousOn ?_ (by fun_prop)
     rw [intervalIntegrable_iff_integrableOn_Ioc_of_le (by simp [Real.pi_nonneg])]
     exact (hf.restrict _).integrable le_top
-  simp only [one_div, mul_inv_rev, ← intervalIntegral.integral_const_mul, ←
-    intervalIntegral.integral_mul_const]
-  congr with y
-  simp only [modulationOperator, Int.cast_neg, Int.cast_natCast, mul_neg, neg_mul, mul_sub, exp_sub,
-    div_eq_inv_mul, ← exp_neg]
-  ring
+  simp only [one_div, mul_inv_rev]
+  calc
+    _ = (↑π)⁻¹ * 2⁻¹ * ((↑n)⁻¹ * cexp (I * ↑i * ↑x) * ∫ (y : ℝ) in 0..2 * π, modulationOperator (-↑i) f y * dirichletKernel i (x - y)) := by
+      ring
+    _ = (↑π)⁻¹ * 2⁻¹ * ∫ (y : ℝ) in (0 : ℝ)..2 * π, (↑n : ℂ)⁻¹ * cexp (I * ↑i * ↑x) * (modulationOperator (-↑i) f y * dirichletKernel i (x - y)) := by
+      congr
+      exact (intervalIntegral.integral_const_mul _ _).symm
+    _ = (↑π)⁻¹ * 2⁻¹ * ∫ (x_1 : ℝ) in 0..2 * π, f x_1 * ((↑n)⁻¹ * (dirichletKernel i (x - x_1) * cexp (I * ↑i * (↑x - ↑x_1)))) := by
+      congr
+      ext y
+      simp only [modulationOperator, Int.cast_neg, Int.cast_natCast, mul_neg, neg_mul, mul_sub, exp_sub, div_eq_inv_mul, ← exp_neg]
+      ring
 
 /-- The convolution with `dirichletApprox` is controlled on `(0, 2π]` in `L^2` norm. This
 follows from the fact that it coincides (up to a constant) with `approxHilbertTransform`,
@@ -447,7 +453,13 @@ lemma eLpNorm_convolution_dirichletApprox {g : ℝ → ℂ} {n : ℕ} (hg : MemL
     simp only [Pi.smul_apply, real_smul, ofReal_mul, ofReal_ofNat, ofReal_inv,
       approxHilbertTransform_eq_dirichletApprox hg, ← mul_assoc, Pi.smul_apply]
     rw [mul_inv_cancel₀ (by simp [Real.pi_ne_zero]), one_mul]
-  rw [this, eLpNorm_const_smul]
+  rw [
+    this,
+    show
+    eLpNorm ((2 * π : ℝ) • fun x ↦ approxHilbertTransform n g x) 2 (volume.restrict (Ioc 0 (2 * π))) =
+    ‖(2 * π : ℝ)‖ₑ * eLpNorm (fun x ↦ approxHilbertTransform n g x) 2 (volume.restrict (Ioc 0 (2 * π)))
+    from eLpNorm_const_smul ..
+  ]
   gcongr
   · have A : ‖2 * π‖ₑ = ENNReal.ofReal (2 * π) := by
       refine Real.enorm_of_nonneg ?_

--- a/Carleson/Classical/HilbertStrongType.lean
+++ b/Carleson/Classical/HilbertStrongType.lean
@@ -437,7 +437,7 @@ lemma approxHilbertTransform_eq_dirichletApprox {f : ℝ → ℂ} (hf : MemLp f 
     _ = (↑π)⁻¹ * 2⁻¹ * ∫ (x_1 : ℝ) in 0..2 * π, f x_1 * ((↑n)⁻¹ * (dirichletKernel i (x - x_1) * cexp (I * ↑i * (↑x - ↑x_1)))) := by
       congr
       ext y
-      simp only [modulationOperator, Int.cast_neg, Int.cast_natCast, mul_neg, neg_mul, mul_sub, exp_sub, div_eq_inv_mul, ← exp_neg]
+      simp [modulationOperator, mul_sub, exp_sub, div_eq_inv_mul, exp_neg]
       ring
 
 /-- The convolution with `dirichletApprox` is controlled on `(0, 2π]` in `L^2` norm. This

--- a/Carleson/Classical/VanDerCorput.lean
+++ b/Carleson/Classical/VanDerCorput.lean
@@ -79,8 +79,14 @@ lemma van_der_Corput {a b : ℝ} (hab : a ≤ b) {n : ℤ} {φ : ℝ → ℂ} {B
       _ = ‖(starRingEnd ℂ) (∫ x in a..b, cexp (I * ↑n * ↑x) * φ x)‖ :=
         (RCLike.norm_conj _).symm
       _ = ‖∫ x in a..b, cexp (I * ↑(-n) * ↑x) * ((starRingEnd ℂ) ∘ φ) x‖ := by
-        rw [intervalIntegral.integral_of_le (by linarith), ← integral_conj,
-          ← intervalIntegral.integral_of_le (by linarith)]
+        congr 1
+        have hconj : (starRingEnd ℂ) (∫ x in a..b, cexp (I * n * x) * φ x) = ∫ x in a..b, (starRingEnd ℂ) (cexp (I * n * x) * φ x) := by
+          change (starRingEnd ℂ) (∫ x in Ioc a b, cexp (I * n * x) * φ x ∂volume - ∫ x in Ioc b a, cexp (I * n * x) * φ x ∂volume) = _
+          rw [map_sub]
+          congr 1
+          · exact integral_conj.symm
+          · exact integral_conj.symm
+        rw [hconj]
         congr
         ext x
         rw [map_mul, ← exp_conj]
@@ -93,7 +99,7 @@ lemma van_der_Corput {a b : ℝ} (hab : a ≤ b) {n : ℤ} {φ : ℝ → ℂ} {B
           simp only [Function.comp_apply]
           rw [edist_eq_enorm_sub, ← map_sub, starRingEnd_apply,
             enorm_eq_nnnorm, nnnorm_star]
-          apply h1 hx hy
+          simpa [edist_eq_enorm_sub, enorm_eq_nnnorm] using h1 hx hy
         · intro x hx
           rw [Function.comp_apply, RCLike.norm_conj]
           exact h2 x hx
@@ -142,8 +148,7 @@ lemma van_der_Corput {a b : ℝ} (hab : a ≤ b) {n : ℤ} {φ : ℝ → ℂ} {B
       rw [mul_add, mul_assoc I n (π / n), mul_div_cancel₀ _ (by simpa), exp_add, mul_comm I π, exp_pi_mul_I]
       ring
     _ = ‖1 / 2 * ∫ x in a..b, cexp (I * ↑n * ↑x) * φ x - cexp (I * ↑n * (↑x + ↑π / ↑n)) * φ x‖ := by
-      congr
-      rw [← intervalIntegral.integral_const_mul]
+      rw [show (1/2 : ℂ) * ∫ x in a..b, cexp (I * ↑n * ↑x) * φ x - cexp (I * ↑n * (↑x + ↑π / ↑n)) * φ x = ∫ x in a..b, (1/2 : ℂ) * (cexp (I * ↑n * ↑x) * φ x - cexp (I * ↑n * (↑x + ↑π / ↑n)) * φ x) from (intervalIntegral.integral_const_mul (1/2 : ℂ) _).symm]
       congr
       ext x
       ring

--- a/Carleson/Classical/VanDerCorput.lean
+++ b/Carleson/Classical/VanDerCorput.lean
@@ -80,14 +80,8 @@ lemma van_der_Corput {a b : ℝ} (hab : a ≤ b) {n : ℤ} {φ : ℝ → ℂ} {B
       _ = ‖(starRingEnd ℂ) (∫ x in a..b, cexp (I * ↑n * ↑x) * φ x)‖ :=
         (RCLike.norm_conj _).symm
       _ = ‖∫ x in a..b, cexp (I * ↑(-n) * ↑x) * ((starRingEnd ℂ) ∘ φ) x‖ := by
-        congr 1
-        have hconj : (starRingEnd ℂ) (∫ x in a..b, cexp (I * n * x) * φ x) = ∫ x in a..b, (starRingEnd ℂ) (cexp (I * n * x) * φ x) := by
-          change (starRingEnd ℂ) (∫ x in Ioc a b, cexp (I * n * x) * φ x ∂volume - ∫ x in Ioc b a, cexp (I * n * x) * φ x ∂volume) = _
-          rw [map_sub]
-          congr 1
-          · exact integral_conj.symm
-          · exact integral_conj.symm
-        rw [hconj]
+        rw [intervalIntegral.integral_of_le (by linarith), ← integral_conj,
+          ← intervalIntegral.integral_of_le (by linarith)]
         congr
         ext x
         rw [map_mul, ← exp_conj]

--- a/Carleson/Classical/VanDerCorput.lean
+++ b/Carleson/Classical/VanDerCorput.lean
@@ -148,7 +148,7 @@ lemma van_der_Corput {a b : ℝ} (hab : a ≤ b) {n : ℤ} {φ : ℝ → ℂ} {B
       rw [mul_add, mul_assoc I n (π / n), mul_div_cancel₀ _ (by simpa), exp_add, mul_comm I π, exp_pi_mul_I]
       ring
     _ = ‖1 / 2 * ∫ x in a..b, cexp (I * ↑n * ↑x) * φ x - cexp (I * ↑n * (↑x + ↑π / ↑n)) * φ x‖ := by
-      rw [show (1/2 : ℂ) * ∫ x in a..b, cexp (I * ↑n * ↑x) * φ x - cexp (I * ↑n * (↑x + ↑π / ↑n)) * φ x = ∫ x in a..b, (1/2 : ℂ) * (cexp (I * ↑n * ↑x) * φ x - cexp (I * ↑n * (↑x + ↑π / ↑n)) * φ x) from (intervalIntegral.integral_const_mul (1/2 : ℂ) _).symm]
+      erw [← intervalIntegral.integral_const_mul]
       congr
       ext x
       ring

--- a/Carleson/Classical/VanDerCorput.lean
+++ b/Carleson/Classical/VanDerCorput.lean
@@ -46,6 +46,7 @@ lemma intervalIntegrable_continuous_mul_lipschitzOnWith
     apply mem_image_of_mem
     exact Ioo_subset_Icc_self hx
 
+set_option backward.isDefEq.respectTransparency false in
 lemma van_der_Corput {a b : ℝ} (hab : a ≤ b) {n : ℤ} {φ : ℝ → ℂ} {B K : ℝ≥0}
     (h1 : LipschitzOnWith K φ (Ioo a b)) (h2 : ∀ x ∈ Ioo a b, ‖φ x‖ ≤ B) :
     ‖∫ x in a..b, exp (I * n * x) * φ x‖ ≤
@@ -148,7 +149,7 @@ lemma van_der_Corput {a b : ℝ} (hab : a ≤ b) {n : ℤ} {φ : ℝ → ℂ} {B
       rw [mul_add, mul_assoc I n (π / n), mul_div_cancel₀ _ (by simpa), exp_add, mul_comm I π, exp_pi_mul_I]
       ring
     _ = ‖1 / 2 * ∫ x in a..b, cexp (I * ↑n * ↑x) * φ x - cexp (I * ↑n * (↑x + ↑π / ↑n)) * φ x‖ := by
-      erw [← intervalIntegral.integral_const_mul]
+      rw [← intervalIntegral.integral_const_mul]
       congr
       ext x
       ring

--- a/Carleson/Defs.lean
+++ b/Carleson/Defs.lean
@@ -217,7 +217,8 @@ class KernelProofData {X : Type*} (a : outParam ℕ) (K : outParam (X → X → 
 
 export KernelProofData (four_le_a)
 
-attribute [instance] KernelProofData.d KernelProofData.cf KernelProofData.hcz
+attribute [implicit_reducible, instance] KernelProofData.d KernelProofData.cf
+attribute [instance] KernelProofData.hcz
 
 section statements
 

--- a/Carleson/Discrete/Defs.lean
+++ b/Carleson/Discrete/Defs.lean
@@ -228,7 +228,7 @@ def ℭ₅ (k n j : ℕ) : Set (𝔓 X) :=
 lemma ℭ₅_def {k n j : ℕ} {p : 𝔓 X} :
     p ∈ ℭ₅ k n j ↔ p ∈ ℭ₄ k n j ∧ ∀ u ∈ 𝔘₁ k n j, ¬(𝓘 p : Set X) ⊆ ⋃ (i ∈ 𝓛 (X := X) n u), i := by
   rw [ℭ₅, mem_diff, 𝔏₄, mem_setOf, not_and, and_congr_right_iff]; intro h
-  simp_rw [h, true_implies]; push_neg; rfl
+  simp_rw [h, true_implies]; push Not; rfl
 
 lemma ℭ₅_subset_ℭ₄ {k n j : ℕ} : ℭ₅ k n j ⊆ ℭ₄ (X := X) k n j := fun t mt ↦ by
   rw [ℭ₅, mem_diff] at mt; exact mt.1

--- a/Carleson/Discrete/Defs.lean
+++ b/Carleson/Discrete/Defs.lean
@@ -154,8 +154,8 @@ lemma card_𝔅_of_mem_ℭ₁ {k n j : ℕ} {p : 𝔓 X} (hp : p ∈ ℭ₁ k n 
     (𝔅 k n p).toFinset.card ∈ Ico (2 ^ j) (2 ^ (j + 1)) := by
   simp_rw [ℭ₁, mem_diff, preℭ₁, mem_setOf, hp.1.1, true_and, not_le] at hp
   constructor
-  · convert hp.1; ext; simp
-  · convert hp.2; ext; simp
+  · convert hp.1; ext; simp only [Set.mem_toFinset, Finset.mem_filter, Finset.mem_univ, true_and]
+  · convert hp.2; ext; simp only [Set.mem_toFinset, Finset.mem_filter, Finset.mem_univ, true_and]
 
 /-- The subset `𝔏₀(k, n)` of `ℭ(k, n)`, given in (5.1.10).
 Not to be confused with `𝔏₀(k, n, j)` which is called `𝔏₀'` in Lean. -/
@@ -248,7 +248,8 @@ variable {k n j l : ℕ}
 lemma 𝔏₀_subset_ℭ : 𝔏₀ (X := X) k n ⊆ ℭ k n := fun _ mu ↦ mu.1
 lemma 𝔏₀_disjoint_ℭ₁ : Disjoint (𝔏₀ (X := X) k n) (ℭ₁ k n j) := by
   by_contra h; rw [not_disjoint_iff] at h; obtain ⟨p, ⟨_, b0⟩, ⟨⟨_, bp⟩ , _⟩⟩ := h
-  simp [b0] at bp
+  simp only [b0, Set.mem_empty_iff_false, Finset.filter_false, Finset.card_empty] at bp
+  linarith [Nat.two_pow_pos j]
 
 lemma 𝔏₁_subset_ℭ₁ : 𝔏₁ (X := X) k n j l ⊆ ℭ₁ k n j := minLayer_subset
 lemma 𝔏₁_subset_ℭ : 𝔏₁ (X := X) k n j l ⊆ ℭ k n := minLayer_subset.trans ℭ₁_subset_ℭ
@@ -274,7 +275,7 @@ def highDensityTiles : Set (𝔓 X) :=
   { p : 𝔓 X | 2 ^ (2 * a + 5) * volume F / volume G < dens₂ {p} }
 
 lemma highDensityTiles_empty (hF : volume F = 0) : highDensityTiles = (∅ : Set (𝔓 X)) := by
-  suffices ∀ (p : 𝔓 X), dens₂ {p} = 0 by simp [highDensityTiles, this]
+  suffices ∀ (p : 𝔓 X), dens₂ {p} = 0 by simp [highDensityTiles, this]; rfl
   simp_rw [dens₂, ENNReal.iSup_eq_zero, ENNReal.div_eq_zero_iff]
   exact fun _ _ _ r _ ↦ Or.inl <| measure_inter_null_of_null_left (ball (𝔠 _) r) hF
 
@@ -282,17 +283,17 @@ lemma highDensityTiles_empty' (hG : volume G = 0) :
     highDensityTiles = (∅ : Set (𝔓 X)) := by
   by_cases hF : volume F = 0
   · exact highDensityTiles_empty hF
-  suffices 2 ^ (2 * a + 5) * volume F / volume G = ⊤ by simp [highDensityTiles, this]
+  suffices 2 ^ (2 * a + 5) * volume F / volume G = ⊤ by simp [highDensityTiles, this]; rfl
   exact hG ▸ ENNReal.div_zero (mul_ne_zero (by simp) hF)
 
 /-- The exceptional set `G₁`, defined in (5.1.25). -/
 def G₁ : Set X := ⋃ (p : 𝔓 X) (_ : p ∈ highDensityTiles), 𝓘 p
 
 lemma G₁_empty (hF : volume F = 0) : G₁ = (∅ : Set X) := by
-  simp [G₁, highDensityTiles_empty hF]
+  simp only [G₁, highDensityTiles_empty hF, Set.biUnion_empty]
 
 lemma G₁_empty' (hG : volume G = 0) : G₁ = (∅ : Set X) := by
-  simp [G₁, highDensityTiles_empty' hG]
+  simp only [G₁, highDensityTiles_empty' hG, Set.biUnion_empty]
 
 lemma measurable_G₁ : MeasurableSet (G₁ (X := X)) :=
   Finite.measurableSet_biUnion highDensityTiles.toFinite fun _ _ ↦ coeGrid_measurable

--- a/Carleson/Discrete/ExceptionalSet.lean
+++ b/Carleson/Discrete/ExceptionalSet.lean
@@ -1,5 +1,6 @@
 import Carleson.Discrete.Defs
 import Carleson.ToMathlib.HardyLittlewood
+
 open MeasureTheory Measure NNReal Metric Set
 open scoped ENNReal
 
@@ -54,6 +55,7 @@ section first_exception
 
 open ENNReal
 
+set_option backward.isDefEq.respectTransparency false in
 /-- Lemma 5.2.1 -/
 lemma first_exception' : volume (G₁ : Set X) ≤ 2 ^ (- 5 : ℤ) * volume G := by
   -- Handle trivial cases
@@ -102,9 +104,7 @@ lemma first_exception' : volume (G₁ : Set X) ≤ 2 ^ (- 5 : ℤ) * volume G :=
       ∫⁻ (x : X) in ball (𝔠 p) (r p), u x := by
     intro p h
     simp_rw [𝓑, mem_toFinset] at h
-    have hr' := (hr h).2.le
-    simp only [r, dif_pos h] at hr' ⊢
-    simpa [u, lintegral_indicator, Measure.restrict_apply, measurableSet_F] using hr'
+    simpa [u, lintegral_indicator, Measure.restrict_apply, measurableSet_F, r, h] using (hr h).2.le
   have ineq := 𝓑.measure_biUnion_le_lintegral (A := defaultA a) K u h2u
   simp only [u, lintegral_indicator, measurableSet_F, Pi.one_apply, lintegral_const,
     MeasurableSet.univ, Measure.restrict_apply, univ_inter, one_mul] at ineq
@@ -191,6 +191,7 @@ lemma iUnion_MsetA_eq_setA : ⋃ i ∈ MsetA (X := X) l k n, ↑i = setA (X := X
   · obtain ⟨j, mj, lj⟩ := mx; exact mem_of_mem_of_subset lj mj
   · obtain ⟨j, mj, lj⟩ := dyadic_union mx; use j, lj, mj
 
+set_option backward.isDefEq.respectTransparency false in
 /-- Equation (5.2.7) in the proof of Lemma 5.2.5. -/
 lemma john_nirenberg_aux1 {L : Grid X} (mL : L ∈ Grid.maxCubes (MsetA l k n))
     (mx : x ∈ setA (l + 1) k n) (mx₂ : x ∈ L) : 2 ^ (n + 1) ≤
@@ -229,8 +230,7 @@ lemma john_nirenberg_aux1 {L : Grid X} (mL : L ∈ Grid.maxCubes (MsetA l k n))
         ext y; simp_rw [Q₂, mem_setOf_eq, Set.notMem_empty, iff_false, not_and, h, Grid.lt_def,
           not_and_or, not_lt]
         exact fun _ ↦ Or.inr (Grid.le_topCube).2
-      simp only [stackSize, this, Set.mem_empty_iff_false, Finset.filter_false,
-        Finset.sum_empty, Nat.zero_le]
+      simp [stackSize, this]
     have Lslq : ∀ q ∈ Q₂, L.succ ≤ 𝓘 q := fun q mq ↦ Grid.succ_le_of_lt mq.2
     have Lout : ¬(L.succ : Set X) ⊆ setA (X := X) l k n := by
       by_contra! hs
@@ -531,10 +531,11 @@ private lemma x_mem_𝓘u : x ∈ (𝓘 u) := by
   simp only [𝔘, mem_filter] at hu
   exact hu.2.1
 
+set_option backward.isDefEq.respectTransparency false in
 include hu in
 private lemma 𝒬m_mem_ball : 𝒬 m ∈ ball_(u) (𝒬 u) 100 := by
   simp only [𝔘, mem_filter, smul] at hu
-  exact hu.2.2.2 (@mem_ball_self (WithFunctionDistance (𝔠 m) (↑D ^ 𝔰 m / 4)) inferInstance (𝒬 m) 1 one_pos)
+  exact hu.2.2.2 (by simp)
 
 include hu hu' in
 private lemma 𝓘_not_lt_𝓘 : ¬𝓘 u < 𝓘 u' := by
@@ -562,14 +563,13 @@ private lemma disjoint_balls (h : u' ≠ u'') :
   nth_rewrite 1 [ball_eq_ball hu hu', ball_eq_ball hu hu'']
   convert cball_disjoint h (𝓘_eq_𝓘 hu' hu'') using 2 <;> norm_num
 
+set_option backward.isDefEq.respectTransparency false in
 include hu hu' in
 private lemma mem_big_ball : 𝒬 u' ∈ big_ball m u := by
   have : 𝒬 m ∈ ball_(u) (𝒬 u') 100 := ball_eq_ball hu hu' ▸ 𝒬m_mem_ball hu'
-  have h2 : 𝒬 u' ∈ ball_(u) (𝒬 m) 100 := @mem_ball_comm _ (instPseudoMetricSpaceWithFunctionDistance (x := 𝔠 u) (r := ↑D ^ 𝔰 u / 4)) _ _ _ |>.mp this
-  simp only [big_ball]
-  apply @ball_subset_ball (WithFunctionDistance (𝔠 u) (↑D ^ 𝔰 u / 4))
-    instPseudoMetricSpaceWithFunctionDistance (𝒬 m) 100 (2 ^ 9 * 0.2) (by norm_num)
-  exact h2
+  rw [@mem_ball_comm] at this
+  simp only [big_ball, mem_ball] at this ⊢
+  exact this.trans (by norm_num)
 
 open scoped Classical in
 include hu in
@@ -585,6 +585,7 @@ private lemma balls_cover_big_ball : CoveredByBalls (big_ball m u) (defaultA a ^
 private lemma 𝒬_injOn_𝔘m : InjOn 𝒬 (SetLike.coe (𝔘 k n j x m)) :=
   fun _ hu _ hu' h ↦ 𝒬_inj h (𝓘_eq_𝓘 hu hu')
 
+set_option backward.isDefEq.respectTransparency false in
 private lemma card_𝔘m_le : (𝔘 k n j x m).card ≤ (defaultA a) ^ 9 := by
   classical
   by_cases h : 𝔘 k n j x m = ∅
@@ -597,15 +598,11 @@ private lemma card_𝔘m_le : (𝔘 k n j x m).card ≤ (defaultA a) ^ 9 := by
   -- ≤ 1, so `(𝔘 k n j x m).card = ((𝔘 k n j x m).image 𝒬).card ≤ (𝓑.biUnion 𝓕).card ≤ 𝓑.card`
   have 𝒬𝔘_eq_union: (𝔘 k n j x m).image 𝒬 = 𝓑.biUnion 𝓕 := by
     ext f
-    simp only [𝓕]
-    constructor
-    · intro hf
-      obtain ⟨g, hg⟩ : ∃ g ∈ 𝓑, f ∈ @ball _ pm g 0.2 := by
-        simpa only [mem_iUnion, exists_prop] using 𝓑_cover (subset_big_ball hu f hf)
-      exact Finset.mem_biUnion.mpr ⟨g, hg.1, mem_filter.mpr ⟨hf, hg.2⟩⟩
-    · intro hf
-      obtain ⟨g, _, hfg⟩ := Finset.mem_biUnion.mp hf
-      exact (mem_filter.mp hfg).1
+    simp only [𝓕, Finset.mem_biUnion, mem_filter]
+    refine ⟨fun hf ↦ ?_, fun ⟨_, _, h, _⟩ ↦ h⟩
+    obtain ⟨g, hg⟩ : ∃ g ∈ 𝓑, f ∈ @ball _ pm g 0.2 := by
+      simpa only [mem_iUnion, exists_prop] using 𝓑_cover (subset_big_ball hu f hf)
+    exact ⟨g, hg.1, hf, hg.2⟩
   have card_le_one : ∀ f ∈ 𝓑, (𝓕 f).card ≤ 1 := by
     refine fun f _ ↦ card_le_one.mpr (fun g₁ hg₁ g₂ hg₂ ↦ ?_)
     by_contra! h
@@ -614,10 +611,8 @@ private lemma card_𝔘m_le : (𝔘 k n j x m).card ≤ (defaultA a) ^ 9 := by
     obtain ⟨u₂, hu₂, rfl⟩ := Finset.mem_image.mp hg₂.1
     apply Set.not_disjoint_iff.mpr ⟨f, mem_ball_comm.mp hg₁.2, mem_ball_comm.mp hg₂.2⟩
     exact disjoint_balls hu hu₁ hu₂ (ne_of_apply_ne 𝒬 h)
-  calc #(𝔘 k n j x m)
-      = #((𝔘 k n j x m).image 𝒬) := (card_image_iff.mpr 𝒬_injOn_𝔘m).symm
-    _ = #(𝓑.biUnion 𝓕) := by rw [𝒬𝔘_eq_union]; rfl
-    _ ≤ _ := (mul_one 𝓑.card ▸ card_biUnion_le_card_mul 𝓑 𝓕 1 card_le_one).trans 𝓑_card_le
+  rw [← card_image_iff.mpr 𝒬_injOn_𝔘m, 𝒬𝔘_eq_union]
+  exact (mul_one 𝓑.card ▸ card_biUnion_le_card_mul 𝓑 𝓕 1 card_le_one).trans 𝓑_card_le
 
 variable (k n j) (x) in
 open scoped Classical in

--- a/Carleson/Discrete/ExceptionalSet.lean
+++ b/Carleson/Discrete/ExceptionalSet.lean
@@ -1,6 +1,6 @@
 import Carleson.Discrete.Defs
 import Carleson.ToMathlib.HardyLittlewood
-
+import Paperproof
 open MeasureTheory Measure NNReal Metric Set
 open scoped ENNReal
 
@@ -95,7 +95,7 @@ lemma first_exception' : volume (G₁ : Set X) ≤ 2 ^ (- 5 : ℤ) * volume G :=
     suffices (𝓘 p : Set X) ⊆ ball (𝔠 p) (r p) from this xp
     apply Grid_subset_ball.trans ∘ ball_subset_ball
     convert (hr hp).1.le
-    simp [r, hp]
+    simp only [r, dif_pos hp]
   apply (OuterMeasureClass.measure_mono volume this).trans
   -- Apply `measure_biUnion_le_lintegral` to `u := F.indicator 1` to bound the volume of ⋃ 𝓑.
   let u := F.indicator (1 : X → ℝ≥0∞)
@@ -103,7 +103,9 @@ lemma first_exception' : volume (G₁ : Set X) ≤ 2 ^ (- 5 : ℤ) * volume G :=
       ∫⁻ (x : X) in ball (𝔠 p) (r p), u x := by
     intro p h
     simp_rw [𝓑, mem_toFinset] at h
-    simpa [u, lintegral_indicator, Measure.restrict_apply, measurableSet_F, r, h] using (hr h).2.le
+    have hr' := (hr h).2.le
+    simp only [r, dif_pos h] at hr' ⊢
+    simpa [u, lintegral_indicator, Measure.restrict_apply, measurableSet_F] using hr'
   have ineq := 𝓑.measure_biUnion_le_lintegral (A := defaultA a) K u h2u
   simp only [u, lintegral_indicator, measurableSet_F, Pi.one_apply, lintegral_const,
     MeasurableSet.univ, Measure.restrict_apply, univ_inter, one_mul] at ineq
@@ -135,7 +137,7 @@ lemma dense_cover (k : ℕ) : volume (⋃ i ∈ 𝓒 (X := X) k, (i : Set X)) �
     simp_rw [𝓒]; intro q mq; rw [mem_iUnion₂] at mq ⊢; obtain ⟨i, hi, mi⟩ := mq
     rw [aux𝓒, mem_diff, mem_setOf] at hi; obtain ⟨j, hj, mj⟩ := hi.1
     use j, ?_, mem_of_mem_of_subset mi hj.1
-    simpa [M] using mj
+    simp only [M, Finset.mem_filter_univ]; exact mj
   let M' := Grid.maxCubes M
   have s₂ : ⋃ i ∈ M, (i : Set X) ⊆ ⋃ i ∈ M', ↑i := iUnion₂_mono' fun i mi ↦ by
     obtain ⟨j, mj, hj⟩ := Grid.exists_maximal_supercube mi; use j, mj, hj.1
@@ -214,7 +216,7 @@ lemma john_nirenberg_aux1 {L : Grid X} (mL : L ∈ Grid.maxCubes (MsetA l k n))
     simp_rw [mem_setOf_eq, and_congr_right_iff]
     refine fun _ ↦ ⟨fun h ↦ ?_, ?_⟩
     · apply lt_of_le_of_ne <| (le_or_ge_or_disjoint.resolve_left h.1).resolve_right h.2
-      by_contra k; subst k; simp at h
+      by_contra k; subst k; exact absurd le_rfl h.1
     · rw [Grid.lt_def, Grid.le_def, not_and_or, not_le]
       exact fun h ↦ ⟨Or.inr h.2, not_disjoint_iff.mpr ⟨x, mem_of_mem_of_subset mx₂ h.1, mx₂⟩⟩
   rw [req] at mx
@@ -228,7 +230,8 @@ lemma john_nirenberg_aux1 {L : Grid X} (mL : L ∈ Grid.maxCubes (MsetA l k n))
         ext y; simp_rw [Q₂, mem_setOf_eq, Set.notMem_empty, iff_false, not_and, h, Grid.lt_def,
           not_and_or, not_lt]
         exact fun _ ↦ Or.inr (Grid.le_topCube).2
-      simp [stackSize, this]
+      simp only [stackSize, this, Set.mem_empty_iff_false, Finset.filter_false,
+        Finset.sum_empty, Nat.zero_le]
     have Lslq : ∀ q ∈ Q₂, L.succ ≤ 𝓘 q := fun q mq ↦ Grid.succ_le_of_lt mq.2
     have Lout : ¬(L.succ : Set X) ⊆ setA (X := X) l k n := by
       by_contra! hs
@@ -532,7 +535,7 @@ private lemma x_mem_𝓘u : x ∈ (𝓘 u) := by
 include hu in
 private lemma 𝒬m_mem_ball : 𝒬 m ∈ ball_(u) (𝒬 u) 100 := by
   simp only [𝔘, mem_filter, smul] at hu
-  exact hu.2.2.2 (by simp)
+  exact hu.2.2.2 (@mem_ball_self (WithFunctionDistance (𝔠 m) (↑D ^ 𝔰 m / 4)) inferInstance (𝒬 m) 1 one_pos)
 
 include hu hu' in
 private lemma 𝓘_not_lt_𝓘 : ¬𝓘 u < 𝓘 u' := by
@@ -552,7 +555,7 @@ private lemma 𝓘_eq_𝓘 : 𝓘 u = 𝓘 u' :=
 
 include hu hu' in
 private lemma ball_eq_ball : ball_(u) = ball_(u') := by
-  rw [𝔠, 𝔰, 𝓘_eq_𝓘 hu hu']
+  delta 𝔠 𝔰; rw [𝓘_eq_𝓘 hu hu']
 
 include hu hu' hu'' in
 private lemma disjoint_balls (h : u' ≠ u'') :
@@ -563,9 +566,11 @@ private lemma disjoint_balls (h : u' ≠ u'') :
 include hu hu' in
 private lemma mem_big_ball : 𝒬 u' ∈ big_ball m u := by
   have : 𝒬 m ∈ ball_(u) (𝒬 u') 100 := ball_eq_ball hu hu' ▸ 𝒬m_mem_ball hu'
-  rw [@mem_ball_comm] at this
-  simp only [big_ball, mem_ball] at this ⊢
-  exact this.trans (by norm_num)
+  have h2 : 𝒬 u' ∈ ball_(u) (𝒬 m) 100 := @mem_ball_comm _ (instPseudoMetricSpaceWithFunctionDistance (x := 𝔠 u) (r := ↑D ^ 𝔰 u / 4)) _ _ _ |>.mp this
+  simp only [big_ball]
+  apply @ball_subset_ball (WithFunctionDistance (𝔠 u) (↑D ^ 𝔰 u / 4))
+    instPseudoMetricSpaceWithFunctionDistance (𝒬 m) 100 (2 ^ 9 * 0.2) (by norm_num)
+  exact h2
 
 open scoped Classical in
 include hu in
@@ -584,7 +589,7 @@ private lemma 𝒬_injOn_𝔘m : InjOn 𝒬 (SetLike.coe (𝔘 k n j x m)) :=
 private lemma card_𝔘m_le : (𝔘 k n j x m).card ≤ (defaultA a) ^ 9 := by
   classical
   by_cases h : 𝔘 k n j x m = ∅
-  · simp [h]
+  · simp only [h, Finset.card_empty]; exact Nat.zero_le _
   have ⟨u, hu⟩ := Finset.nonempty_of_ne_empty h
   let pm := instPseudoMetricSpaceWithFunctionDistance (x := 𝔠 u) (r := (D ^ 𝔰 u / 4))
   have ⟨𝓑, 𝓑_card_le, 𝓑_cover⟩ := balls_cover_big_ball m u
@@ -593,21 +598,27 @@ private lemma card_𝔘m_le : (𝔘 k n j x m).card ≤ (defaultA a) ^ 9 := by
   -- ≤ 1, so `(𝔘 k n j x m).card = ((𝔘 k n j x m).image 𝒬).card ≤ (𝓑.biUnion 𝓕).card ≤ 𝓑.card`
   have 𝒬𝔘_eq_union: (𝔘 k n j x m).image 𝒬 = 𝓑.biUnion 𝓕 := by
     ext f
-    simp only [𝓕, Finset.mem_biUnion, mem_filter]
-    refine ⟨fun hf ↦ ?_, fun ⟨_, _, h, _⟩ ↦ h⟩
-    obtain ⟨g, hg⟩ : ∃ g ∈ 𝓑, f ∈ @ball _ pm g 0.2 := by
-      simpa only [mem_iUnion, exists_prop] using 𝓑_cover (subset_big_ball hu f hf)
-    exact ⟨g, hg.1, hf, hg.2⟩
+    simp only [𝓕]
+    constructor
+    · intro hf
+      obtain ⟨g, hg⟩ : ∃ g ∈ 𝓑, f ∈ @ball _ pm g 0.2 := by
+        simpa only [mem_iUnion, exists_prop] using 𝓑_cover (subset_big_ball hu f hf)
+      exact Finset.mem_biUnion.mpr ⟨g, hg.1, mem_filter.mpr ⟨hf, hg.2⟩⟩
+    · intro hf
+      obtain ⟨g, _, hfg⟩ := Finset.mem_biUnion.mp hf
+      exact (mem_filter.mp hfg).1
   have card_le_one : ∀ f ∈ 𝓑, (𝓕 f).card ≤ 1 := by
     refine fun f _ ↦ card_le_one.mpr (fun g₁ hg₁ g₂ hg₂ ↦ ?_)
     by_contra! h
-    simp only [mem_filter, 𝓕, Finset.mem_image] at hg₁ hg₂
-    rcases hg₁.1 with ⟨u₁, hu₁, rfl⟩
-    rcases hg₂.1 with ⟨u₂, hu₂, rfl⟩
+    simp only [mem_filter, 𝓕] at hg₁ hg₂
+    obtain ⟨u₁, hu₁, rfl⟩ := Finset.mem_image.mp hg₁.1
+    obtain ⟨u₂, hu₂, rfl⟩ := Finset.mem_image.mp hg₂.1
     apply Set.not_disjoint_iff.mpr ⟨f, mem_ball_comm.mp hg₁.2, mem_ball_comm.mp hg₂.2⟩
     exact disjoint_balls hu hu₁ hu₂ (ne_of_apply_ne 𝒬 h)
-  rw [← card_image_iff.mpr 𝒬_injOn_𝔘m, 𝒬𝔘_eq_union]
-  exact (mul_one 𝓑.card ▸ card_biUnion_le_card_mul 𝓑 𝓕 1 card_le_one).trans 𝓑_card_le
+  calc #(𝔘 k n j x m)
+      = #((𝔘 k n j x m).image 𝒬) := (card_image_iff.mpr 𝒬_injOn_𝔘m).symm
+    _ = #(𝓑.biUnion 𝓕) := by rw [𝒬𝔘_eq_union]; rfl
+    _ ≤ _ := (mul_one 𝓑.card ▸ card_biUnion_le_card_mul 𝓑 𝓕 1 card_le_one).trans 𝓑_card_le
 
 variable (k n j) (x) in
 open scoped Classical in
@@ -630,9 +641,11 @@ private lemma indicator_le : ∀ u ∈ (𝔘₁ k n j).toFinset.filter (x ∈ �
     (𝓘 u : Set X).indicator 1 x ≤ (2 : ℝ) ^ (-j : ℤ) * stackSize (𝔐' k n u) x := by
   intro u hu
   by_cases hx : x ∈ (𝓘 u : Set X); swap
-  · simp [hx]
+  · simp only [Set.indicator_of_notMem hx]
+    exact mul_nonneg (zpow_nonneg (by norm_num) _) (Nat.cast_nonneg _)
   suffices (2 : ℝ) ^ (j : ℤ) ≤ stackSize (𝔐' k n u) x by calc
-    _ ≤ (2 : ℝ) ^ (-j : ℤ) * (2 : ℝ) ^ (j : ℤ)       := by simp [hx]
+    _ ≤ (2 : ℝ) ^ (-j : ℤ) * (2 : ℝ) ^ (j : ℤ)       := by
+        rw [Set.indicator_of_mem hx, Pi.one_apply, ← zpow_add₀ (by norm_num : (2 : ℝ) ≠ 0), neg_add_cancel, zpow_zero]
     _ ≤ (2 : ℝ) ^ (-j : ℤ) * stackSize (𝔐' k n u) x := by gcongr
   norm_cast
   simp only [𝔘₁, Finset.mem_filter, toFinset_setOf] at hu
@@ -640,7 +653,7 @@ private lemma indicator_le : ∀ u ∈ (𝔘₁ k n j).toFinset.filter (x ∈ �
   simp only [Finset.coe_filter, mem_toFinset, 𝔐', Finset.card_eq_sum_ones]
   refine Finset.sum_congr rfl (fun m hm ↦ ?_)
   simp only [TileLike.le_def, smul_fst, Finset.mem_filter] at hm
-  simp [hm.2.2.1.1 hx]
+  simp only [Set.indicator_of_mem (hm.2.2.1.1 hx), Pi.one_apply]
 
 open Finset in
 /-- Lemma 5.2.8 -/
@@ -652,7 +665,7 @@ lemma tree_count :
       ∑ u ∈ (𝔘₁ k n j).toFinset.filter (x ∈ 𝓘 ·), (𝓘 u : Set X).indicator (1 : X → ℝ) x := by
     rw [filter_mem_univ_eq_toFinset (𝔘₁ k n j), sum_filter]
     exact sum_congr rfl <|
-      fun u _ ↦ _root_.by_cases (p := x ∈ 𝓘 u) (fun hx ↦ by simp [hx]) (fun hx ↦ by simpa [hx])
+      fun u _ ↦ by simp only [Set.indicator_apply, Membership.mem]; simp
   rw [stackSize_real, this]
   -- Use inequality (5.2.20) to bound the LHS by a double sum, then interchange the sums.
   apply le_trans (sum_le_sum indicator_le)
@@ -707,8 +720,7 @@ lemma boundary_exception {u : 𝔓 X} :
                   · push_cast
                     rfl
                   · simp
-          rw [show ⋃ i ∈ 𝓛 (X := X) n u, (i : Set X) = ⋃ i : 𝓛 (X := X) n u, (i : Set X) by simp]
-          exact measure_mono <| Set.iUnion_subset_iff.mpr <| by simp [i_subset_X_u]
+          exact measure_mono (Set.iUnion₂_subset i_subset_X_u)
       _ ≤ 2 * (12 * D ^ (- Z * (n + 1) - 1 : ℤ) : ℝ≥0) ^ κ * volume (𝓘 u : Set X) := by
           have small_boundary_observation : ∀ i ∈ 𝓛 (X := X) n u, volume X_u ≤ 2 * (12 * D ^ (- Z * (n + 1) - 1 : ℤ) : ℝ≥0) ^ κ * volume (𝓘 u : Set X) := by
             intro i ⟨_, s_i_eq_stuff, _⟩
@@ -811,12 +823,12 @@ lemma boundary_exception {u : 𝔓 X} :
       have h1 : volume (⋃ i ∈ 𝓛 (X := X) n u, (i : Set X)) ≤
         ∑' i : 𝓛 (X := X) n u, volume (i : Set X) := measure_biUnion_le _ (𝓛 n u).to_countable _
       have h2 : ∑' i : 𝓛 (X := X) n u, volume (i : Set X) = 0 := by
-        have : 𝓛 (X := X) n u = ∅ := Set.not_nonempty_iff_eq_empty'.mp <| by
-          rw [Set.Nonempty] at h_𝓛_n_u_non_empty
-          simp [h_𝓛_n_u_non_empty]
-        simp [this]
+        have : IsEmpty (𝓛 (X := X) n u) := by
+          rw [Set.isEmpty_coe_sort]
+          exact Set.not_nonempty_iff_eq_empty.mp h_𝓛_n_u_non_empty
+        exact tsum_empty
       exact (le_of_le_of_eq h1 h2).antisymm (by simp)
-    simp [this]
+    simp only [this, zero_le]
 
 lemma third_exception_aux :
     volume (⋃ p ∈ 𝔏₄ (X := X) k n j, (𝓘 p : Set X)) ≤

--- a/Carleson/Discrete/ExceptionalSet.lean
+++ b/Carleson/Discrete/ExceptionalSet.lean
@@ -1,6 +1,5 @@
 import Carleson.Discrete.Defs
 import Carleson.ToMathlib.HardyLittlewood
-import Paperproof
 open MeasureTheory Measure NNReal Metric Set
 open scoped ENNReal
 

--- a/Carleson/Discrete/ExceptionalSet.lean
+++ b/Carleson/Discrete/ExceptionalSet.lean
@@ -664,7 +664,7 @@ lemma tree_count :
       ∑ u ∈ (𝔘₁ k n j).toFinset.filter (x ∈ 𝓘 ·), (𝓘 u : Set X).indicator (1 : X → ℝ) x := by
     rw [filter_mem_univ_eq_toFinset (𝔘₁ k n j), sum_filter]
     exact sum_congr rfl <|
-      fun u _ ↦ by simp only [Set.indicator_apply, Membership.mem]; simp
+      fun u _ ↦ by simp [Membership.mem]
   rw [stackSize_real, this]
   -- Use inequality (5.2.20) to bound the LHS by a double sum, then interchange the sums.
   apply le_trans (sum_le_sum indicator_le)

--- a/Carleson/Discrete/ForestComplement.lean
+++ b/Carleson/Discrete/ForestComplement.lean
@@ -49,7 +49,7 @@ lemma exists_k_of_mem_𝔓pos (h : p ∈ 𝔓pos (X := X)) : ∃ k, p ∈ TilesA
     obtain ⟨k, hk⟩ := exists_mem_aux𝓒 vpos; exact ⟨_, hk⟩
   let s : ℕ := WellFounded.min wellFounded_lt _ Cn
   have s_mem : s ∈ C := WellFounded.min_mem ..
-  have s_min : ∀ t ∈ C, s ≤ t := fun t mt ↦ WellFounded.min_le _ mt _
+  have s_min : ∀ t ∈ C, s ≤ t := fun t mt ↦ WellFounded.min_le _ mt
   have s_pos : 0 < s := by
     by_contra! h; rw [nonpos_iff_eq_zero] at h
     simp_rw [h, C, aux𝓒, mem_setOf] at s_mem; apply absurd s_mem; push Not; intro _ _
@@ -83,7 +83,7 @@ lemma exists_E₂_volume_pos_of_mem_𝔓pos (h : p ∈ 𝔓pos (X := X)) : ∃ r
   suffices ⋃ i : ℕ, Q ⁻¹' ball_(p) (𝒬 p) i = univ by
     rw [this, inter_univ, ← pos_iff_ne_zero]
     rw [𝔓pos, mem_setOf] at h; exact h.trans_le (measure_mono inter_subset_left)
-  simp_rw [iUnion_eq_univ_iff, mem_preimage, mem_ball]
+  simp_rw [iUnion_eq_univ_iff, mem_preimage]
   exact fun x ↦ exists_nat_gt (dist_(p) (Q x) (𝒬 p))
 
 lemma dens'_pos_of_mem_𝔓pos (h : p ∈ 𝔓pos (X := X)) (hp : p ∈ TilesAt k) : 0 < dens' k {p} := by
@@ -330,11 +330,14 @@ lemma card_𝔒 (p' : 𝔓 X) {l : ℝ≥0} (hl : 2 ≤ l) : (𝔒 p' l).card �
     simp_rw [𝔒, Finset.mem_filter_univ] at mp''
     obtain ⟨x, mx₁, mx₂⟩ := not_disjoint_iff.mp mp''.2
     replace mx₂ := _root_.subset_cball mx₂
-    rw [@mem_ball] at mx₁ mx₂
+    rw [@mem_ball] at mx₁
     calc
       _ ≤ 5⁻¹ + (dist_{𝓘 p'} x (𝒬 p'') + dist_{𝓘 p'} x (𝒬 p')) :=
         add_le_add_right (dist_triangle_left ..) _
-      _ ≤ 5⁻¹ + (1 + l) := by gcongr; rw [← mp''.1]; exact mx₂.le
+      _ ≤ 5⁻¹ + (1 + l) := by
+        gcongr
+        · rw [← mp''.1]; exact mx₂.le
+        · exact mx₁.le
       _ = _ := by rw [inv_eq_one_div, ← add_assoc, add_comm _ l.toReal]; norm_num
   have vO : CoveredByBalls (ball_(p') (𝒬 p') (l + 6 / 5)) ⌊2 ^ (4 * a) * l ^ a⌋₊ 5⁻¹ := by
     apply (ballsCoverBalls_iterate (show 0 < 5⁻¹ by positivity) (𝒬 p')).mono_nat
@@ -360,8 +363,8 @@ lemma card_𝔒 (p' : 𝔓 X) {l : ℝ≥0} (hl : 2 ≤ l) : (𝔒 p' l).card �
       (fun p'' mp'' ↦ ?_) (fun t _ o₁ mo₁ o₂ mo₂ ↦ ?_)).trans cT
   · have := (tO _ mp'').trans uT (mem_ball_self (by positivity))
     rwa [mem_iUnion₂, bex_def] at this
-  · simp_rw [mem_setOf_eq] at mo₁ mo₂; rw [@mem_ball_comm] at mo₁ mo₂
-    exact djO.elim mo₁.1 mo₂.1 (not_disjoint_iff.mpr ⟨t, mo₁.2, mo₂.2⟩)
+  · simp_rw [mem_setOf_eq] at mo₁ mo₂
+    exact djO.elim mo₁.1 mo₂.1 (not_disjoint_iff.mpr ⟨t, mem_ball_comm.mp mo₁.2, mem_ball_comm.mp mo₂.2⟩)
 
 section
 
@@ -461,7 +464,7 @@ lemma iUnion_L0' : ⋃ (l < n), 𝔏₀' (X := X) k n l = 𝔏₀ k n := by
   · have l1 : 𝓘 s₀.1 ≤ 𝓘 sl.1 := s.head_le_last.1
     have l2 : 𝓘 sl.1 ≤ 𝓘 b := 𝓘p'b ▸ sp'.1
     exact (l1.trans l2).trans lm.1
-  change ball_(m) (𝒬 m) 1 ⊆ ball_(s₀.1) (𝒬 s₀.1) 100; intro (θ : Θ X) mθ; rw [@mem_ball] at mθ ⊢
+  change ball_(m) (𝒬 m) 1 ⊆ ball_(s₀.1) (𝒬 s₀.1) 100; intro (θ : Θ X) mθ; rw [mem_ball] at mθ
   have aux : dist_(sl.1) (𝒬 sl.1) θ < 2 * l + 3 :=
     calc
       _ ≤ dist_(sl.1) (𝒬 sl.1) (𝒬 p') + dist_(sl.1) (𝒬 p') θ := dist_triangle ..
@@ -476,13 +479,12 @@ lemma iUnion_L0' : ⋃ (l < n), 𝔏₀' (X := X) k n l = 𝔏₀ k n := by
         gcongr
         · rw [𝔒, Finset.mem_filter] at mb
           obtain ⟨(x : Θ X), x₁, x₂⟩ := not_disjoint_iff.mp mb.2.2
-          replace x₂ := _root_.subset_cball x₂
-          rw [@mem_ball] at x₁ x₂
           calc
             _ ≤ dist_(p') x (𝒬 p') + dist_(p') x (𝒬 b) := dist_triangle_left ..
             _ ≤ _ := by
               apply add_le_add x₁.le
-              change dist_{𝓘 p'} x (𝒬 b) ≤ 1; rw [𝓘p'b]; exact x₂.le
+              change dist_{𝓘 p'} x (𝒬 b) ≤ 1; rw [𝓘p'b]
+              exact (_root_.subset_cball x₂).le
         · change dist_{𝓘 p'} (𝒬 b) θ ≤ dist_{𝓘 b} (𝒬 b) θ; rw [𝓘p'b]
       _ ≤ l + (l + 1) + (dist_(b) (𝒬 m) (𝒬 b) + dist_(b) (𝒬 m) θ) :=
         add_le_add_right (dist_triangle_left ..) _
@@ -565,7 +567,7 @@ lemma antichain_L2 : IsAntichain (· ≤ ·) (𝔏₂ (X := X) k n j) := by
     have s200 : smul 200 z.last.1 ≤ smul 200 q := by
       refine ⟨lq.le, (?_ : ball_(q) (𝒬 q) 200 ⊆ ball_(z.last.1) (𝒬 z.last.1) 200)⟩
       intro (r : Θ X) mr
-      rw [@mem_ball] at mr mϑ₁ mϑ₂ ⊢
+      rw [mem_ball] at mr mϑ₁
       calc
         _ ≤ dist_(z.last.1) r (𝒬 q) + dist_(z.last.1) (𝒬 q) ϑ + dist_(z.last.1) ϑ (𝒬 z.last.1) :=
           dist_triangle4 ..
@@ -601,7 +603,7 @@ lemma carlesonSum_𝔓₁_compl_eq_𝔓pos_inter (f : X → ℂ) :
   have A p (hp : p ∈ (𝔓pos (X := X))ᶜ) : ∀ᵐ x, x ∈ G \ G' → x ∉ 𝓘 p := by
     simp only [𝔓pos, mem_compl_iff, mem_setOf_eq, not_lt, nonpos_iff_eq_zero] at hp
     filter_upwards [measure_eq_zero_iff_ae_notMem.mp hp] with x hx h'x (h''x : x ∈ (𝓘 p : Set X))
-    simp [h''x, h'x.1, h'x.2] at hx
+    exact hx ⟨⟨h''x, h'x.1⟩, h'x.2⟩
   rw [← ae_ball_iff (to_countable 𝔓posᶜ)] at A
   filter_upwards [A] with x hx h'x
   simp only [carlesonSum]
@@ -655,7 +657,7 @@ lemma carlesonSum_𝔓pos_inter_ℭ_eq_add_sum {f : X → ℂ} {x : X} (hkn : k 
   · ext p
     simp only [mem_inter_iff, mem_compl_iff, and_congr_left_iff, and_iff_left_iff_imp, and_imp]
     intro hp
-    simp [𝔏₀_subset_ℭ hp]
+    exact fun _ _ ↦ mem_of_mem_inter_left hp
   · apply Subset.antisymm
     · rintro p ⟨⟨hp, Hp⟩, h'p⟩
       rcases exists_j_of_mem_𝔓pos_ℭ hp.1 Hp hkn with H
@@ -679,7 +681,8 @@ lemma carlesonSum_𝔓pos_inter_𝔏₀_eq_sum {f : X → ℂ} {x : X} :
   congr
   rw [← iUnion_L0']
   ext p
-  simp
+  simp only [mem_inter_iff, mem_iUnion, Finset.mem_Iio]
+  tauto
 
 /-- In each set `ℭ₁ k n j`, the Carleson sum can be decomposed as a sum over `ℭ₂ k n j` and over
 various `𝔏₁ k n j l`. -/
@@ -699,12 +702,13 @@ lemma carlesonSum_𝔓pos_inter_ℭ₁_eq_add_sum {f : X → ℂ} {x : X} :
   · ext p
     simp only [mem_inter_iff, mem_compl_iff, and_congr_left_iff, and_iff_left_iff_imp, and_imp]
     intro hp
-    simp [ℭ₂_subset_ℭ₁ hp]
+    exact fun _ _ ↦ mem_of_mem_inter_left hp
   · ext p
     simp only [ℭ₂, layersAbove, mem_inter_iff, mem_compl_iff, mem_diff, mem_iUnion, exists_prop,
       not_exists, not_and, not_forall, Decidable.not_not, Finset.mem_Iic, 𝔏₁]
     refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-    · simpa [h.1.1] using h.2 h.1.2
+    · obtain ⟨i, hi, hmem⟩ := h.2 h.1.2
+      exact ⟨i, hi, h.1.1, hmem⟩
     · rcases h with ⟨i, hi, h'i⟩
       simp only [h'i.1, not_false_eq_true, and_self, minLayer_subset h'i.2, forall_const, true_and]
       exact ⟨i, hi, h'i.2⟩
@@ -726,15 +730,16 @@ lemma carlesonSum_𝔓pos_inter_ℭ₂_eq_add_sum {f : X → ℂ} {x : X} (hkn :
   · ext p
     simp only [mem_inter_iff, mem_compl_iff, and_congr_left_iff, and_iff_left_iff_imp, and_imp]
     intro hp
-    simp [𝔏₂_subset_ℭ₂ hp]
+    exact fun _ _ ↦ mem_of_mem_inter_left hp
   · ext p
     simp only [mem_inter_iff, mem_compl_iff,
       Finset.mem_Iic, mem_iUnion, exists_and_left, exists_prop]
     refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
     · refine ⟨h.1.1, ?_⟩
       simp only [𝔓₁, mem_iUnion, exists_prop, not_exists, not_and] at h
-      have : p ∉ ℭ₅ k n j := h.1.1.2 n k hkn j hj
-      simpa using (notMem_ℭ₅_iff_mem_𝔏₃ (X := X) hkn hj h.1.1.1 h.1.2 h.2).1 this
+      have := (notMem_ℭ₅_iff_mem_𝔏₃ (X := X) hkn hj h.1.1.1 h.1.2 h.2).1 (h.1.1.2 n k hkn j hj)
+      simp only [mem_iUnion, exists_prop] at this
+      exact this
     · rcases h.2 with ⟨l, lZ, hl⟩
       exact ⟨⟨h.1, ℭ₃_subset_ℭ₂ (maxLayer_subset hl)⟩,
         disjoint_right.1 𝔏₂_disjoint_ℭ₃ (maxLayer_subset hl)⟩
@@ -871,7 +876,7 @@ lemma lintegral_enorm_carlesonSum_le_of_isAntichain_subset_ℭ
         exact (hx.2.1.1 (W hx.1.1)).elim
       simp only [𝔓pos, mem_setOf_eq, this, measure_empty, lt_self_iff_false, not_false_eq_true]
     contrapose! this
-    have : p ∈ highDensityTiles := by simp [highDensityTiles, this]
+    have : p ∈ highDensityTiles := mem_preimage.mp this
     apply subset_biUnion_of_mem this
   calc
   dens₁ (𝔓pos ∩ 𝔓₁ᶜ ∩ 𝔄) ^ ((q - 1) / (8 * ↑a ^ 4)) *

--- a/Carleson/Discrete/ForestComplement.lean
+++ b/Carleson/Discrete/ForestComplement.lean
@@ -52,7 +52,7 @@ lemma exists_k_of_mem_𝔓pos (h : p ∈ 𝔓pos (X := X)) : ∃ k, p ∈ TilesA
   have s_min : ∀ t ∈ C, s ≤ t := fun t mt ↦ WellFounded.min_le _ mt _
   have s_pos : 0 < s := by
     by_contra! h; rw [nonpos_iff_eq_zero] at h
-    simp_rw [h, C, aux𝓒, mem_setOf] at s_mem; apply absurd s_mem; push_neg; intro _ _
+    simp_rw [h, C, aux𝓒, mem_setOf] at s_mem; apply absurd s_mem; push Not; intro _ _
     rw [Int.neg_ofNat_zero, zpow_zero, one_mul]; exact measure_mono inter_subset_right
   use s - 1; rw [TilesAt, mem_preimage, 𝓒, mem_diff, Nat.sub_add_cancel s_pos]
   have : ∀ t < s, t ∉ C := fun t mt ↦ by contrapose! mt; exact s_min t mt
@@ -73,7 +73,7 @@ lemma dens'_le_of_mem_𝔓pos (h : p ∈ 𝔓pos (X := X)) : dens' k {p} ≤ 2 ^
     _ ≤ _ := by
       have E : E₂ l p' ⊆ 𝓘 p' ∩ G := inter_subset_left
       rw [TilesAt, mem_preimage, 𝓒, mem_diff] at mp'; replace mp' := mp'.2
-      rw [aux𝓒, mem_setOf] at mp'; push_neg at mp'; specialize mp' (𝓘 p') le_rfl
+      rw [aux𝓒, mem_setOf] at mp'; push Not at mp'; specialize mp' (𝓘 p') le_rfl
       rw [inter_comm] at E; exact (measure_mono E).trans mp'
 
 lemma exists_E₂_volume_pos_of_mem_𝔓pos (h : p ∈ 𝔓pos (X := X)) : ∃ r : ℕ, 0 < volume (E₂ r p) := by
@@ -149,7 +149,7 @@ lemma exists_j_of_mem_𝔓pos_ℭ (h : p ∈ 𝔓pos (X := X)) (mp : p ∈ ℭ k
   replace h : 0 < volume ((𝓘 p : Set X) ∩ G₂ᶜ) :=
     h.trans_le (measure_mono (inter_subset_left.trans inter_subset_left))
   obtain ⟨x, mx, nx⟩ := nonempty_of_measure_ne_zero h.ne'
-  simp_rw [G₂, mem_compl_iff, mem_iUnion] at nx; push_neg at nx; specialize nx n k hkn
+  simp_rw [G₂, mem_compl_iff, mem_iUnion] at nx; push Not at nx; specialize nx n k hkn
   let B : ℕ := Finset.card { q | q ∈ 𝔅 k n p }
   have Blt : B < 2 ^ (2 * n + 4) := by
     calc
@@ -258,7 +258,7 @@ lemma antichain_decomposition : 𝔓pos (X := X) ∩ 𝔓₁ᶜ = ℜ₀ ∪ ℜ
   pick_goal 2; · exact fun _ _ ↦ iUnion₂_subset fun _ _ ↦ iUnion₂_subset fun _ _ ↦ 𝔏₃_subset_ℭ
   pick_goal -1; · exact fun _ _ ↦ iUnion₂_subset fun _ _ ↦ ℭ₅_subset_ℭ
   by_cases ml0 : p ∈ 𝔏₀ k n
-  · simp_rw [ml0, true_or, iff_true, mem_iUnion₂]; push_neg; intros
+  · simp_rw [ml0, true_or, iff_true, mem_iUnion₂]; push Not; intros
     exact fun a ↦ disjoint_left.mp 𝔏₀_disjoint_ℭ₁ ml0 (ℭ₅_subset_ℭ₁ a)
   simp_rw [ml0, false_or] at split ⊢
   obtain ⟨j, hj, mc1⟩ := split
@@ -534,7 +534,7 @@ private instance : Preorder (ℭ₁' (X := X) k n j) where
 /-- Lemma 5.5.3 -/
 lemma antichain_L2 : IsAntichain (· ≤ ·) (𝔏₂ (X := X) k n j) := by
   classical
-  by_contra h; rw [isAntichain_iff_forall_not_lt] at h; push_neg at h
+  by_contra h; rw [isAntichain_iff_forall_not_lt] at h; push Not at h
   obtain ⟨p', mp', p, mp, l⟩ := h
   have p200 : smul 2 p' ≤ smul 200 p := by
     calc
@@ -579,7 +579,7 @@ lemma antichain_L2 : IsAntichain (· ≤ ·) (𝔏₂ (X := X) k n j) := by
     have : z.last < ⟨q, mq⟩ := by
       refine ⟨s200, (?_ : ¬(smul 200 q ≤ smul 200 z.last.1))⟩
       rw [TileLike.le_def, not_and_or]; exact Or.inl (not_le_of_gt lq)
-    apply absurd maxz; push_neg; use z.snoc ⟨q, mq⟩ this, by simp [C, mz], by simp
+    apply absurd maxz; push Not; use z.snoc ⟨q, mq⟩ this, by simp [C, mz], by simp
 
 end L2Antichain
 

--- a/Carleson/Discrete/ForestUnion.lean
+++ b/Carleson/Discrete/ForestUnion.lean
@@ -146,16 +146,17 @@ nonrec lemma URel.rfl : URel k n j u u := Or.inl rfl
 lemma URel.not_disjoint (hu : u ∈ 𝔘₂ k n j) (hu' : u' ∈ 𝔘₂ k n j) (huu' : URel k n j u u') :
     ¬Disjoint (ball_(u) (𝒬 u) 100) (ball_(u') (𝒬 u') 100) := by
   classical
-  by_cases e : u = u'; · rw [e]; simp
-  simp_rw [URel, e, false_or, 𝔗₁, mem_setOf] at huu'; obtain ⟨p, ⟨mp, np, sl₁⟩, sl₂⟩ := huu'
+  by_cases e : u = u'
+  · rw [e]
+    exact not_disjoint_iff.mpr ⟨𝒬 u', mem_ball_self (by positivity), mem_ball_self (by positivity)⟩
+  simp_rw [URel, e, false_or] at huu'; obtain ⟨p, ⟨mp, np, sl₁⟩, sl₂⟩ := huu'
   by_cases e' : 𝓘 p = 𝓘 u'
   · refine not_disjoint_iff.mpr ⟨𝒬 u, mem_ball_self (by positivity), ?_⟩
-    rw [@mem_ball]
     have i1 : ball_{𝓘 u} (𝒬 u) 1 ⊆ ball_{𝓘 p} (𝒬 p) 2 := sl₁.2
     have i2 : ball_{𝓘 u'} (𝒬 u') 1 ⊆ ball_{𝓘 p} (𝒬 p) 10 := sl₂.2
     replace i1 : 𝒬 u ∈ ball_{𝓘 p} (𝒬 p) 2 := i1 (mem_ball_self zero_lt_one)
     replace i2 : 𝒬 u' ∈ ball_{𝓘 p} (𝒬 p) 10 := i2 (mem_ball_self zero_lt_one)
-    rw [e', @mem_ball] at i1 i2
+    rw [e'] at i1 i2
     calc
       _ ≤ dist_{𝓘 u'} (𝒬 u) (𝒬 p) + dist_{𝓘 u'} (𝒬 u') (𝒬 p) := dist_triangle_right ..
       _ < 2 + 10 := add_lt_add i1 i2
@@ -166,8 +167,12 @@ lemma URel.not_disjoint (hu : u ∈ 𝔘₂ k n j) (hu' : u' ∈ 𝔘₂ k n j) 
   have 𝔅dj : Disjoint (𝔅 k n u) (𝔅 k n u') := by
     simp_rw [𝔅, disjoint_left, mem_setOf, not_and]; intro q ⟨_, sl⟩ _
     simp_rw [TileLike.le_def, smul_fst, smul_snd, not_and_or] at sl ⊢; right
-    have := disjoint_left.mp (h.mono_left sl.2) (mem_ball_self zero_lt_one)
-    rw [not_subset]; use 𝒬 q, mem_ball_self zero_lt_one
+    intro hs
+    apply disjoint_left.mp (h.mono_left sl.2) (mem_ball_self zero_lt_one)
+    apply hs
+    change dist_{𝔠 q, ↑D ^ 𝔰 q / 4} (𝒬 q) (𝒬 q) < 1
+    rw [dist_self]
+    positivity
   have usp : 𝔅 k n u ⊆ 𝔅 k n p := fun q mq ↦ by
     rw [𝔅, mem_setOf] at mq ⊢; exact ⟨mq.1, plu.trans mq.2⟩
   have u'sp : 𝔅 k n u' ⊆ 𝔅 k n p := fun q mq ↦ by
@@ -180,7 +185,7 @@ lemma URel.not_disjoint (hu : u ∈ 𝔘₂ k n j) (hu' : u' ∈ 𝔘₂ k n j) 
       add_le_add (card_𝔅_of_mem_ℭ₁ hu.1.1).1 (card_𝔅_of_mem_ℭ₁ hu'.1.1).1
     _ = (𝔅 k n u ∪ 𝔅 k n u').toFinset.card := by
       rw [toFinset_union]; refine (Finset.card_union_of_disjoint ?_).symm
-      simpa using 𝔅dj
+      rwa [Set.disjoint_toFinset]
     _ ≤ _ := by
       apply Finset.card_le_card
       simp_rw [toFinset_union, subset_toFinset, Finset.coe_union, coe_toFinset, union_subset_iff]
@@ -210,16 +215,19 @@ lemma urel_of_not_disjoint {x y : 𝔓 X} (my : y ∈ 𝔘₂ k n j) (xye : 𝓘
       (smul_mono_left (by norm_num)).trans (wiggle_order_500 sl np)
     exact ⟨(xye ▸ sl.1 : 𝓘 p ≤ 𝓘 x), hpy.2.trans w⟩
   intro (q : Θ X) (mq : q ∈ ball_{𝓘 x} (𝒬 x) 1)
-  rw [@mem_ball] at mq ⊢
   calc
     _ ≤ dist_(y) q ϑ + dist_(y) ϑ (𝒬 y) := dist_triangle ..
     _ ≤ dist_(y) q (𝒬 x) + dist_(y) ϑ (𝒬 x) + dist_(y) ϑ (𝒬 y) := by
       gcongr; apply dist_triangle_right
     _ < 1 + 100 + 100 := by
+      have hϑy : dist_(y) ϑ (𝒬 y) < 100 := ϑy
+      have hc : 𝔠 x = 𝔠 y := congr_arg c xye
+      have hs : 𝔰 x = 𝔰 y := congr_arg s xye
       gcongr
-      · rwa [xye] at mq
-      · rwa [@mem_ball, xye] at ϑx
-      · rwa [@mem_ball] at ϑy
+      · rw [← hc, ← hs]
+        exact mq
+      · rw [← hc, ← hs]
+        exact mem_ball.mp ϑx
     _ < _ := by norm_num
 
 /-- Lemma 5.4.2. -/
@@ -241,20 +249,30 @@ lemma equivalenceOn_urel : EquivalenceOn (URel (X := X) k n j) (𝔘₂ k n j) w
       have w : ball_(x) (𝒬 x) 500 ⊆ ball_(p) (𝒬 p) 4 := (wiggle_order_500 sl np).2
       exact ⟨(yze ▸ xye ▸ sl.1 : 𝓘 p ≤ 𝓘 z), (this.trans w).trans (ball_subset_ball (by norm_num))⟩
     intro (q : Θ X) (mq : q ∈ ball_{𝓘 z} (𝒬 z) 1)
-    rw [@mem_ball] at mq ⊢
     calc
       _ ≤ dist_(x) q ϑ + dist_(x) ϑ (𝒬 x) := dist_triangle ..
-      _ < dist_(x) q ϑ + 100 := by gcongr; rwa [@mem_ball] at ϑx
-      _ ≤ dist_(x) q (𝒬 y) + dist_(x) ϑ (𝒬 y) + 100 := by gcongr; exact dist_triangle_right ..
-      _ < dist_(x) q (𝒬 y) + 100 + 100 := by gcongr; rwa [@mem_ball, ← xye] at ϑy
+      _ < dist_(x) q ϑ + 100 := by
+        change dist_(x) ϑ (𝒬 x) < 100 at ϑx
+        gcongr
+      _ ≤ dist_(x) q (𝒬 y) + dist_(x) ϑ (𝒬 y) + 100 := by
+        gcongr
+        exact dist_triangle_right ..
+      _ < dist_(x) q (𝒬 y) + 100 + 100 := by
+        have : dist_(x) ϑ (𝒬 y) < 100 := by rwa [← xye] at ϑy
+        gcongr
       _ ≤ dist_(x) q θ + dist_(x) θ (𝒬 y) + 100 + 100 := by gcongr; exact dist_triangle ..
-      _ < dist_(x) q θ + 100 + 100 + 100 := by gcongr; rwa [@mem_ball, ← xye] at θy
+      _ < dist_(x) q θ + 100 + 100 + 100 := by
+        have : dist_(x) θ (𝒬 y) < 100 := by rwa [← xye] at θy
+        gcongr
       _ ≤ dist_(x) q (𝒬 z) + dist_(x) θ (𝒬 z) + 100 + 100 + 100 := by
         gcongr; exact dist_triangle_right ..
       _ < 1 + 100 + 100 + 100 + 100 := by
+        have : dist_(x) θ (𝒬 z) < 100 := by rwa [← yze, ← xye] at θz
         gcongr
-        · rwa [← yze, ← xye] at mq
-        · rwa [@mem_ball, ← yze, ← xye] at θz
+        have hc : 𝔠 x = 𝔠 z := (congr_arg c xye).trans (congr_arg c yze)
+        have hs : 𝔰 x = 𝔰 z := (congr_arg s xye).trans (congr_arg s yze)
+        rw [hc, hs]
+        exact mq
       _ < _ := by norm_num
   symm {x y} mx my xy := urel_of_not_disjoint my (URel.eq mx my xy) (URel.not_disjoint mx my xy)
 
@@ -320,16 +338,17 @@ lemma forest_geometry (hu : u ∈ 𝔘₃ k n j) (hp : p ∈ 𝔗₂ k n j u) : 
     have w : smul 4 p ≤ smul 500 u' := (wiggle_order_500 sl np)
     exact ⟨(xye ▸ sl.1 : 𝓘 p ≤ 𝓘 u), w.2.trans this⟩
   intro (q : Θ X) (mq : q ∈ ball_{𝓘 u} (𝒬 u) 1)
-  rw [@mem_ball] at mq ⊢
   calc
     _ ≤ dist_(u') q ϑ + dist_(u') ϑ (𝒬 u') := dist_triangle ..
     _ ≤ dist_(u') q (𝒬 u) + dist_(u') ϑ (𝒬 u) + dist_(u') ϑ (𝒬 u') := by
       gcongr; apply dist_triangle_right
     _ < 1 + 100 + 100 := by
+      change dist_(u') ϑ (𝒬 u') < 100 at ϑy
+      have hc : 𝔠 u = 𝔠 u' := congrArg c xye
+      have hs : 𝔰 u = 𝔰 u' := congrArg s xye
       gcongr
-      · rwa [xye] at mq
-      · rwa [@mem_ball, xye] at ϑx
-      · rwa [@mem_ball] at ϑy
+      · rw [← hc, ← hs]; exact mq
+      · rw [← hc, ← hs]; exact ϑx
     _ < _ := by norm_num
 
 /-- Lemma 5.4.5, verifying (2.0.33) -/
@@ -369,10 +388,9 @@ lemma forest_separation (hu : u ∈ 𝔘₃ k n j) (hu' : u' ∈ 𝔘₃ k n j) 
     · exact (wiggle_order_11_10 lp' (C5_3_3_le (X := X).trans (by norm_num))).trans sl
   specialize np'u p' mpt
   have 𝓘p'u : 𝓘 p' ≤ 𝓘 u := lp'.1.trans h
-  simp_rw [TileLike.le_def, smul_fst, smul_snd, 𝓘p'u, true_and,
-    not_subset_iff_exists_mem_notMem] at np'u
-  obtain ⟨(q : Θ X), mq, nq⟩ := np'u
-  simp_rw [mem_ball, not_lt] at mq nq
+  simp_rw [TileLike.le_def, smul_fst, 𝓘p'u, true_and] at np'u
+  obtain ⟨(q : Θ X), mq, nq⟩ := Set.not_subset.mp np'u
+  change dist_(u) q (𝒬 u) < 1 at mq; change ¬ dist_(p') q (𝒬 p') < 10 at nq; rw [not_lt] at nq
   have d8 : 8 < dist_(p') (𝒬 p) (𝒬 u) :=
     calc
       _ = 10 - 1 - 1 := by norm_num
@@ -426,8 +444,7 @@ lemma forest_inner (hu : u ∈ 𝔘₃ k n j) (hp : p ∈ 𝔗₂ k n j u) :
   have ur : URel k n j u' u'' := Or.inr ⟨p, pu', s10⟩
   have hu'' : u'' ∈ 𝔘₂ k n j := by
     rw [𝔘₂, mem_setOf, not_disjoint_iff]
-    refine ⟨mu'', ⟨p, ?_, p₆⟩⟩
-    simpa [𝔗₁, p₁, s2'] using (lq.1.trans_lt nu'').ne
+    exact ⟨mu'', ⟨p, ⟨p₁, (lq.1.trans_lt nu'').ne, s2'⟩, p₆⟩⟩
   have ru'' : URel k n j u u'' := equivalenceOn_urel.trans (𝔘₃_subset_𝔘₂ hu) mu' hu'' ru' ur
   have qlu : 𝓘 q < 𝓘 u := URel.eq (𝔘₃_subset_𝔘₂ hu) hu'' ru'' ▸ nu''
   have squ : 𝔰 q < 𝔰 u := (Grid.lt_def.mp qlu).2
@@ -514,7 +531,7 @@ lemma stackSize_𝔘₃_le_𝔐 (x : X) : stackSize (𝔘₃ k n j) x ≤ stackS
     exact ⟨(mf k n j ⟨u, mu.1⟩).2, hu.1 mu.2⟩
   · rw [Finset.coe_filter, mem_setOf, Finset.mem_filter_univ] at mu mu'
     simp_rw [mf', mu.1, mu'.1, dite_true, Subtype.val_inj] at e
-    simpa using mf_injOn mu.2 mu'.2 e
+    exact congr_arg Subtype.val (mf_injOn mu.2 mu'.2 e)
 
 /-- Lemma 5.4.8, used to verify that 𝔘₄ satisfies 2.0.34. -/
 lemma forest_stacking (x : X) (hkn : k ≤ n) : stackSize (𝔘₃ (X := X) k n j) x ≤ C5_4_8 n := by
@@ -648,8 +665,8 @@ def forest : Forest X n where
     have : ℭ₆ k n j ∩ 𝔗₁ k n j u ⊆ 𝔗₂ k n j u := by
       apply inter_subset_inter_right
       have : 𝔗₁ k n j u ⊆ ⋃ (_ : URel k n j u u), 𝔗₁ k n j u := by
-        have : URel k n j u u := (equivalenceOn_urel (X := X)).refl _ m
-        simp [this]
+        intro p hp
+        exact Set.mem_iUnion.mpr ⟨(equivalenceOn_urel (X := X)).refl _ m, hp⟩
       apply this.trans
       apply subset_biUnion_of_mem (u := fun u' ↦ ⋃ (_ : URel k n j u u'), 𝔗₁ k n j u') m
     apply Nonempty.mono this
@@ -768,7 +785,7 @@ lemma lintegral_carlesonSum_forest
       contrapose! W
       exact W.trans (subset_union_left.trans subset_union_left)
     contrapose! this
-    have : p ∈ highDensityTiles := by simp [highDensityTiles, this]
+    change p ∈ highDensityTiles at this
     apply subset_biUnion_of_mem this
   · exact diff_subset
 

--- a/Carleson/Discrete/ForestUnion.lean
+++ b/Carleson/Discrete/ForestUnion.lean
@@ -25,7 +25,7 @@ lemma ordConnected_tilesAt : OrdConnected (TilesAt k : Set (𝔓 X)) := by
   constructor
   · obtain ⟨J, hJ, _⟩ := mp''.1
     use J, mp'.2.1.trans hJ
-  · push_neg at mp ⊢
+  · push Not at mp ⊢
     exact fun J hJ ↦ mp.2 J (mp'.1.1.trans hJ)
 
 /-- Lemma 5.3.5 -/
@@ -746,8 +746,7 @@ lemma lintegral_carlesonSum_forest
     · intro a ha b hb hab
       simp only [Function.onFun, disjoint_iff_forall_ne]
       intro x hx y hy
-      simp only [forest, Forest.mem_mk, Finset.coe_filter, Finset.mem_univ, true_and, setOf_mem_eq,
-        𝔉] at ha hb hx hy
+      simp only [Finset.coe_filter, Finset.mem_univ, true_and, 𝔉] at ha hb hx hy
       have := forest_disjoint (X := X) (𝔘₄_subset_𝔘₃ ha) (𝔘₄_subset_𝔘₃ hb) hab
       exact disjoint_iff_forall_ne.1 this hx hy
     congr with p

--- a/Carleson/Discrete/ForestUnion.lean
+++ b/Carleson/Discrete/ForestUnion.lean
@@ -142,6 +142,7 @@ def URel (k n j : ℕ) (u u' : 𝔓 X) : Prop :=
 
 nonrec lemma URel.rfl : URel k n j u u := Or.inl rfl
 
+set_option backward.isDefEq.respectTransparency false in
 /-- Lemma 5.4.1, part 2. -/
 lemma URel.not_disjoint (hu : u ∈ 𝔘₂ k n j) (hu' : u' ∈ 𝔘₂ k n j) (huu' : URel k n j u u') :
     ¬Disjoint (ball_(u) (𝒬 u) 100) (ball_(u') (𝒬 u') 100) := by
@@ -167,12 +168,8 @@ lemma URel.not_disjoint (hu : u ∈ 𝔘₂ k n j) (hu' : u' ∈ 𝔘₂ k n j) 
   have 𝔅dj : Disjoint (𝔅 k n u) (𝔅 k n u') := by
     simp_rw [𝔅, disjoint_left, mem_setOf, not_and]; intro q ⟨_, sl⟩ _
     simp_rw [TileLike.le_def, smul_fst, smul_snd, not_and_or] at sl ⊢; right
-    intro hs
-    apply disjoint_left.mp (h.mono_left sl.2) (mem_ball_self zero_lt_one)
-    apply hs
-    change dist_{𝔠 q, ↑D ^ 𝔰 q / 4} (𝒬 q) (𝒬 q) < 1
-    rw [dist_self]
-    positivity
+    have := disjoint_left.mp (h.mono_left sl.2) (mem_ball_self zero_lt_one)
+    rw [not_subset]; use 𝒬 q, mem_ball_self zero_lt_one
   have usp : 𝔅 k n u ⊆ 𝔅 k n p := fun q mq ↦ by
     rw [𝔅, mem_setOf] at mq ⊢; exact ⟨mq.1, plu.trans mq.2⟩
   have u'sp : 𝔅 k n u' ⊆ 𝔅 k n p := fun q mq ↦ by

--- a/Carleson/FinitaryCarleson.lean
+++ b/Carleson/FinitaryCarleson.lean
@@ -28,14 +28,14 @@ variable [TileStructure Q D κ S o]
 @[reducible] -- Used to simplify notation in the proof of `tile_sum_operator`
 private def 𝔓X_s (s : ℤ) := (@Finset.univ (𝔓 X) _).filter (fun p ↦ 𝔰 p = s)
 
-private lemma 𝔰_eq {s : ℤ} {p : 𝔓 X} (hp : p ∈ 𝔓X_s s) : 𝔰 p = s := by simpa using hp
+private lemma 𝔰_eq {s : ℤ} {p : 𝔓 X} (hp : p ∈ 𝔓X_s s) : 𝔰 p = s := (Finset.mem_filter.mp hp).2
 
 open scoped Classical in
 private lemma 𝔓_biUnion : @Finset.univ (𝔓 X) _ = (Icc (-S : ℤ) S).toFinset.biUnion 𝔓X_s := by
   ext p
   refine ⟨fun _ ↦ ?_, fun _ ↦ Finset.mem_univ p⟩
   rw [Finset.mem_biUnion]
-  refine ⟨𝔰 p, ?_, by simp⟩
+  refine ⟨𝔰 p, ?_, Finset.mem_filter.mpr ⟨Finset.mem_univ _, rfl⟩⟩
   rw [toFinset_Icc, Finset.mem_Icc]
   exact range_s_subset ⟨𝓘 p, rfl⟩
 
@@ -79,7 +79,7 @@ theorem tile_sum_operator {G' : Set X} {f : X → ℂ} {x : X} (hx : x ∈ G \ G
     exact ⟨Finset.mem_Icc.2 (Icc_σ_subset_Icc_S hs), hs⟩
   · rcases exists_Grid hx.1 hs with ⟨I, Is, xI⟩
     obtain ⟨p, 𝓘pI, Qp⟩ : ∃ (p : 𝔓 X), 𝓘 p = I ∧ Q x ∈ Ω p := by simpa using biUnion_Ω ⟨x, rfl⟩
-    have p𝔓Xs : p ∈ 𝔓X_s s := by simpa [𝔰, 𝓘pI]
+    have p𝔓Xs : p ∈ 𝔓X_s s := Finset.mem_filter.mpr ⟨Finset.mem_univ _, by rw [𝔰, 𝓘pI]; exact Is⟩
     have : ∀ p' ∈ 𝔓X_s s, p' ≠ p → carlesonOn p' f x = 0 := by
       intro p' p'𝔓Xs p'p
       apply indicator_of_notMem
@@ -116,5 +116,7 @@ theorem finitary_carleson : ∃ G', MeasurableSet G' ∧ 2 * volume G' ≤ volum
   simp_rw [carlesonSum, mem_univ, Finset.filter_true, tile_sum_operator hx, mul_sub, exp_sub,
     mul_div, div_eq_mul_inv,
     ← smul_eq_mul, integral_smul_const, ← Finset.sum_smul, _root_.enorm_smul]
-  suffices ‖(cexp (I • ((Q x) x : ℂ)))⁻¹‖ₑ = 1 by rw [this, mul_one]
+  suffices ‖(cexp (I • ((Q x) x : ℂ)))⁻¹‖ₑ = 1 by
+    rw [this, mul_one]
+    congr 1
   simp [mul_comm I, enorm_eq_nnnorm]

--- a/Carleson/ForestOperator/AlmostOrthogonality.lean
+++ b/Carleson/ForestOperator/AlmostOrthogonality.lean
@@ -37,7 +37,10 @@ lemma adjoint_tile_support1 : adjointCarleson p f =
   obtain ⟨y, my, Ky⟩ : ∃ y ∈ 𝓘 p, Ks (𝔰 p) y x ≠ 0 := by
     contrapose! hn
     refine setIntegral_eq_zero_of_forall_eq_zero fun y my ↦ ?_
-    simp [hn _ (E_subset_𝓘 my)]
+    simp only [defaultA, defaultD.eq_1, defaultκ.eq_1, mul_eq_zero, map_eq_zero, exp_ne_zero,
+      or_false, indicator_apply_eq_zero]
+    left
+    exact hn _ (E_subset_𝓘 my)
   rw [mem_ball]
   calc
     _ ≤ dist y x + dist y (𝔠 p) := dist_triangle_left ..
@@ -266,7 +269,7 @@ lemma overlap_implies_distance (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u
       · exact (t.lt_dist' hu₂ hu₁ hu.symm c (plu₁.trans h2u)).le
       · have : 𝒬 u₁ ∈ ball_(p) (𝒬 p) 4 :=
           (t.smul_four_le hu₁ c).2 (by convert mem_ball_self zero_lt_one)
-        rw [@mem_ball'] at this; exact this.le
+        exact (@mem_ball' _ (instPseudoMetricSpaceWithFunctionDistance (x := 𝔠 p) (r := ↑D ^ 𝔰 p / 4)) _ _ _).mp this |>.le
     _ ≥ _ := ha
   · calc
     _ ≥ dist_(p) (𝒬 p) (𝒬 u₁) - dist_(p) (𝒬 p) (𝒬 u₂) := by
@@ -276,7 +279,7 @@ lemma overlap_implies_distance (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u
       · exact (t.lt_dist' hu₁ hu₂ hu c plu₁).le
       · have : 𝒬 u₂ ∈ ball_(p) (𝒬 p) 4 :=
           (t.smul_four_le hu₂ c).2 (by convert mem_ball_self zero_lt_one)
-        rw [@mem_ball'] at this; exact this.le
+        exact (@mem_ball' _ (instPseudoMetricSpaceWithFunctionDistance (x := 𝔠 p) (r := ↑D ^ 𝔰 p / 4)) _ _ _).mp this |>.le
     _ ≥ _ := ha
 
 /-- Part 2 of Lemma 7.4.7. -/

--- a/Carleson/ForestOperator/Forests.lean
+++ b/Carleson/ForestOperator/Forests.lean
@@ -142,7 +142,7 @@ lemma correlation_separated_trees (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu 
     · rw [← RCLike.enorm_conj (z := ∫ x, adjointCarlesonSum _ g₂ x * _)]
       erw [← integral_conj]
       congr
-      simp only [map_mul, RingHomCompTriple.comp_apply, RingHom.id_apply, mul_comm]
+      simp [mul_comm]
     · rw [inter_comm]; ring
   exact correlation_separated_trees_of_subset hu₁ hu₂ hu h2u hg₁ hg₂
 

--- a/Carleson/ForestOperator/Forests.lean
+++ b/Carleson/ForestOperator/Forests.lean
@@ -139,10 +139,8 @@ lemma correlation_separated_trees (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu 
   · have hl := (le_or_ge_or_disjoint.resolve_left h2u).resolve_right hd
     rw [disjoint_comm] at hd
     convert this hu₂ hu₁ hu.symm hg₂ hg₁ hd hl using 1
-    · rw [
-        ← RCLike.enorm_conj (z := ∫ x, adjointCarlesonSum _ g₂ x * _),
-        show (starRingEnd ℂ) (∫ x : X, adjointCarlesonSum (t.𝔗 u₂) g₂ x * (starRingEnd ℂ) (adjointCarlesonSum (t.𝔗 u₁) g₁ x)) = ∫ x : X, (starRingEnd ℂ) (adjointCarlesonSum (t.𝔗 u₂) g₂ x * (starRingEnd ℂ) (adjointCarlesonSum (t.𝔗 u₁) g₁ x)) from integral_conj.symm
-      ]
+    · rw [← RCLike.enorm_conj (z := ∫ x, adjointCarlesonSum _ g₂ x * _)]
+      erw [← integral_conj]
       congr
       simp only [map_mul, RingHomCompTriple.comp_apply, RingHom.id_apply, mul_comm]
     · rw [inter_comm]; ring

--- a/Carleson/ForestOperator/Forests.lean
+++ b/Carleson/ForestOperator/Forests.lean
@@ -139,8 +139,12 @@ lemma correlation_separated_trees (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu 
   · have hl := (le_or_ge_or_disjoint.resolve_left h2u).resolve_right hd
     rw [disjoint_comm] at hd
     convert this hu₂ hu₁ hu.symm hg₂ hg₁ hd hl using 1
-    · rw [← RCLike.enorm_conj, ← integral_conj]; congr! 3
-      rw [map_mul, conj_conj, mul_comm]
+    · rw [
+        ← RCLike.enorm_conj (z := ∫ x, adjointCarlesonSum _ g₂ x * _),
+        show (starRingEnd ℂ) (∫ x : X, adjointCarlesonSum (t.𝔗 u₂) g₂ x * (starRingEnd ℂ) (adjointCarlesonSum (t.𝔗 u₁) g₁ x)) = ∫ x : X, (starRingEnd ℂ) (adjointCarlesonSum (t.𝔗 u₂) g₂ x * (starRingEnd ℂ) (adjointCarlesonSum (t.𝔗 u₁) g₁ x)) from integral_conj.symm
+      ]
+      congr
+      simp only [map_mul, RingHomCompTriple.comp_apply, RingHom.id_apply, mul_comm]
     · rw [inter_comm]; ring
   exact correlation_separated_trees_of_subset hu₁ hu₂ hu h2u hg₁ hg₂
 
@@ -232,12 +236,17 @@ lemma stackSize_remainder_ge_one_of_exists (t : Forest X n) (j : ℕ) (x : X)
     1 ≤ stackSize ((t \ ⋃ i < j, t.rowDecomp i) ∩ t.rowDecomp j: Set _) x := by
   classical
   obtain ⟨𝔲', h𝔲'⟩ := hx
-  dsimp [stackSize]
-  rw [← Finset.sum_erase_add _ (a := 𝔲')]
-  · rw [indicator_apply, ← Grid.mem_def,if_pos h𝔲'.right, Pi.one_apply]
-    simp
-  simp_rw [Finset.mem_filter_univ, mem_inter_iff]
-  exact ⟨t.rowDecomp_𝔘_subset j h𝔲'.1, h𝔲'.1⟩
+  calc 1
+      = stackSize {𝔲'} x := by
+        rw [stackSize, Finset.sum_eq_single_of_mem]
+        · exact (Set.indicator_of_mem h𝔲'.2 (1 : X → ℕ)).symm
+        · rw [Finset.mem_filter_univ]
+          exact Set.mem_singleton_iff.mpr rfl
+        · intro b hb hbp
+          rw [Finset.mem_filter_univ, Set.mem_singleton_iff] at hb
+          exact absurd hb hbp
+    _ ≤ stackSize ((t \ ⋃ i < j, t.rowDecomp i) ∩ t.rowDecomp j : Set _) x :=
+        stackSize_mono (Set.singleton_subset_iff.mpr ⟨t.rowDecomp_𝔘_subset j h𝔲'.1, h𝔲'.1⟩)
 
 lemma remainder_stackSize_le (t : Forest X n) (j : ℕ) (x : X) :
     stackSize (t \ ⋃ i < j, t.rowDecomp i : Set _) x ≤ 2 ^ n - j := by
@@ -258,7 +267,7 @@ lemma remainder_stackSize_le (t : Forest X n) (j : ℕ) (x : X) :
       apply tsub_le_tsub hinduct (stackSize_remainder_ge_one_of_exists t j x _)
       rw [mem_diff] at h𝔲
       apply (or_not).elim id
-      push_neg
+      push Not
       intro h
       apply this.elim
       intro _ ⟨hmax, hz⟩
@@ -295,7 +304,7 @@ lemma remainder_stackSize_le (t : Forest X n) (j : ℕ) (x : X) :
       · exact ⟨hmax, mem_rowDecomp_𝔘_maximal t j⟩
     else
       dsimp [stackSize]
-      push_neg at h
+      push Not at h
       rw [Finset.sum_congr rfl (g := fun _ => 0) (by
         simp_rw [Finset.mem_filter_univ, indicator_apply_eq_zero,
           Pi.one_apply, one_ne_zero] at h ⊢
@@ -650,8 +659,8 @@ lemma disjoint_of_ne_of_mem {i j : ℕ} {u u' : 𝔓 X} (hne : u ≠ u') (hu : u
       exact le_trans (le_abs_self _) <|
         abs_dist_sub_le (α := WithFunctionDistance (𝔠 p) (↑D ^ 𝔰 p / 4)) _ _ _
   have : 𝒬 p' ∉ ball_(p) (𝒬 p) 1 := by
-    rw [mem_ball (α := WithFunctionDistance (𝔠 p) (↑D ^ 𝔰 p / 4)),dist_comm]
-    exact not_lt_of_ge <| le_trans (calculation_7_7_4 (X := X)) this.le
+    intro hmem
+    apply not_lt_of_ge (le_trans (calculation_7_7_4 (X := X)) this.le) (mem_ball'.mp hmem)
   have : ¬(Ω p' ⊆ Ω p) := (fun hx => this <| subset_cball <| hx 𝒬_mem_Ω)
   exact (relative_fundamental_dyadic 𝓘_p_le).resolve_right this
 

--- a/Carleson/ForestOperator/Forests.lean
+++ b/Carleson/ForestOperator/Forests.lean
@@ -126,6 +126,7 @@ lemma cst_disjoint (hd : Disjoint (𝓘 u₁ : Set X) (𝓘 u₂)) (hu₁ : u₁
     ← comp_apply (f := conj) (g := indicator _ _), ← indicator_comp_of_zero (by simp),
     ← inter_indicator_mul, hd, indicator_empty]
 
+set_option backward.isDefEq.respectTransparency false in
 /-- Lemma 7.4.4 -/
 lemma correlation_separated_trees (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂)
     (hg₁ : BoundedCompactSupport g₁) (hg₂ : BoundedCompactSupport g₂) :
@@ -140,7 +141,7 @@ lemma correlation_separated_trees (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu 
     rw [disjoint_comm] at hd
     convert this hu₂ hu₁ hu.symm hg₂ hg₁ hd hl using 1
     · rw [← RCLike.enorm_conj (z := ∫ x, adjointCarlesonSum _ g₂ x * _)]
-      erw [← integral_conj]
+      rw [← integral_conj]
       congr
       simp [mul_comm]
     · rw [inter_comm]; ring

--- a/Carleson/ForestOperator/L2Estimate.lean
+++ b/Carleson/ForestOperator/L2Estimate.lean
@@ -734,6 +734,7 @@ lemma boundary_operator_bound_aux (hf : BoundedCompactSupport f) (hg : BoundedCo
       have : 4 ≤ (a : ℝ) := by norm_cast; exact four_le_a X
       linarith
 
+set_option backward.isDefEq.respectTransparency false in
 /-- Lemma 7.2.3. -/
 lemma boundary_operator_bound (hf : BoundedCompactSupport f) :
     eLpNorm (t.boundaryOperator u f) 2 volume ≤ C7_2_3 a * eLpNorm f 2 volume := by
@@ -751,24 +752,18 @@ lemma boundary_operator_bound (hf : BoundedCompactSupport f) :
   nth_rw 1 [show ((2 : ℕ) : ℝ) = (2 : ℝ≥0) by rfl, show (2 : ℝ≥0∞) = (2 : ℝ≥0) by rfl,
     eLpNorm_nnreal_pow_eq_lintegral two_ne_zero]
   convert boundary_operator_bound_aux (t := t) (u := u) hf bcs.toComplex using 2
-  · simp_rw [RCLike.conj_mul]
-    norm_cast
-    simp only [← norm_pow, Real.norm_of_nonneg (sq_nonneg _)]
-    have hι : ∫ (x : X), (↑((t.boundaryOperator u f x).toReal ^ 2) : ℂ) ∂volume =
-        ↑(∫ (x : X), (t.boundaryOperator u f x).toReal ^ 2 ∂volume) := integral_ofReal
-    erw [hι]
-    rw [enorm_eq_nnnorm, nnnorm_real, ← enorm_eq_nnnorm,
-        Real.enorm_eq_ofReal (integral_nonneg (fun x ↦ sq_nonneg _)),
-        MeasureTheory.ofReal_integral_eq_lintegral_ofReal
-          (by simp_rw [sq]; exact (bcs.mul bcs).integrable)
-          (ae_of_all _ fun x ↦ sq_nonneg _)]
-    apply lintegral_congr
-    intro x
-    rw [
-      ENNReal.ofReal_pow ENNReal.toReal_nonneg,
-      ENNReal.ofReal_toReal (boundaryOperator_lt_top hf).ne
-    ]
-    norm_cast
+  · simp_rw [RCLike.conj_mul]; norm_cast
+    simp_rw [← norm_pow, integral_norm_eq_lintegral_enorm
+      (bcs.aestronglyMeasurable.aemeasurable.pow_const 2).aestronglyMeasurable, enorm_pow,
+      enorm_toReal (boundaryOperator_lt_top hf).ne, enorm_eq_self]
+    simp_rw [enorm_eq_nnnorm, coe_algebraMap, nnnorm_real, ← enorm_eq_nnnorm,
+      ← ENNReal.rpow_natCast, Nat.cast_ofNat]
+    refine (enorm_toReal ?_).symm
+    replace hv' := ENNReal.pow_lt_top (n := 2) hv'
+    rw [← ENNReal.rpow_natCast, show ((2 : ℕ) : ℝ) = (2 : ℝ≥0) by rfl,
+      show (2 : ℝ≥0∞) = (2 : ℝ≥0) by rfl, eLpNorm_nnreal_pow_eq_lintegral two_ne_zero,
+      show ((2 : ℝ≥0) : ℝ) = (2 : ℕ) by rfl] at hv'
+    simp_rw [enorm_eq_self] at hv'; exact hv'.ne
   · rw [← elpn_eq, show (2 : ℝ≥0∞) = (2 : ℝ≥0) by rfl]
     simp_rw [eLpNorm_nnreal_eq_lintegral two_ne_zero]; congr!
     simp [enorm_eq_nnnorm, nnnorm_real]

--- a/Carleson/ForestOperator/L2Estimate.lean
+++ b/Carleson/ForestOperator/L2Estimate.lean
@@ -235,7 +235,8 @@ private lemma nontangential_integral_bound₂ (hf : BoundedCompactSupport f) {x 
     _ = ⨍⁻ y in ball (c I) (16 * D ^ s I), ‖f y‖ₑ ∂volume := by rw [setLAverage_eq]
     _ ≤ MB volume 𝓑 c𝓑 r𝓑 f x := by
       rw [MB_def]
-      have : (4, 0, I) ∈ 𝓑 := by simp [𝓑]
+      have : (4, 0, I) ∈ 𝓑 := by
+        simp only [𝓑, Set.mem_prod, Set.mem_Iic, Set.mem_univ, le_add_iff_nonneg_left, zero_le, and_self]
       refine le_of_eq_of_le ?_ (le_biSup _ this)
       have : x ∈ ball (c I) (2 ^ 4 * (D : ℝ) ^ s I) := by
         refine (ball_subset_ball ?_) (Grid_subset_ball hx)
@@ -508,11 +509,16 @@ lemma e728_rearrange (hf : BoundedCompactSupport f) (hg : BoundedCompactSupport 
     _ = ∑ I : Grid X, (volume (ball (c I) (16 * D ^ s I)))⁻¹.toReal *
         ∫ x in I, (conj (g x) * ∑ J ∈ 𝓙' t u (c I) (s I),
           (D ^ ((s J - s I) / (a : ℝ)) * ∫⁻ y in J, ‖f y‖ₑ).toReal) := by
-      congr with I; rw [← integral_const_mul]
+      congr with I
+      have : ∫ x in (I : Set X), ↑(volume (ball (c I) (16 * D ^ s I)))⁻¹.toReal * (conj (g x) * ↑(∑ J ∈ 𝓙' t u (c I) (s I), (D ^ ((s J - s I) / (a : ℝ)) * ∫⁻ y in (J : Set X), ‖f y‖ₑ).toReal)) = ↑(volume (ball (c I) (16 * D ^ s I)))⁻¹.toReal * ∫ x in (I : Set X), conj (g x) * ↑(∑ J ∈ 𝓙' t u (c I) (s I), (D ^ ((s J - s I) / (a : ℝ)) * ∫⁻ y in (J : Set X), ‖f y‖ₑ).toReal) := integral_const_mul _ _
+      rw [← this]
       congr with x; rw [← mul_assoc, mul_comm _ (conj _), mul_assoc]
       congr 1; rw [ofReal_sum, ofReal_sum, Finset.mul_sum]
       congr with J; rw [mul_comm, ofReal_mul]
-    _ = _ := by simp_rw [integral_mul_const, mul_assoc]
+    _ = _ := by
+      congr with I
+      have : ∫ x in (I : Set X), conj (g x) * (↑(∑ J ∈ 𝓙' t u (c I) (s I), (D ^ ((s J - s I) / (a : ℝ)) * ∫⁻ y in (J : Set X), ‖f y‖ₑ).toReal) : ℂ) = (∫ x in (I : Set X), conj (g x)) * (↑(∑ J ∈ 𝓙' t u (c I) (s I), (D ^ ((s J - s I) / (a : ℝ)) * ∫⁻ y in (J : Set X), ‖f y‖ₑ).toReal) : ℂ) := integral_mul_const _ _
+      rw [this, ← mul_assoc]
 
 open scoped Classical in
 /-- Equation (7.2.8) in the proof of Lemma 7.2.3. -/
@@ -556,7 +562,9 @@ lemma e728 (hf : BoundedCompactSupport f) (hg : BoundedCompactSupport g) :
           D ^ ((s J - s I) / (a : ℝ)) * ∫⁻ y in J, ‖f y‖ₑ else 0 := by
       rw [Finset.sum_comm]; congr with I
       simp_rw [Finset.mul_sum, mul_assoc, ← Finset.sum_filter]
-      exact Finset.sum_congr (by ext; simp [𝓙']) fun _ _ ↦ rfl
+      refine Finset.sum_congr ?_ fun _ _ ↦ rfl
+      ext
+      simp only [𝓙', Finset.mem_filter, Finset.mem_univ, Set.mem_toFinset, true_and]
     _ = ∑ J ∈ 𝓙 (t u), ∑ I : Grid X, ∫⁻ y in J,
         if (J : Set X) ⊆ ball (c I) (16 * D ^ s I) ∧ s J ≤ s I then
           (⨍⁻ x in ball (c I) (16 * D ^ s I), ‖g x‖ₑ ∂volume) *
@@ -604,12 +612,12 @@ lemma boundary_geometric_series :
             ext k
             rw [Finset.mem_filter, Finset.mem_Icc, Finset.mem_singleton, and_iff_right_iff_imp]
             intro h'; subst h'; exact ⟨hs, scale_mem_Icc.2⟩
-          simp [this]
+          rw [Set.toFinset_Icc, this, Finset.sum_singleton]
         · have : (Finset.Icc (s J) S).filter (· = s I) = ∅ := by
             ext k
             simp_rw [Finset.mem_filter, Finset.mem_Icc, Finset.notMem_empty, iff_false, not_and]
             intro; lia
-          simp [this]
+          rw [Set.toFinset_Icc, this, Finset.sum_empty]
       · simp_rw [h, false_and, ite_false, Finset.sum_const_zero]
     _ = ∑ kh : Icc (s J) S, ∑ I : Grid X,
         if (J : Set X) ⊆ ball (c I) (16 * D ^ s I) ∧ kh.1 = s I then
@@ -621,7 +629,7 @@ lemma boundary_geometric_series :
       obtain ⟨k, h⟩ := kh
       set J' := (Grid.exists_supercube k h).choose
       have pJ' : s J' = k ∧ J ≤ J' := (Grid.exists_supercube k h).choose_spec
-      by_cases hs : k = s I; swap; · simp [hs]
+      by_cases hs : k = s I; swap; · rw [if_neg (fun h => hs h.2)]; exact zero_le _
       suffices (J : Set X) ⊆ ball (c I) (16 * D ^ s I) → I ∈ kissing J' by
         split_ifs; exacts [by simp_all, by tauto, by positivity, by rfl]
       intro mJ; simp_rw [kissing, Finset.mem_filter_univ]
@@ -743,18 +751,24 @@ lemma boundary_operator_bound (hf : BoundedCompactSupport f) :
   nth_rw 1 [show ((2 : ℕ) : ℝ) = (2 : ℝ≥0) by rfl, show (2 : ℝ≥0∞) = (2 : ℝ≥0) by rfl,
     eLpNorm_nnreal_pow_eq_lintegral two_ne_zero]
   convert boundary_operator_bound_aux (t := t) (u := u) hf bcs.toComplex using 2
-  · simp_rw [RCLike.conj_mul]; norm_cast
-    simp_rw [← norm_pow, integral_norm_eq_lintegral_enorm
-      (bcs.aestronglyMeasurable.aemeasurable.pow_const 2).aestronglyMeasurable, enorm_pow,
-      enorm_toReal (boundaryOperator_lt_top hf).ne, enorm_eq_self]
-    simp_rw [enorm_eq_nnnorm, coe_algebraMap, nnnorm_real, ← enorm_eq_nnnorm,
-      ← ENNReal.rpow_natCast, Nat.cast_ofNat]
-    refine (enorm_toReal ?_).symm
-    replace hv' := ENNReal.pow_lt_top (n := 2) hv'
-    rw [← ENNReal.rpow_natCast, show ((2 : ℕ) : ℝ) = (2 : ℝ≥0) by rfl,
-      show (2 : ℝ≥0∞) = (2 : ℝ≥0) by rfl, eLpNorm_nnreal_pow_eq_lintegral two_ne_zero,
-      show ((2 : ℝ≥0) : ℝ) = (2 : ℕ) by rfl] at hv'
-    simp_rw [enorm_eq_self] at hv'; exact hv'.ne
+  · simp_rw [RCLike.conj_mul]
+    norm_cast
+    simp only [← norm_pow, Real.norm_of_nonneg (sq_nonneg _)]
+    have hι : ∫ (x : X), (↑((t.boundaryOperator u f x).toReal ^ 2) : ℂ) ∂volume =
+        ↑(∫ (x : X), (t.boundaryOperator u f x).toReal ^ 2 ∂volume) := integral_ofReal
+    erw [hι]
+    rw [enorm_eq_nnnorm, nnnorm_real, ← enorm_eq_nnnorm,
+        Real.enorm_eq_ofReal (integral_nonneg (fun x ↦ sq_nonneg _)),
+        MeasureTheory.ofReal_integral_eq_lintegral_ofReal
+          (by simp_rw [sq]; exact (bcs.mul bcs).integrable)
+          (ae_of_all _ fun x ↦ sq_nonneg _)]
+    apply lintegral_congr
+    intro x
+    rw [
+      ENNReal.ofReal_pow ENNReal.toReal_nonneg,
+      ENNReal.ofReal_toReal (boundaryOperator_lt_top hf).ne
+    ]
+    norm_cast
   · rw [← elpn_eq, show (2 : ℝ≥0∞) = (2 : ℝ≥0) by rfl]
     simp_rw [eLpNorm_nnreal_eq_lintegral two_ne_zero]; congr!
     simp [enorm_eq_nnnorm, nnnorm_real]
@@ -842,13 +856,21 @@ private lemma eLpNorm_two_cS_bound_le : eLpNorm (cS_bound t u f) 2 volume ≤
       simpa [eLpNorm, eLpNorm'] using ENNReal.lintegral_Lp_smul (m₁.add m₂) two_pos (C7_1_3 a)
     _ ≤ C7_1_3 a • (eLpNorm g₁ 2 μ + eLpNorm g₂ 2 μ) + eLpNorm g₃ 2 μ := by
       gcongr
-      simpa [eLpNorm, eLpNorm'] using ENNReal.lintegral_Lp_add_le m₁ m₂ one_le_two
+      apply mul_le_mul_of_nonneg_left
+      · exact eLpNorm_add_le m₁.aestronglyMeasurable m₂.aestronglyMeasurable one_le_two
+      · apply zero_le
     _ ≤ C7_1_3 a • ((CMB (defaultA a) 2) * eLpNorm aOC 2 μ + (C7_2_3 a) * eLpNorm aOC 2 μ) +
           (C7_2_2 a) * eLpNorm aOC 2 μ := by
       gcongr
-      · exact eLpNorm_MB_le boundedCompactSupport_approxOnCube
-      · apply le_of_le_of_eq <| boundary_operator_bound boundedCompactSupport_approxOnCube
-        simp [eLpNorm, eLpNorm', aOC, approxOnCube_ofReal, enorm_eq_nnnorm, μ]
+      · apply mul_le_mul_of_nonneg_left _ (zero_le _)
+        gcongr
+        · exact eLpNorm_MB_le boundedCompactSupport_approxOnCube
+        · apply le_of_le_of_eq <| boundary_operator_bound boundedCompactSupport_approxOnCube
+          congr 1
+          apply eLpNorm_congr_norm_ae
+          filter_upwards with x
+          convert Complex.norm_real (aOC x) using 2;
+          exact approxOnCube_ofReal _ _ _
       · apply le_trans <| nontangential_operator_bound boundedCompactSupport_approxOnCube (𝒬 u)
         refine mul_le_mul_right (eLpNorm_mono (fun x ↦ ?_)) _
         apply le_of_le_of_eq norm_approxOnCube_le_approxOnCube_norm
@@ -881,7 +903,7 @@ lemma tree_projection_estimate
       refine lintegral_congr (fun x ↦ ?_)
       by_cases hx : x ∈ ⋃ p ∈ t u, 𝓘 p
       · rw [indicator_of_mem hx]
-      · simp [indicator_of_notMem hx, notMem_support.mp (hx <| support_carlesonSum_subset ·)]
+      · simp only [notMem_support.mp (hx <| support_carlesonSum_subset ·), enorm_zero, mul_zero, indicator_of_notMem hx]
     _ ≤ ∫⁻ x in (⋃ L ∈ 𝓛 (t u), (L : Set X)), ‖g x‖ₑ * ‖carlesonSum (t u) f x‖ₑ := by
       rw [biUnion_𝓛]
       refine lintegral_mono_set (fun x hx ↦ ?_)

--- a/Carleson/ForestOperator/L2Estimate.lean
+++ b/Carleson/ForestOperator/L2Estimate.lean
@@ -65,7 +65,7 @@ private lemma support_subset (b : ℤ) (c : ℤ) (x : X) :
   suffices ((D : ℝ) ^ s)⁻¹ * dist x y ∉ support ψ by simp [Ks, notMem_support.mp this, -defaultD]
   rw [support_ψ (one_lt_realD X), mem_Ioo, not_and_or]
   rcases lt_or_ge ((D : ℝ) ^ (b - 1) / 4) (dist x y) with h | h
-  · push_neg; right
+  · push Not; right
     calc
       _ ≥ ((D : ℝ) ^ c)⁻¹ * (D ^ c / 2) := by
         gcongr
@@ -74,7 +74,7 @@ private lemma support_subset (b : ℤ) (c : ℤ) (x : X) :
         · exact (Finset.mem_Icc.mp hs).2
         · exact hy h
       _ = _ := by field_simp
-  · push_neg; left
+  · push Not; left
     calc
       _ ≤ ((D : ℝ) ^ b)⁻¹ * (D ^ (b - 1) / 4) := by
         refine mul_le_mul ?_ h dist_nonneg ?_

--- a/Carleson/ForestOperator/LargeSeparation.lean
+++ b/Carleson/ForestOperator/LargeSeparation.lean
@@ -607,12 +607,7 @@ lemma holder_correlation_rearrange (hf : BoundedCompactSupport f) :
     _ = ‖∫ y in E p,
         exp (.I * 𝒬 u x) * (conj (Ks (𝔰 p) y x) * exp (.I * (Q y y - Q y x)) * f y) -
         exp (.I * 𝒬 u x') * (conj (Ks (𝔰 p) y x') * exp (.I * (Q y y - Q y x')) * f y)‖ₑ := by
-      rw [
-        edist_eq_enorm_sub, adjointCarleson, adjointCarleson,
-        show cexp (I * ↑((𝒬 u) x)) * ∫ y in E p, (starRingEnd ℂ) (Ks (𝔰 p) y x) * cexp (I * (↑((Q y) y) - ↑((Q y) x))) * f y = ∫ y in E p, cexp (I * ↑((𝒬 u) x)) * ((starRingEnd ℂ) (Ks (𝔰 p) y x) * cexp (I * (↑((Q y) y) - ↑((Q y) x))) * f y) from (integral_const_mul ..).symm,
-        show cexp (I * ↑((𝒬 u) x')) * ∫ y in E p, (starRingEnd ℂ) (Ks (𝔰 p) y x') * cexp (I * (↑((Q y) y) - ↑((Q y) x'))) * f y = ∫ y in E p, cexp (I * ↑((𝒬 u) x')) * ((starRingEnd ℂ) (Ks (𝔰 p) y x') * cexp (I * (↑((Q y) y) - ↑((Q y) x'))) * f y) from (integral_const_mul ..).symm,
-        ← integral_sub (integrable_adjointCarleson_interior hf) (integrable_adjointCarleson_interior hf)
-      ]
+      erw [edist_eq_enorm_sub, adjointCarleson, adjointCarleson, ← integral_const_mul, ← integral_const_mul, ← integral_sub (integrable_adjointCarleson_interior hf) (integrable_adjointCarleson_interior hf)]
     _ = ‖∫ y in E p, f y *
           (conj (Ks (𝔰 p) y x) * exp (.I * (Q y y - Q y x + 𝒬 u x)) -
           conj (Ks (𝔰 p) y x') * exp (.I * (Q y y - Q y x' + 𝒬 u x')))‖ₑ := by

--- a/Carleson/ForestOperator/LargeSeparation.lean
+++ b/Carleson/ForestOperator/LargeSeparation.lean
@@ -607,8 +607,12 @@ lemma holder_correlation_rearrange (hf : BoundedCompactSupport f) :
     _ = ‖∫ y in E p,
         exp (.I * 𝒬 u x) * (conj (Ks (𝔰 p) y x) * exp (.I * (Q y y - Q y x)) * f y) -
         exp (.I * 𝒬 u x') * (conj (Ks (𝔰 p) y x') * exp (.I * (Q y y - Q y x')) * f y)‖ₑ := by
-      rw [edist_eq_enorm_sub, adjointCarleson, adjointCarleson, ← integral_const_mul,
-        ← integral_const_mul, ← integral_sub] <;> exact integrable_adjointCarleson_interior hf
+      rw [
+        edist_eq_enorm_sub, adjointCarleson, adjointCarleson,
+        show cexp (I * ↑((𝒬 u) x)) * ∫ y in E p, (starRingEnd ℂ) (Ks (𝔰 p) y x) * cexp (I * (↑((Q y) y) - ↑((Q y) x))) * f y = ∫ y in E p, cexp (I * ↑((𝒬 u) x)) * ((starRingEnd ℂ) (Ks (𝔰 p) y x) * cexp (I * (↑((Q y) y) - ↑((Q y) x))) * f y) from (integral_const_mul ..).symm,
+        show cexp (I * ↑((𝒬 u) x')) * ∫ y in E p, (starRingEnd ℂ) (Ks (𝔰 p) y x') * cexp (I * (↑((Q y) y) - ↑((Q y) x'))) * f y = ∫ y in E p, cexp (I * ↑((𝒬 u) x')) * ((starRingEnd ℂ) (Ks (𝔰 p) y x') * cexp (I * (↑((Q y) y) - ↑((Q y) x'))) * f y) from (integral_const_mul ..).symm,
+        ← integral_sub (integrable_adjointCarleson_interior hf) (integrable_adjointCarleson_interior hf)
+      ]
     _ = ‖∫ y in E p, f y *
           (conj (Ks (𝔰 p) y x) * exp (.I * (Q y y - Q y x + 𝒬 u x)) -
           conj (Ks (𝔰 p) y x') * exp (.I * (Q y y - Q y x' + 𝒬 u x')))‖ₑ := by
@@ -1232,7 +1236,11 @@ lemma global_tree_control1_edist_part1
   classical calc
     _ ≤ ∑ p ∈ ℭ, edist (exp (.I * 𝒬 u x) * adjointCarleson p f x)
         (exp (.I * 𝒬 u x') * adjointCarleson p f x') := by
-      simp_rw [adjointCarlesonSum, Finset.mul_sum, toFinset_ofFinset]
+      simp_rw [adjointCarlesonSum, Finset.mul_sum]
+      have heq : Finset.univ.filter (· ∈ ℭ) = ℭ.toFinset :=
+        Finset.ext (fun x => by simp only [Finset.mem_filter, Finset.mem_univ, true_and,
+          Set.mem_toFinset])
+      rw [heq]
       exact ENNReal.edist_sum_le_sum_edist
     _ = ∑ p ∈ ℭ with ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (16 * D ^ s J)),
         edist (exp (.I * 𝒬 u x) * adjointCarleson p f x)
@@ -1309,7 +1317,7 @@ lemma gtc_sum_Icc_le_two : ∑ k ∈ Finset.Icc (s J) S, (D : ℝ≥0∞) ^ ((s 
       pick_goal -1
       · rw [Finset.mem_Icc] at hk
         rw [Int.toNat_of_nonneg (by lia), neg_sub]
-      all_goals simp at hk ⊢; try omega
+      all_goals simp only [Finset.mem_Icc] at hk ⊢; omega
     _ ≤ ∑' k : ℕ, 2 ^ (-k : ℤ) := ENNReal.sum_le_tsum _
     _ = _ := ENNReal.sum_geometric_two_pow_neg_one
 
@@ -1702,14 +1710,18 @@ lemma edist_holderFunction_le (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u�
   let CH := χ t u₁ u₂ J
   let T₁ := fun z ↦ exp (.I * 𝒬 u₁ z) * adjointCarlesonSum (t u₁) f₁ z
   let T₂ := fun z ↦ exp (.I * 𝒬 u₂ z) * adjointCarlesonSum (t u₂ ∩ 𝔖₀ t u₁ u₂) f₂ z
+  rw [edist_eq_enorm_sub]
   change ‖CH x * T₁ x * conj (T₂ x) - CH x' * T₁ x' * conj (T₂ x')‖ₑ ≤ _
   calc
-    _ ≤ _ := edist_triangle4 _ (CH x' * T₁ x * conj (T₂ x)) (CH x' * T₁ x' * conj (T₂ x)) _
+    _ ≤ edist (CH x * T₁ x * conj (T₂ x)) (CH x' * T₁ x * conj (T₂ x)) +
+        edist (CH x' * T₁ x * conj (T₂ x)) (CH x' * T₁ x' * conj (T₂ x)) +
+        edist (CH x' * T₁ x' * conj (T₂ x)) (CH x' * T₁ x' * conj (T₂ x')) := by
+      rw [← edist_eq_enorm_sub]
+      exact edist_triangle4 ..
     _ = edist (CH x) (CH x') * ‖T₁ x‖ₑ * ‖T₂ x‖ₑ + CH x' * edist (T₁ x) (T₁ x') * ‖T₂ x‖ₑ +
         CH x' * ‖T₁ x'‖ₑ * edist (T₂ x) (T₂ x') := by
-      simp_rw [edist_eq_enorm_sub, ← sub_mul, ← mul_sub, enorm_mul, ← RingHom.map_sub,
-        RCLike.enorm_conj, ← ofReal_sub, Complex.enorm_real, NNReal.enorm_eq]
-      rfl
+      simp_rw [edist_eq_enorm_sub, ← sub_mul, ← mul_sub, ← map_sub (starRingEnd ℂ), enorm_mul, RCLike.enorm_conj]
+      rw [Complex.enorm_real, NNReal.enorm_eq, edist_dist, NNReal.dist_eq, ← Complex.ofReal_sub, Complex.enorm_real, Real.enorm_eq_ofReal_abs]
     _ ≤ C7_5_2 a * C7_5_9s a * C7_5_10 a * P7_5_4 t u₁ u₂ f₁ f₂ J * (edist x x' / D ^ s J) +
         C7_5_9d a * C7_5_10 a * P7_5_4 t u₁ u₂ f₁ f₂ J * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ +
         C7_5_9s a * C7_5_9d a * P7_5_4 t u₁ u₂ f₁ f₂ J * (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ := by

--- a/Carleson/ForestOperator/LargeSeparation.lean
+++ b/Carleson/ForestOperator/LargeSeparation.lean
@@ -32,8 +32,15 @@ lemma χtilde_pos_iff : 0 < χtilde J u₁ x ↔ x ∈ 𝓘 u₁ ∧ x ∈ ball 
   have := @one_le_realD a; rw [χtilde]
   by_cases h : x ∈ 𝓘 u₁
   · rw [indicator_of_mem h, Real.toNNReal_pos, sub_pos, zpow_neg, inv_mul_lt_iff₀' (by positivity)]
-    simp [h]
-  · rw [indicator_of_notMem h]; simp [h]
+    exact iff_and_self.mpr fun a ↦ h
+  · rw [indicator_of_notMem h]
+    apply Iff.intro
+    · simp
+    · simp only [defaultA, defaultD.eq_1, defaultκ.eq_1, defaultD, Nat.cast_pow, Nat.cast_ofNat,
+      mem_ball, lt_self_iff_false, imp_false, not_and, not_lt]
+      intro h1
+      exfalso
+      exact h h1
 
 lemma χtilde_le_eight : χtilde J u₁ x ≤ 8 := by
   unfold χtilde; apply indicator_le fun _ _ ↦ ?_
@@ -1425,12 +1432,14 @@ lemma global_tree_control1_supbound (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (h
       rcases hℭ with rfl | rfl
       · nth_rw 2 [← one_mul ‖_‖ₑ]; rw [← enorm_exp_I_mul_ofReal (𝒬 u₁ x), ← enorm_mul]
         nth_rw 3 [← one_mul ‖_‖ₑ]; rw [← enorm_exp_I_mul_ofReal (𝒬 u₁ x'), ← enorm_mul]
-        exact ENNReal.enorm_enorm_sub_enorm_le.trans
-          (global_tree_control1_edist_left hu₁ hu₂ hu h2u hJ hf hx hx')
+        apply ENNReal.enorm_enorm_sub_enorm_le.trans
+        rw [← edist_eq_enorm_sub]
+        exact global_tree_control1_edist_left hu₁ hu₂ hu h2u hJ hf hx hx'
       · nth_rw 2 [← one_mul ‖_‖ₑ]; rw [← enorm_exp_I_mul_ofReal (𝒬 u₂ x), ← enorm_mul]
         nth_rw 3 [← one_mul ‖_‖ₑ]; rw [← enorm_exp_I_mul_ofReal (𝒬 u₂ x'), ← enorm_mul]
-        exact ENNReal.enorm_enorm_sub_enorm_le.trans
-          (global_tree_control1_edist_right hu₁ hu₂ hu h2u hJ hf hx hx')
+        apply ENNReal.enorm_enorm_sub_enorm_le.trans
+        rw [← edist_eq_enorm_sub]
+        exact global_tree_control1_edist_right hu₁ hu₂ hu h2u hJ hf hx hx'
     _ ≤ (C7_5_9d a * 2 ^ ((2 : ℕ) : ℝ) * ⨅ x ∈ J, MB volume 𝓑 c𝓑 r𝓑 f x) + ε := by
       gcongr; rw [mem_ball] at hx hx'; rw [edist_dist]
       calc
@@ -1773,8 +1782,10 @@ lemma holder_correlation_tree (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u�
       · exact iSup₂_le_iff.mpr fun x mx ↦ enorm_holderFunction_le hu₁ hu₂ hu h2u hJ hf₁ hf₂ mx
       · calc
           _ ≤ I7_5_4 a * P7_5_4 t u₁ u₂ f₁ f₂ J *
-              (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ / edist x x' ^ τ :=
-            ENNReal.div_le_div_right (edist_holderFunction_le hu₁ hu₂ hu h2u hJ hf₁ hf₂ mx mx') _
+              (edist x x' / D ^ s J) ^ (a : ℝ)⁻¹ / edist x x' ^ τ := by
+              rw [← edist_eq_enorm_sub]
+              have h := edist_holderFunction_le hu₁ hu₂ hu h2u hJ hf₁ hf₂ mx mx'
+              exact ENNReal.div_le_div_right h (edist x x' ^ τ)
           _ = _ := by
             rw [mul_div_assoc, defaultτ, ← ENNReal.div_rpow_of_nonneg _ _ (by positivity),
               div_eq_mul_inv, div_eq_mul_inv, ← mul_rotate _ (edist x x'),

--- a/Carleson/ForestOperator/LargeSeparation.lean
+++ b/Carleson/ForestOperator/LargeSeparation.lean
@@ -597,6 +597,7 @@ lemma integrable_adjointCarleson_interior (hf : BoundedCompactSupport f) :
 
 attribute [fun_prop] continuous_conj Continuous.comp_aestronglyMeasurable
 
+set_option backward.isDefEq.respectTransparency false in
 /-- Sub-equations (7.5.10) and (7.5.11) in Lemma 7.5.5. -/
 lemma holder_correlation_rearrange (hf : BoundedCompactSupport f) :
     edist (exp (.I * 𝒬 u x) * adjointCarleson p f x) (exp (.I * 𝒬 u x') * adjointCarleson p f x') ≤
@@ -606,7 +607,7 @@ lemma holder_correlation_rearrange (hf : BoundedCompactSupport f) :
     _ = ‖∫ y in E p,
         exp (.I * 𝒬 u x) * (conj (Ks (𝔰 p) y x) * exp (.I * (Q y y - Q y x)) * f y) -
         exp (.I * 𝒬 u x') * (conj (Ks (𝔰 p) y x') * exp (.I * (Q y y - Q y x')) * f y)‖ₑ := by
-      erw [edist_eq_enorm_sub, adjointCarleson, adjointCarleson, ← integral_const_mul, ← integral_const_mul, ← integral_sub (integrable_adjointCarleson_interior hf) (integrable_adjointCarleson_interior hf)]
+      rw [edist_eq_enorm_sub, adjointCarleson, adjointCarleson, ← integral_const_mul, ← integral_const_mul, ← integral_sub (integrable_adjointCarleson_interior hf) (integrable_adjointCarleson_interior hf)]
     _ = ‖∫ y in E p, f y *
           (conj (Ks (𝔰 p) y x) * exp (.I * (Q y y - Q y x + 𝒬 u x)) -
           conj (Ks (𝔰 p) y x') * exp (.I * (Q y y - Q y x' + 𝒬 u x')))‖ₑ := by

--- a/Carleson/ForestOperator/LargeSeparation.lean
+++ b/Carleson/ForestOperator/LargeSeparation.lean
@@ -199,13 +199,13 @@ lemma moderate_scale_change (hJ : J ∈ 𝓙₅ t u₁ u₂) (hJ' : J' ∈ 𝓙�
   by_contra! hs
   have fa : ∀ p ∈ t.𝔖₀ u₁ u₂, ¬↑(𝓘 p) ⊆ ball (c J) (100 * D ^ (s J + 1)) :=
     hJ.1.1.resolve_left (by linarith [(scale_mem_Icc (i := J')).1])
-  apply absurd fa; push_neg
+  apply absurd fa; push Not
   obtain ⟨J'', sJ'', lJ''⟩ : ∃ J'', s J'' = s J' + 1 ∧ J' ≤ J'' := by
     refine Grid.exists_supercube (s J' + 1) ⟨by lia, ?_⟩
     rw [lt_sub_iff_add_lt] at hs; exact hs.le.trans scale_mem_Icc.2
   obtain ⟨p, mp, sp⟩ : ∃ p ∈ t.𝔖₀ u₁ u₂, ↑(𝓘 p) ⊆ ball (c J'') (100 * D ^ (s J' + 1 + 1)) := by
     have : J'' ∉ 𝓙₀ (t.𝔖₀ u₁ u₂) := bigger_than_𝓙_is_not_in_𝓙₀ lJ'' (by linarith) hJ'.1
-    rw [𝓙₀, mem_setOf_eq, sJ''] at this; push_neg at this; exact this.2
+    rw [𝓙₀, mem_setOf_eq, sJ''] at this; push Not at this; exact this.2
   use p, mp, sp.trans (ball_subset_ball' ?_)
   calc
     _ ≤ 100 * D ^ (s J' + 1 + 1) + (dist (c J'') (c J') + dist (c J) (c J')) :=
@@ -907,7 +907,7 @@ lemma limited_scale_impact_second_estimate (hp : p ∈ t u₂ \ 𝔖₀ t u₁ u
     have J'Touches𝔖₀ : J' ∉ 𝓙₀ (t.𝔖₀ u₁ u₂) := bigger_than_𝓙_is_not_in_𝓙₀ (le := belongs)
       (sle := by linarith [plusOne]) (A_in := hJ.1)
     rw [𝓙₀, Set.notMem_setOf_iff] at J'Touches𝔖₀
-    push_neg at J'Touches𝔖₀
+    push Not at J'Touches𝔖₀
     exact J'Touches𝔖₀.right
   apply calculation_9 (X := X)
   apply one_le_of_le_mul_right₀ (b := 2 ^ ((Z : ℝ) * n / 2)) (by positivity)
@@ -1890,7 +1890,7 @@ lemma lower_oscillation_bound (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u�
     exact mem_of_mem_inter_left hJ
   unfold 𝓙₀ at notIn𝓙₀
   simp only [mem_setOf_eq, not_or, not_forall] at notIn𝓙₀
-  push_neg at notIn𝓙₀
+  push Not at notIn𝓙₀
   obtain ⟨_, ⟨ p, pIn, pSubset ⟩⟩ := notIn𝓙₀
   have thus :=
     calc 2 ^ ((Z : ℝ) * n / 2)

--- a/Carleson/ForestOperator/LargeSeparation.lean
+++ b/Carleson/ForestOperator/LargeSeparation.lean
@@ -36,8 +36,7 @@ lemma χtilde_pos_iff : 0 < χtilde J u₁ x ↔ x ∈ 𝓘 u₁ ∧ x ∈ ball 
   · rw [indicator_of_notMem h]
     apply Iff.intro
     · simp
-    · simp only [defaultA, defaultD.eq_1, defaultκ.eq_1, defaultD, Nat.cast_pow, Nat.cast_ofNat,
-      mem_ball, lt_self_iff_false, imp_false, not_and, not_lt]
+    · simp only [lt_self_iff_false, imp_false, not_and]
       intro h1
       exfalso
       exact h h1
@@ -1232,9 +1231,9 @@ lemma global_tree_control1_edist_part1
     _ ≤ ∑ p ∈ ℭ, edist (exp (.I * 𝒬 u x) * adjointCarleson p f x)
         (exp (.I * 𝒬 u x') * adjointCarleson p f x') := by
       simp_rw [adjointCarlesonSum, Finset.mul_sum]
-      have heq : Finset.univ.filter (· ∈ ℭ) = ℭ.toFinset :=
-        Finset.ext (fun x => by simp only [Finset.mem_filter, Finset.mem_univ, true_and,
-          Set.mem_toFinset])
+      have heq : Finset.univ.filter (· ∈ ℭ) = ℭ.toFinset := by
+        ext x
+        simp only [Finset.mem_filter, Finset.mem_univ, true_and, Set.mem_toFinset]
       rw [heq]
       exact ENNReal.edist_sum_le_sum_edist
     _ = ∑ p ∈ ℭ with ¬Disjoint (ball (𝔠 p) (8 * D ^ 𝔰 p)) (ball (c J) (16 * D ^ s J)),

--- a/Carleson/ForestOperator/PointwiseEstimate.lean
+++ b/Carleson/ForestOperator/PointwiseEstimate.lean
@@ -64,7 +64,7 @@ lemma S_eq_zero_of_topCube_mem_𝓙₀ {𝔖 : Set (𝔓 X)} (h𝔖 : 𝔖.Nonem
   suffices (S : ℤ) = -(S : ℤ) by exact_mod_cast eq_zero_of_neg_eq this.symm
   rw [𝓙₀, mem_setOf_eq, s, s_topCube] at h
   apply h.resolve_right
-  push_neg
+  push Not
   have ⟨p, hp⟩ := h𝔖
   refine ⟨p, hp, subset_topCube.trans <| Grid_subset_ball.trans <| ball_subset_ball ?_⟩
   apply mul_le_mul (by norm_num) (c0 := by positivity) (b0 := by norm_num)

--- a/Carleson/ForestOperator/PointwiseEstimate.lean
+++ b/Carleson/ForestOperator/PointwiseEstimate.lean
@@ -127,16 +127,18 @@ lemma approxOnCube_apply {C : Set (Grid X)} (hC : C.PairwiseDisjoint (fun I ↦ 
   have eq0 : ∑ i ∈ Finset.filter (¬ J = ·) (Finset.univ.filter (· ∈ C)),
       (i : Set X).indicator (fun _ ↦ ⨍ y in i, f y) x = 0 := by
     suffices ∀ i ∈ (Finset.univ.filter (· ∈ C)).filter (¬ J = ·),
-      (i : Set X).indicator (fun _ ↦ ⨍ y in i, f y) x = 0 by simp [Finset.sum_congr rfl this]
+      (i : Set X).indicator (fun _ ↦ ⨍ y in i, f y) x = 0 by exact Finset.sum_eq_zero this
     intro i hi
     rw [Finset.mem_filter, Finset.mem_filter_univ] at hi
     apply indicator_of_notMem <|
       Set.disjoint_left.mp ((hC.eq_or_disjoint hJ hi.1).resolve_left hi.2) xJ
   have eq_ave : ∑ i ∈ (Finset.univ.filter (· ∈ C)).filter (J = ·),
       (i : Set X).indicator (fun _ ↦ ⨍ y in i, f y) x = ⨍ y in J, f y := by
-    suffices (Finset.univ.filter (· ∈ C)).filter (J = ·) = {J} by simp [this, xJ, ← Grid.mem_def]
+    suffices (Finset.univ.filter (· ∈ C)).filter (J = ·) = {J} by
+      rw [this, Finset.sum_singleton, Set.indicator_of_mem xJ]
     exact subset_antisymm (fun _ h ↦ Finset.mem_singleton.mpr (Finset.mem_filter.mp h).2.symm)
-      (fun _ h ↦ by simp [Finset.mem_singleton.mp h, hJ])
+      (fun _ h ↦ Finset.mem_filter.mpr ⟨Finset.mem_filter.mpr ⟨Finset.mem_univ _,
+        (Finset.mem_singleton.mp h) ▸ hJ⟩, (Finset.mem_singleton.mp h).symm⟩)
   rw [eq0, eq_ave, zero_add]
 
 lemma boundedCompactSupport_approxOnCube {𝕜 : Type*} [RCLike 𝕜] {C : Set (Grid X)} {f : X → 𝕜} :
@@ -166,7 +168,13 @@ lemma lintegral_eq_lintegral_approxOnCube {C : Set (Grid X)}
   rw [eq, lintegral_const, average_eq, smul_eq_mul, ENNReal.ofReal_mul, ENNReal.ofReal_inv_of_pos,
     ofReal_integral_eq_lintegral_ofReal hf.norm.integrable.restrict nonneg, mul_comm,
     ← mul_assoc, Measure.restrict_apply MeasurableSet.univ, univ_inter]
-  · simp [volume_coeGrid_lt_top.ne, ENNReal.mul_inv_cancel vol_J_ne_zero]
+  · simp only [Measure.real,
+      Measure.restrict_apply_univ,
+      ENNReal.ofReal_toReal volume_coeGrid_lt_top.ne,
+      ENNReal.mul_inv_cancel vol_J_ne_zero volume_coeGrid_lt_top.ne,
+      one_mul,
+      ofReal_norm_eq_enorm
+    ]
   · simpa using ENNReal.toReal_pos vol_J_ne_zero volume_coeGrid_lt_top.ne
   · exact inv_nonneg.mpr ENNReal.toReal_nonneg
 
@@ -195,8 +203,9 @@ lemma cubeOf_spec {i : ℤ} (hi : i ∈ Icc (-S : ℤ) S) (I : Grid X) {x : X} (
   apply Classical.epsilon_spec (p := fun I ↦ x ∈ I ∧ s I = i)
   by_cases hiS : i = S
   · use topCube, subset_topCube hx, hiS ▸ s_topCube
-  simpa [and_comm] using Set.mem_iUnion₂.mp <| Grid_subset_biUnion i
+  have ⟨y, hy, hys⟩ := Set.mem_iUnion₂.mp <| Grid_subset_biUnion i
     ⟨hi.1, s_topCube (X := X) ▸ lt_of_le_of_ne hi.2 hiS⟩ (subset_topCube hx)
+  exact frequently_principal.mp fun a ↦ a hys hy
 
 /-- The definition `T_𝓝^θ f(x)`, given in (7.1.3).
 For convenience, the suprema are written a bit differently than in the blueprint
@@ -214,7 +223,7 @@ protected theorem MeasureTheory.Measurable.nontangentialMaximalFunction {θ : Θ
   let c := ⨆ x' ∈ I, ⨆ s₂ ∈ Icc (s I) S, ⨆ (_ : ENNReal.ofReal (D ^ (s₂ - 1)) ≤ upperRadius Q θ x'),
     ‖∑ i ∈ (Icc (s I) s₂), ∫ (y : X), Ks i x' y * f y‖ₑ
   have : (fun x ↦ ⨆ (_ : x ∈ I), c) = fun x ↦ ite (x ∈ I) c 0 := by
-    ext x; by_cases hx : x ∈ I <;> simp [hx]
+    ext x; by_cases hx : x ∈ I <;> simp only [hx, iSup_pos, iSup_neg, if_pos, if_neg, bot_eq_zero, not_false_eq_true]
   convert (measurable_const.ite coeGrid_measurable measurable_const) using 1
 
 -- Set used in definition of `boundaryOperator`
@@ -251,7 +260,8 @@ lemma boundaryOperator_lt_top (hf : BoundedCompactSupport f) : t.boundaryOperato
   by_cases hx : x ∈ (I : Set X)
   · rw [indicator_of_mem hx]
     exact ENNReal.sum_lt_top.mpr (fun _ _ ↦ ijIntegral_lt_top hf)
-  · simp [hx]
+  · rw [indicator_of_notMem hx]
+    exact ENNReal.zero_lt_top
 
 
 /-- The indexing set for the collection of balls 𝓑, defined above Lemma 7.1.3. -/
@@ -339,16 +349,17 @@ irreducible_def C7_1_4 (a : ℕ) : ℝ≥0 := 10 * 2 ^ ((𝕔 + 4) * a ^ 3)
 -- Used in the proof of `exp_sub_one_le`, which is used to prove Lemma 7.1.4
 private lemma exp_Lipschitz : LipschitzWith 1 (fun (t : ℝ) ↦ exp (.I * t)) := by
   have mul_I : Differentiable ℝ fun (t : ℝ) ↦ I * t := Complex.ofRealCLM.differentiable.const_mul I
-  refine lipschitzWith_of_nnnorm_deriv_le mul_I.cexp (fun x ↦ ?_)
-  have : (fun (t : ℝ) ↦ cexp (I * t)) = cexp ∘ (fun (t : ℝ) ↦ I * t) := rfl
-  rw [this, deriv_comp x differentiableAt_exp (mul_I x), Complex.deriv_exp, deriv_const_mul_field']
-  simp_rw [show deriv ofReal x = 1 from ofRealCLM.hasDerivAt.deriv, mul_one]
-  rw [nnnorm_mul, nnnorm_I, mul_one, ← norm_toNNReal, mul_comm, Complex.norm_exp_ofReal_mul_I]
+  refine lipschitzWith_of_nnnorm_deriv_le mul_I.cexp (fun x ↦ ?_) 
+  have key : HasDerivAt (fun t : ℝ ↦ cexp (I * ↑t)) (cexp (I * ↑x) * I) x := by
+    simpa using (Complex.hasDerivAt_exp _).comp x
+      (by simpa using Complex.ofRealCLM.hasDerivAt.const_mul I)
+  rw [key.deriv, nnnorm_mul, nnnorm_I, mul_one, ← norm_toNNReal, mul_comm, Complex.norm_exp_ofReal_mul_I]
   exact Real.toNNReal_one.le
 
 -- Used in the proof of Lemma 7.1.4
 private lemma exp_sub_one_le (t : ℝ) : ‖exp (.I * t) - 1‖ ≤ ‖t‖ := by
-  simpa [enorm_eq_nnnorm] using exp_Lipschitz t 0
+  have h := exp_Lipschitz.dist_le_mul t 0
+  simpa [dist_eq_norm, dist_zero_right] using h
 
 -- Used in the proofs of Lemmas 7.1.4 and 7.1.5
 private lemma dist_lt_5 (hu : u ∈ t) (mp : p ∈ t.𝔗 u) (Qxp : Q x ∈ Ω p) :
@@ -386,12 +397,13 @@ private lemma L7_1_4_bound (hu : u ∈ t) {s : ℤ} (hs : s ∈ t.σ u x) {y : X
       simp_rw [← hp', ← hpₛ, 𝔰, _root_.s]; ring
     apply le_trans <| Grid.dist_strictMono_iterate' sub_ge_0 pₛ_le_p' this
     gcongr
-    calc  C2_1_2 a ^ (t.σMax u x ⟨s, hs⟩ - s)
+    · calc  C2_1_2 a ^ (t.σMax u x ⟨s, hs⟩ - s)
       _ ≤ C2_1_2 a ^ (t.σMax u x ⟨s, hs⟩ - s : ℝ)                     := by norm_cast
       _ ≤ (1 / 2 : ℝ) ^ (t.σMax u x ⟨s, hs⟩ - s : ℝ)                  :=
         Real.rpow_le_rpow (by rw [C2_1_2]; positivity)
           ((C2_1_2_le_inv_256 X).trans (by norm_num)) (by norm_cast)
       _ = 2 ^ (s - σMax t u x ⟨s, hs⟩)                                := by simp [← Int.cast_sub]
+    exact le_refl _
   calc ‖exp (.I * (-𝒬 u y + Q x y + 𝒬 u x - Q x x)) - 1‖
     _ ≤ dist_{x, D ^ s / 2} (𝒬 u) (Q x) :=
       exp_bound.trans <| oscillation_le_cdist x _ (𝒬 u) (Q x)
@@ -525,7 +537,7 @@ private lemma L7_1_4_integral_le_integral (hu : u ∈ t) (hf : BoundedCompactSup
   classical
   let Js := Set.toFinset { J ∈ 𝓙 (t u) | ((J : Set X) ∩ ball x (D ^ (𝔰 p) / 2)).Nonempty }
   have mem_Js {J : Grid X} : J ∈ Js ↔ J ∈ 𝓙 (t.𝔗 u) ∧ (↑J ∩ ball x (D ^ 𝔰 p / 2)).Nonempty := by
-    simp [Js]
+    simp only [Js, Set.mem_toFinset, Set.mem_setOf_eq]
   have Js_disj : (Js : Set (Grid X)).Pairwise (Disjoint on fun J ↦ (J : Set X)) :=
     fun i₁ hi₁ i₂ hi₂ h ↦ pairwiseDisjoint_𝓙 (mem_Js.mp hi₁).1 (mem_Js.mp hi₂).1 h
   calc
@@ -534,7 +546,7 @@ private lemma L7_1_4_integral_le_integral (hu : u ∈ t) (hf : BoundedCompactSup
       have h := ball_covered_by_𝓙 hu pu xp
       refine (subset_inter_iff.mpr ⟨h, subset_refl _⟩).trans fun y hy ↦ ?_
       have ⟨J, hJ, yJ⟩ := Set.mem_iUnion₂.mp hy.1
-      exact ⟨J, ⟨⟨J, by simp [mem_Js.mpr ⟨hJ, ⟨y, mem_inter yJ hy.2⟩⟩]⟩, yJ⟩⟩
+      exact Set.mem_biUnion (mem_Js.mpr ⟨hJ, ⟨y, mem_inter yJ hy.2⟩⟩) yJ
     _ = ∑ J ∈ Js, ∫⁻ y in J, ‖f y‖ₑ := by
       rw [lintegral_biUnion_finset Js_disj fun _ _ ↦ coeGrid_measurable]
     _ = ∑ J ∈ Js, ∫⁻ y in J, ‖approxOnCube (𝓙 (t u)) (‖f ·‖) y‖ₑ := by
@@ -564,7 +576,9 @@ private lemma L7_1_4_laverage_le_MB (hL : L ∈ 𝓛 (t u)) (hx : x ∈ L) (hx' 
     {p : 𝔓 X} (pu : p ∈ t.𝔗 u) (xp : x ∈ E p) :
     (∫⁻ y in ball (𝔠 p) (16 * D ^ 𝔰 p), ‖g y‖ₑ) / volume (ball (𝔠 p) (16 * D ^ 𝔰 p)) ≤
     MB volume 𝓑 c𝓑 r𝓑 g x' := by
-  have mem_𝓑 : (4, 0, 𝓘 p) ∈ 𝓑 := by simp [𝓑]
+  have mem_𝓑 : (4, 0, 𝓘 p) ∈ 𝓑 := by
+    simp only [𝓑, Set.mem_prod, Set.mem_Iic, Set.mem_univ, and_true]
+    omega
   convert le_biSup (hi := mem_𝓑) <| fun i ↦ ((ball (c𝓑 i) (r𝓑 i)).indicator (x := x') <|
     fun _ ↦ ⨍⁻ y in ball (c𝓑 i) (r𝓑 i), ‖g y‖ₑ ∂volume)
   · have x'_in_ball : x' ∈ ball (c𝓑 (4, 0, 𝓘 p)) (r𝓑 (4, 0, 𝓘 p)) := by
@@ -574,7 +588,7 @@ private lemma L7_1_4_laverage_le_MB (hL : L ∈ 𝓛 (t u)) (hx : x ∈ L) (hx' 
       linarith [defaultD_pow_pos a (GridStructure.s (𝓘 p))]
     have hc𝓑 : 𝔠 p = c𝓑 (4, 0, 𝓘 p) := by simp [c𝓑, 𝔠]
     have hr𝓑 : 16 * D ^ 𝔰 p = r𝓑 (4, 0, 𝓘 p) := by rw [r𝓑, 𝔰]; norm_num
-    simp [-defaultD, laverage, x'_in_ball, ENNReal.div_eq_inv_mul, hc𝓑, hr𝓑]
+    rw [Set.indicator_of_mem x'_in_ball, ← hc𝓑, ← hr𝓑, MeasureTheory.setLAverage_eq]
   · simp only [MB, maximalFunction, ENNReal.rpow_one, inv_one]
 
 /-- Lemma 7.1.4 -/
@@ -741,7 +755,10 @@ private lemma p_sum_eq_s_sum {α : Type*} [AddCommMonoid α] (I : ℤ → X → 
   let 𝔗' := Finset.univ.filter (fun p ↦ p ∈ t.𝔗 u ∧ x ∈ E p)
   have : ∑ p ∈ 𝔗', (E p).indicator (I (𝔰 p)) x =
       ∑ p ∈ Finset.univ.filter (· ∈ t.𝔗 u), (E p).indicator (I (𝔰 p)) x := by
-    apply Finset.sum_subset (fun p hp ↦ by simp [(Finset.mem_filter.mp hp).2.1])
+    apply Finset.sum_subset
+    · intro p hp
+      apply Finset.mem_filter.mpr
+      exact ⟨Finset.mem_univ _, (Finset.mem_filter.mp hp).2.1⟩
     intro p p𝔗 p𝔗'
     simp_rw [𝔗', Finset.mem_filter_univ, not_and] at p𝔗 p𝔗'
     exact indicator_of_notMem (p𝔗' p𝔗) (I (𝔰 p))
@@ -757,7 +774,8 @@ private lemma p_sum_eq_s_sum {α : Type*} [AddCommMonoid α] (I : ℤ → X → 
     exact Nonempty.not_disjoint ⟨Q x, ⟨hp.2.2.1.2, hp'.2.2.1.2⟩⟩ <| disjoint_Ω h <|
       (eq_or_disjoint hpp').resolve_right <| Nonempty.not_disjoint ⟨x, ⟨hp.2.2.1.1, hp'.2.2.1.1⟩⟩
   · intro s hs
-    simpa [𝔗', σ] using hs
+    obtain ⟨p, ⟨hp1, hp2⟩, hps⟩ := by simpa [σ] using hs
+    exact ⟨p, Finset.mem_filter.mpr ⟨Finset.mem_univ _, hp1, hp2⟩, hps⟩
   · intro p hp
     simp only [Finset.mem_filter, 𝔗'] at hp
     exact indicator_of_mem hp.2.2 (I (𝔰 p))
@@ -781,18 +799,29 @@ private lemma L7_1_6_integral_eq {J : Grid X} (hJ : J ∈ 𝓙 (t.𝔗 u)) {i : 
       ((integrable_Ks_x (one_lt_realD (X := X))).smul_const _).restrict.to_average
   have μJ_neq_0 : NeZero (volume.restrict (J : Set X)) :=
     NeZero.mk fun h ↦ (volume_coeGrid_pos (defaultD_pos a) (i := J)).ne <|
-      by simpa [h] using Measure.restrict_apply_self volume (J : Set X)
+      by rw [← Measure.restrict_apply_univ, h, Measure.coe_zero, Pi.zero_apply]
   have μJ_finite := Restrict.isFiniteMeasure volume (hs := ⟨volume_coeGrid_lt_top (i := J)⟩)
   -- Split both sides into two separate integrals
   rw [setIntegral_congr_fun coeGrid_measurable eq1]
-  simp_rw [mul_sub, integral_sub i1 i2, ← smul_eq_mul, ← average_smul_const, sub_smul]
-  rw [setIntegral_congr_fun coeGrid_measurable eq2, integral_sub]
+  simp_rw [mul_sub, integral_sub i1 i2, ← smul_eq_mul]
+  have rhs_rw : ∫ (y : X) in ↑J, (⨍ (z : X) in ↑J, Ks i x y - Ks i x z) • f y =
+      ∫ (y : X) in ↑J, ⨍ (z : X) in ↑J, Ks i x y • f y - Ks i x z • f y := by
+    apply setIntegral_congr_fun coeGrid_measurable
+    intro y _
+    exact (average_smul_const (fun z ↦ Ks i x y - Ks i x z) (f y)).symm.trans
+      (by simp_rw [sub_smul])
+  rw [rhs_rw, setIntegral_congr_fun coeGrid_measurable eq2, integral_sub]
   · congr 1 -- Check that corresponding integrals are equal
     · exact setIntegral_congr_fun coeGrid_measurable (fun y hy ↦ (average_const _ _).symm)
     · simp_rw [average_smul_const, integral_smul_const, integral_smul, average_eq]
-      rw [smul_comm, smul_assoc]
+      have h : ∀ (A B : ℂ) (r : ℝ), A • r • B = (r • A) • B := by
+        intro A B r
+        simp only [smul_eq_mul, Complex.real_smul]
+        ring
+      exact h ..
   -- Check integrability to justify the last use of `integral_sub`
-  · simpa [average_const]
+  · simp only [average_const]
+    exact i1
   · simp_rw [average_smul_const]
     change Integrable ((⨍ z in (J : Set X), Ks i x z) • f) (volume.restrict J)
     exact hf.integrable.restrict.smul _
@@ -864,10 +893,11 @@ private lemma L7_1_6_I_le (hu : u ∈ t) (hf : BoundedCompactSupport f) {p : �
       have ⟨J, hJ⟩ := Set.mem_iUnion.mp <| ball_covered_by_𝓙 hu hp hxp (mem_ball'.mpr hy)
       use J
       simpa using hJ
-    refine ⟨J, ⟨⟨J, ?_⟩, yJ⟩⟩
-    suffices J ∈ 𝓙' t u (𝔠 p) (𝔰 p) by simp [this]
-    simpa [𝓙', hJ] using And.intro (Grid_subset_ball' hp hxp ⟨hJ, y, yJ, mem_ball'.mpr hy⟩)
-      (s_le_s hp hxp ⟨hJ, ⟨y, ⟨yJ, mem_ball'.mpr hy⟩⟩⟩)
+    have hJ𝓙' : J ∈ 𝓙' t u (𝔠 p) (𝔰 p) := by
+      simp only [𝓙', Finset.mem_filter, Finset.mem_univ, true_and]
+      exact ⟨hJ, Grid_subset_ball' hp hxp ⟨hJ, y, yJ, mem_ball'.mpr hy⟩,
+             s_le_s hp hxp ⟨hJ, ⟨y, ⟨yJ, mem_ball'.mpr hy⟩⟩⟩⟩
+    exact Set.mem_biUnion (Finset.mem_coe.mpr hJ𝓙') yJ
   _ = ‖∑ J ∈ 𝓙' t u (𝔠 p) (𝔰 p), ∫ y in J, Ks (𝔰 p) x y * (f y - approxOnCube (𝓙 (t u)) f y)‖ₑ := by
     refine congrArg _ (integral_biUnion_finset _ (fun _ _ ↦ coeGrid_measurable) ?_ ?_)
     · exact fun i hi j hj hij ↦ pairwiseDisjoint_𝓙 (mem_𝓙_of_mem_𝓙' hi) (mem_𝓙_of_mem_𝓙' hj) hij
@@ -891,7 +921,12 @@ lemma sum_p_eq_sum_I_sum_p (f : X → ℤ → ℝ≥0∞) :
   set ps := fun (I : Grid X) ↦ Finset.univ.filter (fun p ↦ p ∈ t u ∧ 𝓘 p = I)
   calc
   _ = ∑ p ∈ Finset.univ.biUnion ps, (E p).indicator 1 x * f (𝔠 p) (𝔰 p) :=
-    Finset.sum_congr (by ext p; simp [ps]) (fun _ _ ↦ rfl)
+    have hps_eq : Finset.univ.filter (· ∈ t u) = Finset.univ.biUnion ps := by
+      ext p
+      simp only [ps, Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_biUnion,
+        exists_and_left]
+      exact ⟨fun h ↦ ⟨h, _, rfl⟩, And.left⟩
+    Finset.sum_congr hps_eq (fun _ _ ↦ rfl)
   _ = ∑ I : Grid X, ∑ p ∈ Finset.univ.filter (fun p ↦ p ∈ t u ∧ 𝓘 p = I),
         (E p).indicator 1 x * f (𝔠 p) (𝔰 p) := by
     refine (Finset.sum_biUnion ?_)
@@ -1062,8 +1097,12 @@ lemma pointwise_tree_estimate (hu : u ∈ t) (hL : L ∈ 𝓛 (t u)) (hx : x ∈
           ∑ i ∈ t.σ u x, ∫ (y : X),
             (f y * ((exp (I * (- 𝒬 u y + Q x y + 𝒬 u x - Q x x)) - 1) * Ks i x y) +
             (f y - g y) * Ks i x y + g y * Ks i x y) := by
-    simp_rw [← integral_const_mul, Ks, mul_sub, mul_add, sub_eq_add_neg, exp_add]
-    exact Finset.fold_congr (fun s hs ↦ integral_congr_ae (funext fun y ↦ by ring).eventuallyEq)
+    simp_rw [Ks, mul_sub, mul_add, sub_eq_add_neg, exp_add]
+    apply Finset.sum_congr rfl
+    intro _ _
+    apply (integral_const_mul ..).symm.trans
+    apply integral_congr_ae
+    exact (funext fun y ↦ by ring).eventuallyEq
   rw [this]
   -- It suffices to show that the integral splits into the three terms bounded by Lemmas 7.1.4-6
   suffices ∑ i ∈ t.σ u x, ∫ (y : X),
@@ -1092,7 +1131,10 @@ lemma pointwise_tree_estimate (hu : u ∈ t) (hL : L ∈ 𝓛 (t u)) (hx : x ∈
       (c := ∑ J with J ∈ 𝓙 (t u), ‖⨍ y in J, f y‖)
     · exact (stronglyMeasurable_approxOnCube _ _).aestronglyMeasurable
     · refine ae_of_all _ fun x ↦ (norm_sum_le _ _).trans <| Finset.sum_le_sum (fun J hJ ↦ ?_)
-      by_cases h : x ∈ (J : Set X) <;> simp [h]
+      by_cases h : x ∈ (J : Set X)
+      · rw [Set.indicator_of_mem h]
+      · rw [Set.indicator_apply, if_neg h, norm_zero]
+        exact norm_nonneg _
   have : ∀ (y : X), ‖cexp (I * (-𝒬 u y + Q x y + 𝒬 u x - Q x x)) - 1‖ ≤ 2 := by
     refine fun y ↦ le_of_le_of_eq (norm_sub_le _ _) ?_
     norm_cast

--- a/Carleson/ForestOperator/PointwiseEstimate.lean
+++ b/Carleson/ForestOperator/PointwiseEstimate.lean
@@ -816,7 +816,7 @@ private lemma L7_1_6_integral_eq {J : Grid X} (hJ : J ∈ 𝓙 (t.𝔗 u)) {i : 
     · simp_rw [average_smul_const, integral_smul_const, integral_smul, average_eq]
       have h : ∀ (A B : ℂ) (r : ℝ), A • r • B = (r • A) • B := by
         intro A B r
-        simp only [smul_eq_mul, Complex.real_smul]
+        simp
         ring
       exact h ..
   -- Check integrability to justify the last use of `integral_sub`

--- a/Carleson/ForestOperator/QuantativeEstimate.lean
+++ b/Carleson/ForestOperator/QuantativeEstimate.lean
@@ -33,7 +33,7 @@ lemma local_dens1_tree_bound_exists (hu : u ∈ t) (hL : L ∈ 𝓛 (t u))
       refine measure_mono fun x ⟨⟨mxL, mxG⟩, mxU⟩ ↦ ⟨⟨by apply lip ▸ mxL, mxG⟩, ?_⟩
       rw [mem_iUnion₂] at mxU; obtain ⟨q, mq, hq⟩ := mxU; rw [smul_snd, mem_preimage]
       have plq := lip ▸ le_of_mem_𝓛 hL mq (not_disjoint_iff.mpr ⟨x, E_subset_𝓘 hq, mxL⟩)
-      simp_rw [mem_ball']
+      apply (@mem_ball' ..).mpr
       calc
         _ ≤ dist_(p) (𝒬 p) (𝒬 u) + dist_(p) (𝒬 u) (𝒬 q) + dist_(p) (𝒬 q) (Q x) :=
           dist_triangle4 ..
@@ -118,7 +118,7 @@ lemma local_dens1_tree_bound (hu : u ∈ t) (hL : L ∈ 𝓛 (t u)) :
           refine le_of_mem_of_mem ?_ mxp' (E_subset_𝓘 hq)
           change s (𝓘 p') ≤ 𝔰 q; rw [ip']; suffices s L < 𝔰 q by lia
           exact hp₂ q mq (not_disjoint_iff.mpr ⟨x, mxL, hq⟩)
-        simp_rw [mem_ball']
+        apply (@mem_ball' ..).mpr
         calc
           _ ≤ dist_(p') (𝒬 p') (𝒬 u) + dist_(p') (𝒬 u) (𝒬 q) + dist_(p') (𝒬 q) (Q x) :=
             dist_triangle4 ..
@@ -302,7 +302,9 @@ private lemma eLpNorm_approxOnCube_two_le {C : Set (Grid X)}
           (J : Set X).indicator (fun _ ↦ ENNReal.ofReal (⨍ y in J, ‖f y‖)) x) ^ 2 := by
       congr with x
       congr with J
-      by_cases hx : x ∈ (J : Set X) <;> simp [hx]
+      by_cases hx : x ∈ (J : Set X)
+      · rw [indicator_of_mem hx, indicator_of_mem hx]
+      · rw [indicator_of_notMem hx, indicator_of_notMem hx, ENNReal.ofReal_zero]
     _ = ∫⁻ x, ∑ J ∈ Finset.univ.filter (· ∈ C),
           (J : Set X).indicator (fun _ ↦ (ENNReal.ofReal (⨍ y in J, ‖f y‖)) ^ 2) x := by
       congr with x
@@ -335,7 +337,8 @@ private lemma eLpNorm_approxOnCube_two_le {C : Set (Grid X)}
         div_eq_mul_inv, mul_pow, div_eq_mul_inv, mul_assoc]
       simp_rw [ofReal_norm_eq_enorm]
       by_cases hJ : volume (J : Set X) = 0
-      · simp [setLIntegral_measure_zero _ _ hJ]
+      · have h0 : ∫⁻ x in (J : Set X), ‖f x‖ₑ = 0 := setLIntegral_measure_zero _ _ hJ
+        rw [h0, zero_pow two_pos.ne', zero_mul, zero_mul]
       congr
       rw [sq, mul_assoc, ENNReal.inv_mul_cancel hJ volume_coeGrid_lt_top.ne, mul_one]
     _ = ∑ J ∈ Finset.univ.filter (· ∈ C), (∫⁻ y in J ∩ s, ‖f y‖ₑ * 1) ^ 2 / volume (J : Set X) := by
@@ -370,7 +373,8 @@ private lemma eLpNorm_approxOnCube_two_le {C : Set (Grid X)}
     _ ≤ _ := by
       rw [← setLIntegral_univ]
       have h : (GridStructure.coeGrid · ∩ s) ≤ GridStructure.coeGrid := fun _ ↦ inter_subset_left
-      have hC : C = (Finset.univ.filter (· ∈ C) : Set (Grid X)) := by simp
+      have hC : C = (Finset.univ.filter (· ∈ C) : Set (Grid X)) := by
+        rw [Finset.coe_filter_univ]; rfl
       rw [← lintegral_biUnion_finset (hC ▸ disj_C.mono h) (fun _ _ ↦ coeGrid_measurable.inter hs)]
       exact mul_right_mono <| lintegral_mono_set (subset_univ _)
 
@@ -398,7 +402,11 @@ private lemma density_tree_bound_aux (hf : BoundedCompactSupport f)
       · rw [indicator_of_mem hx]
       suffices carlesonSum (t u) f x = 0 by simp [hx, this]
       refine Finset.sum_eq_zero (fun p hp ↦ indicator_of_notMem (fun hxp ↦ ?_) _)
-      exact hx ⟨E p, ⟨p, by simp [Finset.mem_filter.mp hp]⟩, hxp⟩
+      apply hx
+      refine ⟨E p, ⟨p, ?_⟩, hxp⟩
+      rw [filter_mem_univ_eq_toFinset ((fun x ↦ t.𝔗 x) u)] at hp
+      have : Nonempty (p ∈ t.𝔗 u) := ⟨mem_toFinset.mp hp⟩
+      exact Set.iUnion_const (E p)
     _ ≤ _ := tree_projection_estimate hf hgℰ hu
     _ ≤ C7_2_1 a * (c * eLpNorm f 2 volume) *
         (2 ^ (((𝕔 / 2 : ℕ) + 1) * (a : ℝ) ^ 3) * dens₁ (t u) ^ (2 : ℝ)⁻¹ * eLpNorm g 2 volume) := by

--- a/Carleson/ForestOperator/QuantativeEstimate.lean
+++ b/Carleson/ForestOperator/QuantativeEstimate.lean
@@ -87,7 +87,7 @@ lemma local_dens1_tree_bound (hu : u ∈ t) (hL : L ∈ 𝓛 (t u)) :
     volume (L ∩ G ∩ ⋃ p ∈ t u, E p) ≤ C7_3_2 a * dens₁ (t u) * volume (L : Set X) := by
   by_cases hq : (L : Set X) ∩ ⋃ p ∈ t u, E p = ∅
   · rw [inter_comm (L : Set X), inter_assoc, hq, inter_empty, measure_empty]; exact zero_le _
-  rw [← disjoint_iff_inter_eq_empty, disjoint_iUnion₂_right] at hq; push_neg at hq
+  rw [← disjoint_iff_inter_eq_empty, disjoint_iUnion₂_right] at hq; push Not at hq
   by_cases! hp₂ : ∃ p ∈ t u, ¬Disjoint (L : Set X) (E p) ∧ 𝔰 p ≤ s L
   · exact local_dens1_tree_bound_exists hu hL hp₂
   obtain ⟨p, mp, hp⟩ := hq; have sLp := hp₂ p mp hp
@@ -101,9 +101,9 @@ lemma local_dens1_tree_bound (hu : u ∈ t) (hL : L ∈ 𝓛 (t u)) :
       by_contra h
       simp_rw [𝓛, mem_setOf, maximal_iff] at hL
       exact lL'.ne (hL.2 h lL'.le)
-    rw [𝓛₀, mem_setOf, not_or, not_and_or] at L'nm; push_neg at L'nm
+    rw [𝓛₀, mem_setOf, not_or, not_and_or] at L'nm; push Not at L'nm
     have nfa : ¬∀ p ∈ t u, ¬L' ≤ 𝓘 p := by
-      push_neg; refine ⟨p, mp, Grid.le_dyadic ?_ lL'.le lip.le⟩; change s L' ≤ 𝔰 p; lia
+      push Not; refine ⟨p, mp, Grid.le_dyadic ?_ lL'.le lip.le⟩; change s L' ≤ 𝔰 p; lia
     simp_rw [nfa, false_or] at L'nm; exact L'nm.2
   suffices ∃ p' ∈ lowerCubes (t u),
       𝓘 p' = L' ∧ dist_(p') (𝒬 p') (𝒬 u) < 4 ∧ smul 9 p'' ≤ smul 9 p' by
@@ -220,7 +220,7 @@ lemma local_dens2_tree_bound (hu : u ∈ t) (hJ : J ∈ 𝓙 (t u)) :
   have ⟨J', hJJ', hsJ'⟩ := J.exists_scale_succ (J.scale_lt_scale_topCube J_top)
   have : J' ∉ 𝓙₀ (t u) := fun h ↦ succ_ne_self (s J) <| hJ.eq_of_le h hJJ' ▸ hsJ'.symm
   rw [𝓙₀, mem_setOf_eq] at this
-  push_neg at this
+  push Not at this
   obtain ⟨p, hpu, hp⟩ := this.2
   have d0 := realD_pos a
   have volume_le : volume (ball (c J') (204 * D ^ (s J' + 1))) ≤
@@ -406,7 +406,7 @@ private lemma density_tree_bound_aux (hf : BoundedCompactSupport f)
       have hgℰ' : ∀ x ∉ G ∩ ℰ, ℰ.indicator g x = 0 := by
         intro x hx
         rw [mem_inter_iff] at hx
-        push_neg at hx
+        push Not at hx
         by_cases xG : x ∈ G
         · apply indicator_of_notMem (hx xG)
         · have : g x = 0 := by rw [← notMem_support]; exact xG ∘ (h2g ·)

--- a/Carleson/ForestOperator/RemainingTiles.lean
+++ b/Carleson/ForestOperator/RemainingTiles.lean
@@ -810,6 +810,7 @@ lemma cntp_approxOnCube_eq (hu₁ : u₁ ∈ t) :
 Has value `2 ^ (232 * a ^ 3 + 21 * a + 5- 25/(101a) * Z n κ)` in the blueprint. -/
 irreducible_def C7_4_6 (a n : ℕ) : ℝ≥0 := C7_2_1 a * C7_6_2 a n
 
+set_option backward.isDefEq.respectTransparency false in
 /-- Lemma 7.4.6 -/
 lemma correlation_near_tree_parts (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu : u₁ ≠ u₂) (h2u : 𝓘 u₁ ≤ 𝓘 u₂)
     (hf₁ : BoundedCompactSupport f₁) (hf₂ : BoundedCompactSupport f₂) :
@@ -821,7 +822,7 @@ lemma correlation_near_tree_parts (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu 
   calc
     _ = ‖∫ x, conj (adjointCarlesonSum (t u₁) f₁ x) *
         adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f₂ x‖ₑ := by
-      erw [← RCLike.enorm_conj, ← integral_conj]
+      rw [← RCLike.enorm_conj, ← integral_conj]
       congr! 3 with x
       rw [map_mul, RingHomCompTriple.comp_apply, RingHom.id_apply]
     _ = ‖∫ x, conj (U.indicator (adjointCarlesonSum (t u₁) (U.indicator f₁)) x) *

--- a/Carleson/ForestOperator/RemainingTiles.lean
+++ b/Carleson/ForestOperator/RemainingTiles.lean
@@ -113,7 +113,7 @@ lemma thin_scale_impact_prelims (hu₁ : u₁ ∈ t) (hJ : J ∈ 𝓙₆ t u₁)
   have qlt : 𝓘 q < 𝓘 u₁ := lt_of_le_of_ne (t.smul_four_le hu₁ mq).1 (t.𝓘_ne_𝓘 hu₁ mq)
   have u₁nm : 𝓘 u₁ ∉ 𝓙₆ t u₁ := by
     simp_rw [𝓙₆, mem_inter_iff, mem_Iic, le_rfl, and_true, 𝓙, mem_setOf, Maximal, not_and_or]; left
-    rw [𝓙₀, mem_setOf]; push_neg; rw [Grid.lt_def] at qlt
+    rw [𝓙₀, mem_setOf]; push Not; rw [Grid.lt_def] at qlt
     refine ⟨(scale_mem_Icc.1.trans_lt qlt.2).ne',
       ⟨q, mq, qlt.1.trans <| Grid_subset_ball.trans <| ball_subset_ball ?_⟩⟩
     change 4 * (D : ℝ) ^ (𝔰 u₁) ≤ 100 * D ^ (𝔰 u₁ + 1); gcongr
@@ -122,8 +122,8 @@ lemma thin_scale_impact_prelims (hu₁ : u₁ ∈ t) (hJ : J ∈ 𝓙₆ t u₁)
   rw [Grid.lt_def] at Jlt; obtain ⟨J', lJ', sJ'⟩ := Grid.exists_scale_succ Jlt.2
   replace lJ' : J < J' := Grid.lt_def.mpr ⟨lJ'.1, by lia⟩
   have J'nm : J' ∉ 𝓙₀ (t u₁) := by
-    by_contra hh; apply absurd hJ.1.2; push_neg; use J', hh, lJ'.le, not_le_of_gt lJ'
-  rw [𝓙₀, mem_setOf] at J'nm; push_neg at J'nm; obtain ⟨p', mp', sp'⟩ := J'nm.2
+    by_contra hh; apply absurd hJ.1.2; push Not; use J', hh, lJ'.le, not_le_of_gt lJ'
+  rw [𝓙₀, mem_setOf] at J'nm; push Not at J'nm; obtain ⟨p', mp', sp'⟩ := J'nm.2
   exact ⟨b1, ⟨J', lJ', sJ', ⟨p', mp', sp'⟩⟩⟩
 
 /-- The key relation of Lemma 7.6.3, which will eventually be shown to lead to a contradiction. -/

--- a/Carleson/ForestOperator/RemainingTiles.lean
+++ b/Carleson/ForestOperator/RemainingTiles.lean
@@ -243,7 +243,7 @@ lemma square_function_count (hJ : J ∈ 𝓙₆ t u₁) {s' : ℤ} :
   · suffices ({I : Grid X | s I = s J - s' ∧ Disjoint (I : Set X) (𝓘 u₁) ∧
         ¬Disjoint (J : Set X) (ball (c I) (8 * D ^ s I)) } : Finset (Grid X)) = ∅ by
       rw [this]
-      simp
+      simp only [Finset.sum_empty, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, laverage_zero, zero_le]
     simp only [Finset.filter_eq_empty_iff, Finset.mem_univ, not_and, Decidable.not_not,
       true_implies]
     intros I hI
@@ -543,7 +543,9 @@ lemma btp_integral_bound :
       refine mul_le_mul_right (lintegral_mono fun y ↦ ?_) _
       by_cases my : y ∈ ball (c I) (8 * D ^ s I)
       · refine mul_le_mul_right ?_ _; rw [MB_def]
-        have : (3, 0, I) ∈ 𝓑 := by simp [𝓑]
+        have : (3, 0, I) ∈ 𝓑 := by
+          simp only [𝓑, Set.mem_prod, mem_Iic, Set.mem_univ, and_true]
+          omega
         refine le_of_eq_of_le ?_ (le_biSup _ this)
         have : y ∈ ball (c I) (2 ^ 3 * (D : ℝ) ^ s I) := by rwa [show (2 : ℝ) ^ 3 = 8 by norm_num]
         simp_rw [c𝓑, r𝓑, Nat.cast_zero, add_zero, indicator_of_mem this, enorm_eq_nnnorm]
@@ -819,7 +821,11 @@ lemma correlation_near_tree_parts (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu 
   calc
     _ = ‖∫ x, conj (adjointCarlesonSum (t u₁) f₁ x) *
         adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f₂ x‖ₑ := by
-      rw [← RCLike.enorm_conj, ← integral_conj]; congr! 3 with x
+      rw [
+        ← RCLike.enorm_conj,
+        show (starRingEnd ℂ) (∫ (x : X), adjointCarlesonSum (t u₁) f₁ x * (starRingEnd ℂ) (adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f₂ x)) = ∫ (x : X), (starRingEnd ℂ) (adjointCarlesonSum (t u₁) f₁ x * (starRingEnd ℂ) (adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f₂ x)) from integral_conj.symm
+      ]
+      congr! 3 with x
       rw [map_mul, RingHomCompTriple.comp_apply, RingHom.id_apply]
     _ = ‖∫ x, conj (U.indicator (adjointCarlesonSum (t u₁) (U.indicator f₁)) x) *
         adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f₂ x‖ₑ := by

--- a/Carleson/ForestOperator/RemainingTiles.lean
+++ b/Carleson/ForestOperator/RemainingTiles.lean
@@ -821,10 +821,7 @@ lemma correlation_near_tree_parts (hu₁ : u₁ ∈ t) (hu₂ : u₂ ∈ t) (hu 
   calc
     _ = ‖∫ x, conj (adjointCarlesonSum (t u₁) f₁ x) *
         adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f₂ x‖ₑ := by
-      rw [
-        ← RCLike.enorm_conj,
-        show (starRingEnd ℂ) (∫ (x : X), adjointCarlesonSum (t u₁) f₁ x * (starRingEnd ℂ) (adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f₂ x)) = ∫ (x : X), (starRingEnd ℂ) (adjointCarlesonSum (t u₁) f₁ x * (starRingEnd ℂ) (adjointCarlesonSum (t u₂ \ 𝔖₀ t u₁ u₂) f₂ x)) from integral_conj.symm
-      ]
+      erw [← RCLike.enorm_conj, ← integral_conj]
       congr! 3 with x
       rw [map_mul, RingHomCompTriple.comp_apply, RingHom.id_apply]
     _ = ‖∫ x, conj (U.indicator (adjointCarlesonSum (t u₁) (U.indicator f₁)) x) *

--- a/Carleson/HolderVanDerCorput.lean
+++ b/Carleson/HolderVanDerCorput.lean
@@ -179,7 +179,10 @@ lemma dist_holderApprox_le {z : X} {R t : ℝ} (hR : 0 < R) {C : ℝ≥0} (ht : 
     apply (closure_mono hφ).trans (closure_ball_subset_closedBall.trans ?_)
     exact closedBall_subset_ball (by linarith)
   have : (∫ y, cutoff R t x y * φ x) / (∫ y, (cutoff R t x y : ℂ)) = φ x := by
-    rw [integral_mul_const, mul_div_cancel_left₀]
+    rw [
+      show ∫ y, (cutoff R t x y : ℂ) * φ x = (∫ y, (cutoff R t x y : ℂ)) * φ x from integral_mul_const (φ x) _,
+      mul_div_cancel_left₀
+    ]
     simpa only [ne_eq, ofReal_eq_zero, integral_complex_ofReal] using (integral_cutoff_pos hR ht).ne'
   rw [dist_eq_norm, ← this, holderApprox, integral_complex_ofReal, ← sub_div,
     ← integral_sub]; rotate_left

--- a/Carleson/HolderVanDerCorput.lean
+++ b/Carleson/HolderVanDerCorput.lean
@@ -539,7 +539,7 @@ theorem holder_van_der_corput {z : X} {R : ℝ} {φ : X → ℂ}
   Lipschitz and the cancellativity assumption for the integral against Lipschitz functions. -/
   have : (ENNReal.ofReal t) ^ (-1 - a : ℝ) * (1 + edist_{z, R} f g) ^ (- τ) ≤
       (1 + edist_{z, R} f g) ^ (- τ ^ 2 / (2 + a)) := by
-    simp only [defaultA, coe_nndist, defaultτ, t]
+    simp only [coe_nndist, defaultτ, t]
     rw [← ENNReal.ofReal_rpow_of_pos (by positivity),
       ENNReal.ofReal_add zero_le_one (by positivity), ← edist_dist, ENNReal.ofReal_one]
     rw [← ENNReal.rpow_mul, ← ENNReal.rpow_add]; rotate_left
@@ -583,7 +583,7 @@ theorem holder_van_der_corput {z : X} {R : ℝ} {φ : X → ℂ}
     apply this.trans_eq
     rw [show - τ ^ 2 / (2 + a) = (-τ / (2 + a)) * τ by ring, ENNReal.rpow_mul]
     congr 1
-    simp only [defaultA, coe_nndist, defaultτ, t]
+    simp only [coe_nndist, defaultτ, t]
     rw [← ENNReal.ofReal_rpow_of_pos (by positivity),
       ENNReal.ofReal_add zero_le_one (by positivity), ← edist_dist, ENNReal.ofReal_one]
     congr

--- a/Carleson/MetricCarleson/Basic.lean
+++ b/Carleson/MetricCarleson/Basic.lean
@@ -642,7 +642,7 @@ lemma tendsto_carlesonOperatorIntegrand_of_dominated_convergence
   · apply h_bound.mp
     apply Eventually.of_forall
     intro n hn
-    simp only [defaultA, Complex.norm_mul, norm_exp_I_mul_ofReal, mul_one, norm_real,
+    simp only [Complex.norm_mul, norm_exp_I_mul_ofReal, mul_one, norm_real,
       Real.norm_eq_abs]
     apply ae_restrict_le
     apply hn.mp

--- a/Carleson/MetricCarleson/Main.lean
+++ b/Carleson/MetricCarleson/Main.lean
@@ -44,7 +44,9 @@ lemma carlesonOperator_eq_biSup_Θ'_J102 {x : X} (mf : Measurable f) (nf : (‖f
           carlesonOperatorIntegrand K θ' q₁ q₂ f x)‖ₑ := by rw [add_sub_cancel]
       _ ≤ ‖carlesonOperatorIntegrand K θ' q₁ q₂ f x‖ₑ +
           edist (carlesonOperatorIntegrand K θ' q₁ q₂ f x)
-          (carlesonOperatorIntegrand K θ R₁ R₂ f x) := by rw [edist_comm]; exact enorm_add_le _ _
+          (carlesonOperatorIntegrand K θ R₁ R₂ f x) := by
+          rw [edist_comm, edist_eq_enorm_sub]
+          exact enorm_add_le _ _
       _ ≤ _ := by
         gcongr
         · calc

--- a/Carleson/Operators.lean
+++ b/Carleson/Operators.lean
@@ -101,7 +101,7 @@ theorem BoundedCompactSupport.bddAbove_norm_carlesonOn
     have : ∃ y, Ks (𝔰 p) x y * f y * cexp (I * (Q x y - Q x x)) ≠ 0 := by
       by_contra! hc
       apply hx
-      simp [hc]
+      simp_rw [hc, integral_zero]
     obtain ⟨y, hy⟩ := this
     simp only [ne_eq, mul_eq_zero, exp_ne_zero, or_false, not_or] at hy
     apply le_trans <| dist_triangle _ y _
@@ -169,8 +169,9 @@ lemma carlesonSum_inter_add_inter_compl {f : X → ℂ} {x : X} (A B : Set (𝔓
   simp only [carlesonSum]
   conv_rhs => rw [← Finset.sum_filter_add_sum_filter_not _ (fun p ↦ p ∈ B)]
   congr 2
-  · ext; simp
-  · ext; simp
+  · ext; simp only [Finset.mem_filter, Finset.mem_univ, true_and, Set.mem_inter_iff]
+  · ext; simp only [Finset.mem_filter, Finset.mem_univ, true_and, Set.mem_inter_iff,
+      Set.mem_compl_iff]
 
 lemma sum_carlesonSum_of_pairwiseDisjoint {ι : Type*} {f : X → ℂ} {x : X} {A : ι → Set (𝔓 X)}
     {s : Finset ι} (hs : (s : Set ι).PairwiseDisjoint A) :
@@ -179,18 +180,19 @@ lemma sum_carlesonSum_of_pairwiseDisjoint {ι : Type*} {f : X → ℂ} {x : X} {
   simp only [carlesonSum]
   rw [← Finset.sum_biUnion]
   · congr with p
-    simp
+    simp only [Finset.mem_biUnion, Finset.mem_filter, Finset.mem_univ, true_and,
+      Set.mem_iUnion₂, exists_prop]
   · convert hs
     refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
     · intro i hi j hj hij
       convert Finset.disjoint_coe.2 (h hi hj hij)
-      · ext; simp
-      · ext; simp
+      · ext; simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_coe]
+      · ext; simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_coe]
     · intro i hi j hj hij
       apply Finset.disjoint_coe.1
       convert h hi hj hij
-      · ext; simp
-      · ext; simp
+      · ext; simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_coe]
+      · ext; simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_coe]
 
 end Carleson
 
@@ -342,7 +344,7 @@ lemma adjointCarleson_adjoint
         nth_rw 2 [mul_assoc, mul_comm]
         gcongr
         apply mul_le_mul (norm_indicator_one_le ..) norm_MKD_le_norm_Ks (by simp) (by simp) |>.trans
-        simp [hM₀ x y h]
+        linarith [hM₀ x y h]
       · suffices hz : H x y = 0 by rw [hz]; simp only [norm_zero, ge_iff_le]; positivity
         unfold H; simp [image_eq_zero_of_notMem_tsupport h]
     have : Integrable (fun z : X × X ↦ M₀ * ‖g z.1‖ * ‖f z.2‖) :=
@@ -359,17 +361,28 @@ lemma adjointCarleson_adjoint
       exact fun z ↦ (hHleH₀ z.1 z.2).trans <| Real.le_norm_self _
   calc
     _ = ∫ x, conj (g x) * ∫ y, (E p).indicator 1 x * MKD (𝔰 p) x y * f y := by
-      conv =>
-        enter [1, 2, x, 2]; unfold carlesonOn
-        rw [indicator_eq_indicator_one_mul, ← integral_const_mul]
-        enter [2, y]; rw [← mul_assoc]
-    _ = ∫ x, ∫ y, H x y := by unfold H; simp_rw [← integral_const_mul, mul_assoc]
+      congr 1; ext x; congr 1
+      simp only [carlesonOn]
+      rw [indicator_eq_indicator_one_mul, ← smul_eq_mul, ← integral_smul]
+      congr 1; ext y; unfold MKD; simp [smul_eq_mul]; ring
+    _ = ∫ x, ∫ y, H x y := by
+      unfold H; congr 1; ext x
+      calc conj (g x) * ∫ y, (E p).indicator 1 x * MKD (𝔰 p) x y * f y
+          = ∫ y, conj (g x) * ((E p).indicator 1 x * MKD (𝔰 p) x y * f y) :=
+            (integral_const_mul _ _).symm
+        _ = ∫ y, conj (g x) * (E p).indicator 1 x * MKD (𝔰 p) x y * f y := by
+            congr 1; ext y; ring
     _ = ∫ y, ∫ x, H x y := integral_integral_swap hH
     _ = ∫ y, (∫ x, conj (g x) * (E p).indicator 1 x * MKD (𝔰 p) x y) * f y := by
-      simp_rw [H, integral_mul_const]
+      simp_rw [H]; congr 1; ext y
+      exact integral_mul_const _ _
     _ = ∫ y, conj (∫ x, g x * (E p).indicator 1 x * conj (MKD (𝔰 p) x y)) * f y := by
-      simp_rw [← integral_conj]; congrm (∫ _, (∫ _, ?_) * (f _))
-      rw [map_mul, conj_conj, map_mul, conj_indicator, map_one]
+      congr 1; ext y; congr 1
+      have h : ∀ x, conj (g x) * (E p).indicator 1 x * MKD (𝔰 p) x y =
+          conj (g x * (E p).indicator 1 x * conj (MKD (𝔰 p) x y)) :=
+        fun x => by rw [map_mul, conj_conj, map_mul, conj_indicator, map_one]
+      simp_rw [h]
+      exact integral_conj
     _ = _ := by
       congr! with y
       simp_rw [mul_comm (g _) _]

--- a/Carleson/Operators.lean
+++ b/Carleson/Operators.lean
@@ -362,8 +362,7 @@ lemma adjointCarleson_adjoint
   calc
     _ = ∫ x, conj (g x) * ∫ y, (E p).indicator 1 x * MKD (𝔰 p) x y * f y := by
       congr 1; ext x; congr 1
-      simp only [carlesonOn]
-      rw [indicator_eq_indicator_one_mul, ← smul_eq_mul, ← integral_smul]
+      rw [carlesonOn, indicator_eq_indicator_one_mul, ← smul_eq_mul, ← integral_smul]
       congr 1; ext y; unfold MKD; simp [smul_eq_mul]; ring
     _ = ∫ x, ∫ y, H x y := by
       unfold H; congr 1; ext x

--- a/Carleson/Psi.lean
+++ b/Carleson/Psi.lean
@@ -289,7 +289,10 @@ lemma support_ψS_subset_Icc {b c : ℤ} {x : ℝ}
 
 lemma finsum_ψ (hx : 0 < x) : ∑ᶠ s : ℤ, ψ D (D ^ (-s) * x) = 1 := by
   refine Eq.trans ?_ (sum_ψ hD hx)
-  apply Eq.trans <| finsum_eq_sum _ <| support_ψS hD hx ▸ Finset.finite_toSet (nonzeroS D x)
+  have hfin : HasFiniteSupport (fun s : ℤ ↦ ψ D (D ^ (-s) * x)) := by
+    have h := Finset.finite_toSet (nonzeroS D x)
+    rwa [← support_ψS hD hx] at h
+  apply Eq.trans <| finsum_eq_sum _ hfin
   congr
   ext
   rw [Finite.mem_toFinset, support_ψS hD hx, Finset.mem_coe]

--- a/Carleson/TileExistence.lean
+++ b/Carleson/TileExistence.lean
@@ -547,7 +547,7 @@ mutual
       let y := H.min {i | x ∈ I2 hk i} this
       have hy_i2 : x ∈ I2 hk y := H.min_mem {i|x ∈ I2 hk i} this
       have hy_is_min : ∀ y', x ∈ I2 hk y' → ¬ y' < y :=
-        fun y' hy' ↦ sorry -- was: H.not_lt_min {i | x ∈ I2 hk i} this hy'
+        fun y' hy' ↦ H.not_lt_min {i | x ∈ I2 hk i} hy'
       use y
       revert hy_i2 hy_is_min
       generalize y = y

--- a/Carleson/ToMathlib/HardyLittlewood.lean
+++ b/Carleson/ToMathlib/HardyLittlewood.lean
@@ -544,8 +544,8 @@ protected theorem MeasureTheory.AESublinearOn.maximalFunction
   · intro u hu
     filter_upwards [MB_ae_ne_top h𝓑 hR hu] with x hx
     simpa [MB, maximalFunction] using hx
-  · intro f c hf; rw [NNReal.smul_def]; exact hf.const_smul _
-  · intro f c hf; rw [NNReal.smul_def]; exact hf.const_smul _
+  · intro f c hf; exact hf.const_smul _
+  · intro f c hf; exact hf.const_smul _
   · intro i _
     refine AESublinearOn.const (T μ c r i) P (fun hf hg ↦ T.add_le i (hP hf))
       (fun f d hf ↦ T.smul i) |>.indicator _

--- a/Carleson/ToMathlib/LorentzType.lean
+++ b/Carleson/ToMathlib/LorentzType.lean
@@ -478,7 +478,7 @@ lemma HasRestrictedWeakType'.hasLorentzType [SigmaFinite ν]
 theorem RCLike.norm_I {K : Type u_1} [RCLike K] : ‖(RCLike.I : K)‖ = if RCLike.I ≠ (0 : K) then 1 else 0 := by
   split_ifs with h
   · apply RCLike.norm_I_of_ne_zero h
-  · push_neg at h
+  · push Not at h
     simpa
 
 /-

--- a/Carleson/ToMathlib/MeasureTheory/Function/LocallyIntegrable.lean
+++ b/Carleson/ToMathlib/MeasureTheory/Function/LocallyIntegrable.lean
@@ -23,10 +23,4 @@ theorem locallyIntegrable_congr'_enorm {f : X → ε} {g : X → ε'}
     LocallyIntegrable f μ ↔ LocallyIntegrable g μ :=
   ⟨fun h2f => h2f.congr'_enorm hg h, fun h2g => h2g.congr'_enorm hf <| Filter.EventuallyEq.symm h⟩
 
-theorem LocallyIntegrable.congr {f g : X → ε} (hf : LocallyIntegrable f μ) (h : f =ᵐ[μ] g) :
-  LocallyIntegrable g μ := fun x ↦ (hf x).congr h
-
-theorem locallyIntegrable_congr {f g : X → ε} (h : f =ᵐ[μ] g) : LocallyIntegrable f μ ↔ LocallyIntegrable g μ :=
-  ⟨fun hf => hf.congr h, fun hg => hg.congr h.symm⟩
-
 end MeasureTheory

--- a/Carleson/ToMathlib/MeasureTheory/Function/LorentzSeminorm/Basic.lean
+++ b/Carleson/ToMathlib/MeasureTheory/Function/LorentzSeminorm/Basic.lean
@@ -177,13 +177,7 @@ lemma eLorentzNorm_eq_eLpNorm {f : α → ε} (hf : AEStronglyMeasurable f μ) :
         · rw[Filter.eventually_iff_exists_mem]
           use {x | x ≠ 0}
           constructor
-          · refine mem_ae_iff.mpr ?_
-            erw [
-              show ({x : ℝ≥0 | x ≠ 0})ᶜ = {0} by simp,
-              NNReal.volume_val,
-              Set.image_singleton
-            ]
-            exact Real.volume_singleton
+          · simp [mem_ae_iff]
           · intro x hx
             rw [ENNReal.inv_lt_top, ENNReal.coe_pos]
             exact pos_of_ne_zero hx

--- a/Carleson/ToMathlib/MeasureTheory/Function/LorentzSeminorm/Basic.lean
+++ b/Carleson/ToMathlib/MeasureTheory/Function/LorentzSeminorm/Basic.lean
@@ -178,8 +178,12 @@ lemma eLorentzNorm_eq_eLpNorm {f : α → ε} (hf : AEStronglyMeasurable f μ) :
           use {x | x ≠ 0}
           constructor
           · refine mem_ae_iff.mpr ?_
-            rw [NNReal.volume_val]
-            simp
+            rw [
+              show ({x : ℝ≥0 | x ≠ 0})ᶜ = {0} by ext; simp,
+              NNReal.volume_val,
+              show Subtype.val '' ({0} : Set ℝ≥0) = _ from Set.image_singleton
+            ]
+            exact Real.volume_singleton
           · intro x hx
             rw[ENNReal.inv_lt_top, ENNReal.coe_pos]
             exact pos_of_ne_zero hx
@@ -311,7 +315,7 @@ lemma eLorentzNorm_eq_wnorm (hp : p ≠ 0) {f : α → ε} : eLorentzNorm f p �
       · apply ContinuousWithinAt.ennreal_mul continuous_id'.continuousWithinAt
           (continuousWithinAt_distribution _).ennrpow_const
         · rw [or_iff_not_imp_left]
-          push_neg
+          push Not
           intro h
           exfalso
           rw [h] at ha

--- a/Carleson/ToMathlib/MeasureTheory/Function/LorentzSeminorm/Basic.lean
+++ b/Carleson/ToMathlib/MeasureTheory/Function/LorentzSeminorm/Basic.lean
@@ -178,14 +178,14 @@ lemma eLorentzNorm_eq_eLpNorm {f : α → ε} (hf : AEStronglyMeasurable f μ) :
           use {x | x ≠ 0}
           constructor
           · refine mem_ae_iff.mpr ?_
-            rw [
-              show ({x : ℝ≥0 | x ≠ 0})ᶜ = {0} by ext; simp,
+            erw [
+              show ({x : ℝ≥0 | x ≠ 0})ᶜ = {0} by simp,
               NNReal.volume_val,
-              show Subtype.val '' ({0} : Set ℝ≥0) = _ from Set.image_singleton
+              Set.image_singleton
             ]
             exact Real.volume_singleton
           · intro x hx
-            rw[ENNReal.inv_lt_top, ENNReal.coe_pos]
+            rw [ENNReal.inv_lt_top, ENNReal.coe_pos]
             exact pos_of_ne_zero hx
         · simp
     _ = (ENNReal.ofReal p.toReal  * ∫⁻ t in Set.Ioi (0 : ℝ), distribution f (.ofReal t) μ *

--- a/Carleson/ToMathlib/MeasureTheory/Measure/NNReal.lean
+++ b/Carleson/ToMathlib/MeasureTheory/Measure/NNReal.lean
@@ -191,18 +191,17 @@ theorem NNReal.Ici_eq {a : ℝ≥0} :
 
 lemma NNReal.volume_Iio {b : ℝ≥0} : volume (Set.Iio b) = b := by
   rw [NNReal.volume_val]
-  simp only [val_eq_coe]
-  rw [toReal_Iio_eq_Ico, Real.volume_Ico]
-  simp
+  change volume (NNReal.toReal '' Set.Iio b) = b
+  simp only [image_coe_Iio, Real.volume_Ico, sub_zero, ofReal_coe_nnreal]
 
 lemma NNReal.volume_Ioi {b : ℝ≥0} : volume (Set.Ioi b) = ⊤ := by
   rw [NNReal.volume_val]
-  simp only [val_eq_coe]
-  rw [toReal_Ioi_eq_Ioi, Real.volume_Ioi]
+  change volume (NNReal.toReal '' Set.Ioi b) = ⊤
+  simp only [image_coe_Ioi, Real.volume_Ioi]
 
 lemma NNReal.volume_Ioo {a b : ℝ≥0} : volume (Set.Ioo a b) = b - a:= by
   rw [NNReal.volume_val]
-  simp only [val_eq_coe]
+  change volume (NNReal.toReal '' Set.Ioo a b) = b - a
   rw [toReal_Ioo_eq_Ioo, Real.volume_Ioo, ENNReal.ofReal_sub] <;> simp
 
 -- TODO: the proofs in the following lemmas feel quite repetitive

--- a/Carleson/ToMathlib/MeasureTheory/Measure/NNReal.lean
+++ b/Carleson/ToMathlib/MeasureTheory/Measure/NNReal.lean
@@ -5,7 +5,9 @@ import Carleson.ToMathlib.MeasureTheory.Integral.Lebesgue
 open MeasureTheory NNReal ENNReal Set
 
 noncomputable
-instance NNReal.MeasureSpace : MeasureSpace ℝ≥0 := ⟨Measure.Subtype.measureSpace.volume⟩
+instance NNReal.MeasureSpace : MeasureSpace ℝ≥0 where
+  toMeasurableSpace := NNReal.measurableSpace
+  volume := Measure.comap Subtype.val (volume : Measure ℝ)
 
 -- Upstreaming status:
 -- The results in this file are generally worth having, but the proofs can be golfed
@@ -16,22 +18,10 @@ lemma NNReal.volume_val {s : Set ℝ≥0} : volume s = volume (Subtype.val '' s)
 
 -- sanity check: this measure is what you expect
 example : volume (Ioo (3 : ℝ≥0) 5) = 2 := by
-  have : Subtype.val '' Ioo (3 : ℝ≥0) 5 = Ioo (3 : ℝ) 5 := by
-    ext x
-    constructor
-    · simp only [val_eq_coe, mem_image, mem_Ioo, Subtype.exists, coe_mk, exists_and_right,
-      exists_eq_right, forall_exists_index, and_imp]
-      intro hx1 hx2 hx3
-      exact ⟨hx2, hx3⟩
-    · intro hx
-      simp only [val_eq_coe, mem_image, mem_Ioo, Subtype.exists, coe_mk, exists_and_right,
-        exists_eq_right]
-      have : 0 ≤ x := by linarith [hx.1]
-      use this
-      rw [← Subtype.coe_lt_coe, ← Subtype.coe_lt_coe]
-      exact hx
-  rw [NNReal.volume_val, this]
-  simpa only [Real.volume_Ioo, ENNReal.ofReal_eq_ofNat] using by norm_num
+  rw [NNReal.volume_val]
+  change volume (NNReal.toReal '' Ioo 3 5) = 2
+  rw [NNReal.image_coe_Ioo, Real.volume_Ioo, ENNReal.ofReal_eq_ofNat]
+  norm_num
 
 -- integral over a function over NNReal equals the integral over the right set of real numbers
 

--- a/Carleson/ToMathlib/MeasureTheory/Measure/NNReal.lean
+++ b/Carleson/ToMathlib/MeasureTheory/Measure/NNReal.lean
@@ -5,8 +5,7 @@ import Carleson.ToMathlib.MeasureTheory.Integral.Lebesgue
 open MeasureTheory NNReal ENNReal Set
 
 noncomputable
-instance NNReal.MeasureSpace : MeasureSpace ℝ≥0 where
-  volume := Measure.comap Subtype.val (volume : Measure ℝ)
+instance NNReal.MeasureSpace : MeasureSpace ℝ≥0 := ⟨Measure.comap Subtype.val (volume : Measure ℝ)⟩
 
 -- Upstreaming status:
 -- The results in this file are generally worth having, but the proofs can be golfed

--- a/Carleson/ToMathlib/MeasureTheory/Measure/NNReal.lean
+++ b/Carleson/ToMathlib/MeasureTheory/Measure/NNReal.lean
@@ -17,9 +17,7 @@ lemma NNReal.volume_val {s : Set ℝ≥0} : volume s = volume (Subtype.val '' s)
 
 -- sanity check: this measure is what you expect
 example : volume (Ioo (3 : ℝ≥0) 5) = 2 := by
-  rw [NNReal.volume_val]
-  change volume (NNReal.toReal '' Ioo 3 5) = 2
-  rw [NNReal.image_coe_Ioo, Real.volume_Ioo, ENNReal.ofReal_eq_ofNat]
+  erw [volume_val, NNReal.image_coe_Ioo, Real.volume_Ioo, ofReal_eq_ofNat]
   norm_num
 
 -- integral over a function over NNReal equals the integral over the right set of real numbers
@@ -179,19 +177,14 @@ theorem NNReal.Ici_eq {a : ℝ≥0} :
     rwa [← Real.le_toNNReal_iff_coe_le hx2]
 
 lemma NNReal.volume_Iio {b : ℝ≥0} : volume (Set.Iio b) = b := by
-  rw [NNReal.volume_val]
-  change volume (NNReal.toReal '' Set.Iio b) = b
-  simp only [image_coe_Iio, Real.volume_Ico, sub_zero, ofReal_coe_nnreal]
+  erw [volume_val, image_coe_Iio b, Real.volume_Ico, sub_zero, ofReal_coe_nnreal]
 
 lemma NNReal.volume_Ioi {b : ℝ≥0} : volume (Set.Ioi b) = ⊤ := by
-  rw [NNReal.volume_val]
-  change volume (NNReal.toReal '' Set.Ioi b) = ⊤
-  simp only [image_coe_Ioi, Real.volume_Ioi]
+  erw [volume_val, image_coe_Ioi, Real.volume_Ioi]
 
 lemma NNReal.volume_Ioo {a b : ℝ≥0} : volume (Set.Ioo a b) = b - a:= by
-  rw [NNReal.volume_val]
-  change volume (NNReal.toReal '' Set.Ioo a b) = b - a
-  rw [toReal_Ioo_eq_Ioo, Real.volume_Ioo, ENNReal.ofReal_sub] <;> simp
+  erw [volume_val, toReal_Ioo_eq_Ioo, Real.volume_Ioo, ofReal_sub (hq := by simp)]
+  simp
 
 -- TODO: the proofs in the following lemmas feel quite repetitive
 -- extract helper lemma to re-use some of the argument!

--- a/Carleson/ToMathlib/MeasureTheory/Measure/NNReal.lean
+++ b/Carleson/ToMathlib/MeasureTheory/Measure/NNReal.lean
@@ -6,7 +6,6 @@ open MeasureTheory NNReal ENNReal Set
 
 noncomputable
 instance NNReal.MeasureSpace : MeasureSpace ℝ≥0 where
-  toMeasurableSpace := NNReal.measurableSpace
   volume := Measure.comap Subtype.val (volume : Measure ℝ)
 
 -- Upstreaming status:

--- a/Carleson/ToMathlib/MinLayer.lean
+++ b/Carleson/ToMathlib/MinLayer.lean
@@ -97,9 +97,9 @@ lemma exists_le_in_minLayer_of_le (ha : a ∈ A.minLayer n) (hm : m ≤ n) :
     rw [minLayer, mem_setOf, minimal_iff] at ha nma
     have al : a ∈ A \ ⋃ (l < n), A.minLayer l := by
       have : a ∈ A \ ⋃ (k < n + 1), A.minLayer k := ha.1
-      push (_ ∈ _) at this ⊢; push_neg at this ⊢
+      push (_ ∈ _) at this ⊢; push Not at this ⊢
       exact ⟨this.1, fun l hl h ↦ this.2 l (Nat.lt_succ_of_lt hl) h⟩
-    simp_rw [al, true_and] at nma; push_neg at nma; obtain ⟨a', ha', la⟩ := nma
+    simp_rw [al, true_and] at nma; push Not at nma; obtain ⟨a', ha', la⟩ := nma
     have ma' : a' ∈ A.minLayer n := by
       by_contra h
       have a'l : a' ∈ A \ ⋃ (l < n + 1), A.minLayer l := by
@@ -189,7 +189,7 @@ lemma exists_le_in_layersAbove_of_le [Finite α] (ha : a ∈ A.layersAbove n) (h
   classical
   have ma : a ∈ A \ ⋃ (l' < n), A.minLayer l' := by
     simp only [layersAbove] at ha ⊢
-    push _ ∈ _ at ha ⊢; push_neg at ha ⊢
+    push _ ∈ _ at ha ⊢; push Not at ha ⊢
     exact ⟨ha.1, fun l' hl' h ↦ ha.2 l' hl'.le h⟩
   have := Fintype.ofFinite α
   let C : Finset α :=
@@ -201,7 +201,7 @@ lemma exists_le_in_layersAbove_of_le [Finite α] (ha : a ∈ A.layersAbove n) (h
   conv at mina' => enter [x]; rw [and_imp]
   have ma'₁ : a' ∈ A.minLayer n := by
     rw [minLayer, mem_setOf, minimal_iff]
-    push _ ∈ _; push_neg
+    push _ ∈ _; push Not
     exact ⟨ma'.1, fun y hy ly ↦ le_antisymm (mina' hy (ly.trans ma'.2) ly) ly⟩
   obtain ⟨c, mc, lc⟩ := exists_le_in_minLayer_of_le ma'₁ hm
   use c, mc, lc.trans ma'.2

--- a/Carleson/ToMathlib/RealInterpolation/Main.lean
+++ b/Carleson/ToMathlib/RealInterpolation/Main.lean
@@ -244,7 +244,7 @@ lemma toReal {T : (α → ε₁) → α' → ℝ≥0∞}
     simp only [ne_eq, hfx, not_false_eq_true, enorm_toReal, hgx] at hx ⊢
     exact enorm_toReal_le.trans hx
   · filter_upwards [h.2 f c hf, hP f hf] with x hx hfx
-    simp only [hx, Pi.smul_apply, toReal_smul]
+    rw [hx, Pi.smul_apply, toReal_smul]
     rfl
 
 end AESublinearOn

--- a/Carleson/ToMathlib/RealInterpolation/Main.lean
+++ b/Carleson/ToMathlib/RealInterpolation/Main.lean
@@ -244,7 +244,8 @@ lemma toReal {T : (α → ε₁) → α' → ℝ≥0∞}
     simp only [ne_eq, hfx, not_false_eq_true, enorm_toReal, hgx] at hx ⊢
     exact enorm_toReal_le.trans hx
   · filter_upwards [h.2 f c hf, hP f hf] with x hx hfx
-    simp_rw [hx, Pi.smul_apply, toReal_smul]
+    simp only [hx, Pi.smul_apply, toReal_smul]
+    rfl
 
 end AESublinearOn
 

--- a/Carleson/ToMathlib/RealInterpolation/Main.lean
+++ b/Carleson/ToMathlib/RealInterpolation/Main.lean
@@ -110,8 +110,8 @@ lemma biSup {ι : Type*} {𝓑 : Set ι} (h𝓑 : 𝓑.Countable) {T : ι → (�
   --   tauto
   intro f g hf hg
   simp_rw [AESubadditiveOn] at h
-  conv at hT' => enter [i]; rw [forall_swap]
-  rw [forall_swap] at hT'; rw [forall₂_swap] at h
+  conv at hT' => enter [i]; rw [forall_comm]
+  rw [forall_comm] at hT'; rw [forall₂_comm] at h
   simp_rw [imp.swap, ← imp_forall_iff] at h hT'
   specialize h f hf g hg
   simp_rw [enorm_eq_self] at h ⊢
@@ -170,8 +170,8 @@ lemma biSup {ι : Type*} {𝓑 : Set ι} (h𝓑 : 𝓑.Countable) {T : ι → (�
     rw [ne_eq, eq_top_iff] at hx ⊢
     exact fun h ↦ hx <| h.trans (le_biSup (fun i ↦ T i f x) hi)
   refine ⟨AESubadditiveOn.biSup h𝓑 hT h_add (fun i hi ↦ (h i hi).1), fun f c hf ↦ ?_⟩
-  conv at hT' => enter [i]; rw [forall_swap]
-  rw [forall_swap] at hT'; simp_rw [imp.swap, ← imp_forall_iff] at hT'
+  conv at hT' => enter [i]; rw [forall_comm]
+  rw [forall_comm] at hT'; simp_rw [imp.swap, ← imp_forall_iff] at hT'
   filter_upwards [(ae_ball_iff h𝓑).mpr (fun i hi ↦ (h i hi).2 f c hf),
     (ae_ball_iff h𝓑).mpr (hT' f hf), (ae_ball_iff h𝓑).mpr (hT' (c • f) (h_smul hf))] with x hx hT'fx hT'cfx
   simp_rw [Pi.smul_apply, ENNReal.smul_iSup]
@@ -241,7 +241,7 @@ lemma toReal {T : (α → ε₁) → α' → ℝ≥0∞}
     AESublinearOn (T · · |>.toReal) P A ν := by
   refine ⟨fun f g hf hg ↦ ?_, fun f c hf ↦ ?_⟩
   · filter_upwards [h.1 f g hf hg, hP f hf, hP g hg] with x hx hfx hgx
-    simp only [enorm_eq_self, ne_eq, hfx, not_false_eq_true, enorm_toReal, hgx] at hx ⊢
+    simp only [ne_eq, hfx, not_false_eq_true, enorm_toReal, hgx] at hx ⊢
     exact enorm_toReal_le.trans hx
   · filter_upwards [h.2 f c hf, hP f hf] with x hx hfx
     simp_rw [hx, Pi.smul_apply, toReal_smul]

--- a/Carleson/ToMathlib/RealInterpolation/Minkowski.lean
+++ b/Carleson/ToMathlib/RealInterpolation/Minkowski.lean
@@ -690,8 +690,7 @@ lemma estimate_trnc₁ {spf : ScaledPowerFunction} {j : Bool}
       cases j
       · unfold sel
         dsimp only
-        rw [hspf]
-        simp only [Bool.if_false_right, Bool.and_true, Bool.false_bne, decide_eq_true_eq]
+        simp only [hspf, Bool.if_false_right, Bool.and_true, Bool.false_bne, decide_eq_true_eq]
         split_ifs with is_ζ_pos
         · apply toReal_strict_mono
           · exact interp_exp_ne_top hq₀q₁ ht hq
@@ -701,8 +700,7 @@ lemma estimate_trnc₁ {spf : ScaledPowerFunction} {j : Bool}
             (le_of_not_gt is_ζ_pos)
       · unfold sel
         dsimp only
-        rw [hspf]
-        simp only [Bool.if_false_right, Bool.and_true, Bool.true_bne, Bool.not_eq_true',
+        simp only [hspf, Bool.if_false_right, Bool.and_true, Bool.true_bne, Bool.not_eq_true',
             decide_eq_false_iff_not]
         split_ifs with is_ζ_pos
         · apply toReal_strict_mono hq'

--- a/Carleson/ToMathlib/RealInterpolation/Misc.lean
+++ b/Carleson/ToMathlib/RealInterpolation/Misc.lean
@@ -886,7 +886,7 @@ lemma truncCompl_Lp_Lq_lower
   refine (rpow_lt_top_iff_of_pos this).mp ?_
   refine lt_of_le_of_lt (estimate_eLpNorm_truncCompl hp hpq hf.1 ht) ?_
   apply mul_lt_top
-  · push_neg at ht'
+  · push Not at ht'
     finiteness
   refine (rpow_lt_top_iff_of_pos ?_).mpr hf.2
   exact toReal_pos (hpq.1.trans_le hpq.2).ne' hp

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -475,8 +475,7 @@ theorem cotlar_control (ha : 4 ≤ a) {g : X → ℂ} (hg : BoundedFiniteSupport
     _ ≤ ‖czOperator K R g x - czOperator K R g x'‖ₑ + ‖czOperator K R g x'‖ₑ := by
       apply enorm_add_le
     _ = nndist (czOperator K R g x) (czOperator K R g x') + ‖czOperator K R ((ball x (R / 2))ᶜ.indicator g) x'‖ₑ := by
-      simp only [enorm_eq_nnnorm, ← nndist_eq_nnnorm]
-      rw [cut_out_ball hr hx]
+      rw [enorm_eq_nnnorm, ← nndist_eq_nnnorm, cut_out_ball hr hx]
     _ ≤ C10_1_2 a * globalMaximalFunction volume 1 g x + (‖czOperator K r ((ball x (R / 2))ᶜ.indicator g) x' - czOperator K R ((ball x (R / 2))ᶜ.indicator g) x'‖ₑ + ‖czOperator K r ((ball x (R / 2))ᶜ.indicator g) x'‖ₑ) := by
       gcongr
       · apply estimate_x_shift ha hg R_pos

--- a/Carleson/TwoSidedCarleson/NontangentialOperator.lean
+++ b/Carleson/TwoSidedCarleson/NontangentialOperator.lean
@@ -138,8 +138,8 @@ lemma estimate_10_1_3 (ha : 4 ≤ a) {g : X → ℂ} (hg : BoundedFiniteSupport 
       gcongr
       · rw [rpow_mul]
         apply rpow_le_rpow _ (by positivity)
-        · norm_cast
-          exact est_edist y hy
+        · apply (est_edist y hy).trans_eq
+          simp [rpow_add, rpow_natCast, pow_succ]
       · exact est_vol y hy
     rw [lintegral_const_mul'' _ hg.aemeasurable.restrict.enorm]
     trans (1 / (2 : ℝ≥0)) ^ ((i + 1) * (a : ℝ)⁻¹) * (C_K ↑a / volume (ball x (2 ^ (i + 1) * r))) *
@@ -474,7 +474,9 @@ theorem cotlar_control (ha : 4 ≤ a) {g : X → ℂ} (hg : BoundedFiniteSupport
       ring
     _ ≤ ‖czOperator K R g x - czOperator K R g x'‖ₑ + ‖czOperator K R g x'‖ₑ := by
       apply enorm_add_le
-    _ = nndist (czOperator K R g x) (czOperator K R g x') + ‖czOperator K R ((ball x (R / 2))ᶜ.indicator g) x'‖ₑ := by congr 2; exact cut_out_ball hr hx
+    _ = nndist (czOperator K R g x) (czOperator K R g x') + ‖czOperator K R ((ball x (R / 2))ᶜ.indicator g) x'‖ₑ := by
+      simp only [enorm_eq_nnnorm, ← nndist_eq_nnnorm]
+      rw [cut_out_ball hr hx]
     _ ≤ C10_1_2 a * globalMaximalFunction volume 1 g x + (‖czOperator K r ((ball x (R / 2))ᶜ.indicator g) x' - czOperator K R ((ball x (R / 2))ᶜ.indicator g) x'‖ₑ + ‖czOperator K r ((ball x (R / 2))ᶜ.indicator g) x'‖ₑ) := by
       gcongr
       · apply estimate_x_shift ha hg R_pos
@@ -750,9 +752,12 @@ theorem simple_nontangential_operator (ha : 4 ≤ a)
       (4 : ℝ≥0) • globalMaximalFunction volume 1 (czOperator K r g) by rfl]
   apply le_trans <| eLpNorm_add_le (by fun_prop) (by fun_prop) one_le_two
   apply le_trans <| add_le_add (eLpNorm_add_le (by fun_prop) (by fun_prop) one_le_two) (by rfl)
-  simp_rw [eLpNorm_const_smul' (f := globalMaximalFunction volume 1 g),
-      eLpNorm_const_smul' (f := globalMaximalFunction volume 1 (czOperator K r g)),
-      enorm_NNReal, add_assoc, ← add_mul]
+  rw [
+    show eLpNorm ((4 : ℝ≥0) • globalMaximalFunction volume 1 (czOperator K r g)) 2 volume = ‖(4 : ℝ≥0)‖ₑ * eLpNorm (globalMaximalFunction volume 1 (czOperator K r g)) 2 volume from eLpNorm_const_smul',
+    show eLpNorm (C10_1_5 a • globalMaximalFunction volume 1 g) 2 volume = ‖C10_1_5 a‖ₑ * eLpNorm (globalMaximalFunction volume 1 g) 2 volume from eLpNorm_const_smul',
+    show eLpNorm (C10_1_2 a • globalMaximalFunction volume 1 g) 2 volume = ‖C10_1_2 a‖ₑ * eLpNorm (globalMaximalFunction volume 1 g) 2 volume from eLpNorm_const_smul',
+    enorm_NNReal, enorm_NNReal, enorm_NNReal, add_assoc, ← add_mul
+  ]
   apply le_trans <| add_le_add
     (mul_le_mul_right (hst_gmf_czg.2.trans <| mul_le_mul_right (hT r hr g hg).2 _) _)
     (mul_le_mul_right hst_gmf_g.2 _)

--- a/Carleson/TwoSidedCarleson/RestrictedWeakType.lean
+++ b/Carleson/TwoSidedCarleson/RestrictedWeakType.lean
@@ -61,14 +61,12 @@ theorem two_sided_metric_carleson_hasLorentzType [na : NoAtoms (@volume X d.toMe
   · intro f g hf hg
     apply Filter.Eventually.of_forall
     intro x
-    simp only [enorm_eq_self]
     apply carlesonOperator_add_le_add_carlesonOperator
     · apply (hf.memLp _).locallyIntegrable <;> simp [hq.1.le]
     · apply (hg.memLp _).locallyIntegrable <;> simp [hq.1.le]
   · intro a f
     apply Filter.Eventually.of_forall
     intro x
-    simp only [enorm_eq_self]
     apply le_of_eq
     rw [carlesonOperator_const_smul']
     rfl

--- a/Carleson/TwoSidedCarleson/WeakCalderonZygmund.lean
+++ b/Carleson/TwoSidedCarleson/WeakCalderonZygmund.lean
@@ -1299,7 +1299,7 @@ private lemma integral_g (hf : BoundedFiniteSupport f) (hα : 0 < α) (hX : Gene
   by_cases! hj : czRadius hX j ≤ 0
   · simp [Metric.ball_eq_empty.mpr <| mul_nonpos_of_nonneg_of_nonpos three_pos.le hj]
   rw [integral_sub (integrableOn_g₀ hf hα hX j) (integrableOn_d hX j)]
-  simp only [d, setAverage_eq, integral_const, smul_smul, measureReal_restrict_apply_univ, mul_inv_cancel₀ (measureReal_ball_pos (czCenter hX j) (mul_pos three_pos hj)).ne', one_smul, sub_self]
+  simp [d, setAverage_eq, smul_smul, mul_inv_cancel₀ (measureReal_ball_pos (czCenter hX j) (mul_pos three_pos hj)).ne']
 
 private lemma lintegral_enorm_half_g (hf : BoundedFiniteSupport f) (hα : 0 < α)
     (hX : GeneralCase f (α' a α)) (j : ℕ) :

--- a/Carleson/TwoSidedCarleson/WeakCalderonZygmund.lean
+++ b/Carleson/TwoSidedCarleson/WeakCalderonZygmund.lean
@@ -1206,7 +1206,7 @@ private lemma lemma_10_2_7_bound (hx : x ∈ (Ω f (α' a α))ᶜ) (hX : General
   · simp [Metric.ball_eq_empty.mpr <| mul_nonpos_of_nonneg_of_nonpos three_pos.le hj]
   calc
     _ = ‖(∫ y in czBall3 hX j, K x y * g y) - ∫ y in czBall3 hX j, K x (czCenter hX j) * g y‖ₑ := by
-      rw [integral_const_mul, hg0, mul_zero, sub_zero]
+      rw [integral_const_mul_of_integrable (IntegrableOn.integrable g_int), hg0, mul_zero, sub_zero]
     _ = ‖∫ y in czBall3 hX j, (K x y - K x (czCenter hX j)) * g y‖ₑ := by
       simp_rw [sub_mul]
       rw [integral_sub ?_ (g_int.const_mul _)]
@@ -1299,9 +1299,7 @@ private lemma integral_g (hf : BoundedFiniteSupport f) (hα : 0 < α) (hX : Gene
   by_cases! hj : czRadius hX j ≤ 0
   · simp [Metric.ball_eq_empty.mpr <| mul_nonpos_of_nonneg_of_nonpos three_pos.le hj]
   rw [integral_sub (integrableOn_g₀ hf hα hX j) (integrableOn_d hX j)]
-  suffices (volume.real (czBall3 hX j) : ℂ) * ((volume.real (czBall3 hX j)) : ℂ)⁻¹ = 1 by
-    simp [d, this, setAverage_eq, ← mul_assoc]
-  exact_mod_cast mul_inv_cancel₀ (measureReal_ball_pos (czCenter hX j) (mul_pos three_pos hj)).ne'
+  simp only [d, setAverage_eq, integral_const, smul_smul, measureReal_restrict_apply_univ, mul_inv_cancel₀ (measureReal_ball_pos (czCenter hX j) (mul_pos three_pos hj)).ne', one_smul, sub_self]
 
 private lemma lintegral_enorm_half_g (hf : BoundedFiniteSupport f) (hα : 0 < α)
     (hX : GeneralCase f (α' a α)) (j : ℕ) :
@@ -1350,13 +1348,27 @@ private lemma 𝒥₂_bound (hf : BoundedFiniteSupport f) (hα : 0 < α) (hx : x
       exact subset.trans (fun y ↦ by simp [dist_comm y]; tauto)
     · exact (integrableOn_K_Icc hj).mono_set subset |>.mul_const _
   _ ≤ ‖_‖ₑ + ‖_‖ₑ := enorm_add_le _ _
+  _ = ‖2 * (2⁻¹ * ∫ y in czBall3 hX j, K x y * g r x hX j y)‖ₑ + ‖_‖ₑ := by
+    congr
+    ring
+  _ = ‖2 * ∫ y in czBall3 hX j, K x y * (2⁻¹ * g r x hX j y)‖ₑ + ‖_‖ₑ := by
+    congr
+    have h : ∀ y, K x y * (2⁻¹ * g r x hX j y) = 2⁻¹ * (K x y * g r x hX j y) := by
+      intro y
+      exact mul_left_comm ..
+    simp_rw [h]
+    exact (integral_const_mul ..).symm
   _ = ‖(2 : ℂ)‖ₑ * ‖∫ y in czBall3 hX j, K x y * (2⁻¹ * g r x hX j y)‖ₑ + ‖_‖ₑ := by
-    rw [← enorm_mul, ← integral_const_mul]; congr; ext; ring
+    rw [← enorm_mul]
   _ ≤ _ := by
     gcongr
     · simp [← ofReal_norm_eq_enorm]
     · apply lemma_10_2_7_bound hx hX j ((integrableOn_g r x hα hf hX j).const_mul 2⁻¹)
-      · rw [integral_const_mul, integral_g hf hα hX, mul_zero]
+      · have h :
+          ∫ (y : X) in czBall3 hX j, 2⁻¹ * g r x hX j y =
+          2⁻¹ * ∫ (y : X) in czBall3 hX j, g r x hX j y :=
+          integral_const_mul ..
+        simp_rw [h, integral_g hf hα hX, mul_zero]
       · apply lintegral_enorm_half_g hf hα hX
     · apply le_trans (enorm_integral_le_lintegral_enorm _)
       simp_rw [enorm_mul, lintegral_mul_const _ (measurable_K_right x).enorm, ← mul_comm ‖_‖ₑ]
@@ -1434,7 +1446,8 @@ private lemma tsum_𝒥₂ (hf : BoundedFiniteSupport f) (hα : 0 < α) (hx : x 
         _ = _ * ∑' (j : 𝒥₂ r x hX), _ := by rw [ENNReal.tsum_mul_left]
         _ ≤ _ * 2 ^ (a^3 + 10*a) := mul_le_mul_right (tsum_integral_K_le hx hX) _
         _ = 2 ^ (2*a + 1 : ℝ) * ((2 ^ (a^3 + 12*a + 4 : ℝ))⁻¹ * α) * 2 ^ (a^3 + 10*a : ℝ) := by
-          simp only [α', c10_0_3]; rw [coe_inv (by norm_num)]; norm_cast
+          norm_cast
+          simp [α', c10_0_3]
         _ = 2 ^ (2*a + 1 : ℝ) * 2 ^ (- (a^3 + 12*a + 4 : ℝ)) * 2 ^ (a^3 + 10*a : ℝ) * α := by
           rw [rpow_neg]; ring
         _ = 2 ^ ((2 * a + 1) + -(a ^ 3 + 12 * a + 4 : ℝ) + (a ^ 3 + 10 * a)) * α := by


### PR DESCRIPTION
Continues with migration to Lean v4.29 (https://github.com/fpvandoorn/carleson/pull/545)

## TODOs:
- [x] `integral_smth` (`integral_conj`, etc.) can be further shortened into  `_ = (starRingEnd ℂ) (∫ y in _, _)`
- [ ] didn't pay attention to n of symbols per line
- [ ] didn't look into preexisting `set_option backward.isDefEq.respectTransparency false`
- [x] double-check `instance NNReal.MeasureSpace`
- [ ] I noticed many lemmas in `Calculations.lean` can now be shortened into plain `simp`