### PR TITLE
Paper task 16: Bounded compact support

### DIFF
--- a/Carleson/ToMathlib/BoundedCompactSupport.lean
+++ b/Carleson/ToMathlib/BoundedCompactSupport.lean
@@ -8,8 +8,6 @@ import Carleson.ToMathlib.Misc
 
 /-!
 
-EXPERIMENTAL
-
 # Bounded compactly supported functions
 
 The purpose of this file is to provide helper lemmas to streamline proofs that
@@ -30,7 +28,7 @@ Upstreaming status: should be upstreamed, but need to clarify design questions f
   there any operation which preserves `BoundedCompactSupport` but not `BoundedFiniteSupport`?
   Decide if we want both classes in mathlib or just one of them. If the latter, rewrite all of
   Carleson/ToMathlib to use that one class.
-
+  (Discussion on Zulip)
 -/
 
 open Bornology Function Set HasCompactSupport
@@ -401,6 +399,8 @@ variable {F : X × Y → E}
 
 variable {F : X × Y → E}
 
+/- This and other fiberwise constructions are problematic with the current
+choice of using a.e. boundedness in place of everywhere boundedness -/
 -- ---- adapt and prove below when needed
 -- theorem prod_left (hF : BoundedCompactSupport f μ) :
 --     ∀ y, BoundedCompactSupport (fun x ↦ F (x, y)) := fun y ↦ {

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -128,7 +128,7 @@ collaborative effort, written and developed in public.
 
 \subsection{Overview of the formalization project}\label{subsec:overview}
 % TODO: I assume that the classical and generalized Carleson theorems will already be mentioned in the previous subsection, so that I can cite them here.
-The goal of the Carleson project was to formalize the proof of the metric space Carleson theorem [ref], proven in \cite{ThieleCarlesonPreprint}, as well as the proof of the classical Carleson theorem [ref] as a corollary of this more general result. 
+The goal of the Carleson project was to formalize the proof of the metric space Carleson theorem [ref], proven in \cite{ThieleCarlesonPreprint}, as well as the proof of the classical Carleson theorem [ref] as a corollary of this more general result.
 
 The original reference \cite{ThieleCarlesonPreprint} was written as a traditional paper for experts in harmonic analysis, but its formalization was since the beginning envisioned as a large scale collaborative project. This posed a problem, since there are not many experts in formalization that are also experts in harmonic analysis, so most of the potential contributors to the formalization would not have the required expertise to fill in the gaps that are considered routine arguments in a harmonic analysis paper.
 
@@ -307,11 +307,33 @@ The process of generalisation revealed that this abstraction is also useful on i
 	\item Working with \texttt{MemLp}, not functions on \texttt{Lp}.
 \end{itemize}
 
-\subsection{The \texttt{BoundedCompactSupport} structure}\label{subsec:bdd_comp_supp}
-\begin{itemize}
-	\item \texttt{BoundedCompactSupport} and packaging conditions.
-	\item Ongoing experiments with \texttt{fun\_prop}. TODO: consider whether this should be a separate subsection.
-\end{itemize}
+\subsection{Test function classes}\label{subsec:bdd_comp_supp}
+A common task during the formalization was to prove the various integrability and measurability sidegoals
+arising when estimating integrals.
+As is typical in harmonic analysis, most technical estimates are {\it a priori} estimates involving
+input functions in suitable test function classes.
+
+In many parts of this project, bounded measurable compactly supported functions provided a convenient
+test function class. We also used the slightly larger class
+of bounded measurable functions supported on a set of finite measure in places where this weaker hypothesis
+matches the blueprint more closely.
+Since most constructions appearing in the proof leave these function classes invariant,
+integrability and measurability considerations are usually mathematically trivial.
+
+It is desirable for this simplicity to be reflected in the formalization.
+This motivated implementing test function classes as
+structures \texttt{BoundedCompactSupport} and \texttt{BoundedFiniteSupport} in Lean and
+to implement an API supporting common operations.
+% We are not currently doing that consistently, various operations are still handled ad-hoc, so this description is in part aspirational.
+
+%\todo{Include an example. Should there be code examples?}
+Many of these arguments could feasibly be further streamlined using \texttt{fun\_prop}.
+\todo{expand/change as desired}
+
+% \begin{itemize}
+% 	\item \texttt{BoundedCompactSupport} and packaging conditions.
+% 	\item Ongoing experiments with \texttt{fun\_prop}. TODO: consider whether this should be a separate subsection.
+% \end{itemize}
 
 \subsection{Common pitfalls}\label{subsec:pitfalls}
 \begin{itemize}

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -323,14 +323,19 @@ Since most constructions appearing in the proof leave these function classes inv
 integrability and measurability considerations are usually mathematically trivial.
 
 It is desirable for this simplicity to be reflected in the formalization.
-This motivated implementing test function classes as
-structures \texttt{BoundedCompactSupport} and \texttt{BoundedFiniteSupport} in Lean and
-to implement an API supporting common operations.
-% We are not currently doing that consistently, various operations are still handled ad-hoc, so this description is in part aspirational.
+This motivated packaging the recurring side conditions into test function classes.
 
-%\todo{Include an example. Should there be code examples?}
-Many of these arguments could feasibly be further streamlined using \texttt{fun\_prop}.
-\todo{expand/change as desired}
+The structures \lean{BoundedCompactSupport} and \lean{BoundedFiniteSupport} record,
+respectively, essentially bounded measurable functions with compact support and with support of finite measure.
+Once these hypotheses are bundled, later proofs can invoke short API lemmas instead of repeatedly
+reproving the same measure-theoretic facts. For example, from a hypothesis
+\lean{hf : BoundedCompactSupport f} one immediately obtains that \lean{f} is a member of
+any desired $L^p$ space, % in the context of this project
+or that \lean{s.indicator f} again has bounded compact support when \lean{s} is measurable.
+Lemmas such as \lean{hf.carlesonSum} show that the relevant
+operators preserve the test function class, so once compact support has been established at the input, it remains available throughout the argument.
+
+Further API extensions and better support from \texttt{fun\_prop} could streamline these arguments even more.
 
 % \begin{itemize}
 % 	\item \texttt{BoundedCompactSupport} and packaging conditions.

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -22,6 +22,8 @@
 
 \newcommand{\mathlib}{\texttt{Mathlib}\xspace}
 
+\newcommand{\todo}[1]{{\color{blue}{TODO: {#1}}}}
+
 % These options can be changed later; these may be personal preferences.
 \hypersetup{
   bookmarks,bookmarksopen,bookmarksnumbered,


### PR DESCRIPTION
Here is a first draft. Please feel free to change as needed.
I changed the subsection title to "Test function classes", both to make it less technical sounding and to reflect the fact that we're using two similar classes, `BoundedCompactSupport` and `BoundedFiniteSupport`.

There was a question whether one of the two should be removed and if so which one. I think it might make sense to keep both in this project since this more accurately reflects the blueprint. Upstreaming is another question.
Discussion thread on Zulip: [#Carleson > BoundedCompactSupport vs BoundedFiniteSupport](https://leanprover.zulipchat.com/#narrow/channel/442935-Carleson/topic/BoundedCompactSupport.20vs.20BoundedFiniteSupport/with/591030566)


