### PR TITLE
ci: populate the upstreaming dashboard from `Carleson/ToMathlib`

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           website-directory: ./docs
           project-name: Carleson
+          search-root: Carleson.ToMathlib
           relevant-labels: carleson
           include-drafts: true
           branch-name: master


### PR DESCRIPTION
The dashboard at https://florisvandoorn.com/carleson/upstreaming has been empty because [the action](https://github.com/leanprover-community/upstreaming-dashboard-action) looks under `Carleson/Mathlib/` by default, and our upstreaming candidates live under `Carleson/ToMathlib/`.

Once https://github.com/leanprover-community/upstreaming-dashboard-action/pull/3 is merged, this `search-root: Carleson.ToMathlib` line is all that's needed. Keeping this as a draft until then.