### PR TITLE
chore: bump to mathlib 4.31 - continuing

### DIFF
--- a/Carleson/Classical/CarlesonHunt.lean
+++ b/Carleson/Classical/CarlesonHunt.lean
@@ -113,7 +113,7 @@ theorem exceptional_set_carleson {f : ℝ → ℂ} (periodic_f : f.Periodic (2 *
         simp
       · simp only [gt_iff_lt, nonpos_iff_eq_zero]
         rw [distribution_eq_zero_iff]
-        apply essSup_le_of_ae_le; swap; · sorry -- TODO: proof was done here!
+        apply essSup_le_of_ae_le; swap; · isBoundedDefault
         rw [EventuallyLE, ae_restrict_iff' measurableSet_Ioc]
         filter_upwards with x hx
         simp only [enorm_eq_self, iSup_le_iff]

--- a/Carleson/Classical/ClassicalCarleson.lean
+++ b/Carleson/Classical/ClassicalCarleson.lean
@@ -95,7 +95,7 @@ theorem exceptional_set_carleson' {f : ℝ → ℂ} (cont_f : Continuous f)
           _ = δ / 4 := by simp
       · simp only [gt_iff_lt, nonpos_iff_eq_zero]
         rw [distribution_eq_zero_iff]
-        apply essSup_le_of_ae_le; swap; · sorry -- TODO: proof was done here!
+        apply essSup_le_of_ae_le; swap; · isBoundedDefault
         rw [EventuallyLE, ae_restrict_iff' measurableSet_Ioc]
         filter_upwards with x hx
         simp only [enorm_eq_self, iSup_le_iff]

--- a/Carleson/ToMathlib/Distribution.lean
+++ b/Carleson/ToMathlib/Distribution.lean
@@ -355,7 +355,7 @@ lemma distribution_eq_zero_iff {ε} [TopologicalSpace ε] [ESeminormedAddMonoid 
     apply essSup_le_of_ae_le
     · filter_upwards [h]
       simp
-    sorry -- TODO: proof was done now
+    isBoundedDefault
   · rw [essSup]
     intro h
     rw [← Filter.Eventually]

--- a/Carleson/ToMathlib/MeasureTheory/Function/EssSup.lean
+++ b/Carleson/ToMathlib/MeasureTheory/Function/EssSup.lean
@@ -14,7 +14,7 @@ lemma essSup_le_iSup {α : Type*} {β : Type*} {m : MeasurableSpace α} {μ : Me
   apply essSup_le_of_ae_le
   · filter_upwards [] with i
     apply le_iSup
-  sorry -- TODO: proof used to be done now!
+  isBoundedDefault
 
 lemma iSup_le_essSup {α : Type*} {β : Type*} {m : MeasurableSpace α} {μ : Measure α}
   [CompleteLinearOrder β] {f : α → β} (h : ∀ ⦃x⦄, ∀ ⦃a⦄, a < f x → μ {y | a < f y} ≠ 0) :

--- a/Carleson/ToMathlib/RealInterpolation/LorentzInterpolation.lean
+++ b/Carleson/ToMathlib/RealInterpolation/LorentzInterpolation.lean
@@ -31,7 +31,6 @@ lemma C_LorentzInterpolation_pos {p₀ p₁ q₀ q₁ q : ℝ≥0∞} {C₀ C₁
 theorem exists_hasLorentzType_real_interpolation {p₀ p₁ r₀ r₁ q₀ q₁ s₀ s₁ p q : ℝ≥0∞}
     [MeasurableSpace E₁] [TopologicalSpace E₁] [ENormedAddCommMonoid E₁]
     [MeasurableSpace E₂] [TopologicalSpace E₂] [ENormedAddCommMonoid E₂]
-    [TopologicalSpace E₃] [MeasurableSpace E₃] [BorelSpace E₃]
     -- TODO: find out which of the conditions `(1 ≤ ·)` are actually necessary.
     (hp₀ : 1 ≤ p₀) (hp₁ : 1 ≤ p₁) (hr₀ : 1 ≤ r₀) (hr₁ : 1 ≤ r₁)
     (hq₀ : 1 ≤ q₀) (hq₁ : 1 ≤ q₁) (hs₀ : 1 ≤ s₀) (hs₁ : 1 ≤ s₁)

--- a/Carleson/TwoSidedCarleson/RestrictedWeakType.lean
+++ b/Carleson/TwoSidedCarleson/RestrictedWeakType.lean
@@ -229,7 +229,6 @@ theorem two_sided_metric_carleson_hasStrongType
   set kpd : KernelProofData a K := KernelProofData.mk d ha cf this
   rw [hasStrongType_iff_hasLorentzType]
   unfold C_carleson_hasStrongType
-  sorry /- TODO: proof was done before!
   convert exists_hasLorentzType_real_interpolation _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ lorentzType_q₀ lorentzType_q₁ _ _
   · simp [hq₀.1.le]
   · simp [hq₁.1.le]
@@ -276,6 +275,6 @@ theorem two_sided_metric_carleson_hasStrongType
       · apply (hg.memLp _).locallyIntegrable <;> simp [hq₀.1.le]
       · apply (hg.memLp _).locallyIntegrable <;> simp [hq₁.1.le]
   · simp only [coe_pos]
-    exact lt_trans (zero_lt_one' ℝ≥0) hq.1 -/
+    exact lt_trans (zero_lt_one' ℝ≥0) hq.1
 
 end


### PR DESCRIPTION
Continues https://github.com/fpvandoorn/carleson/pull/602

### Explanations

- In `LorentzInterpolation.lean`, some excessive instance implicits were accidentally added  ([here](https://github.com/fpvandoorn/carleson/pull/602/changes#diff-8598e84ced7c855b3a8b52d629e56a25be9d86608319dde41360ac327a2216b1R34)).
So, the only reason  `RestrictedWeakType.lean` proof broke was because of those new instance implicits we now had to satisfy.