### PR TITLE
chore: tweak .bib file according to modern practices

### DIFF
--- a/paper/references.bib
+++ b/paper/references.bib
@@ -265,9 +265,9 @@ MRREVIEWER = {Borislav\ R.\ Draganov},
   publisher   = {{Springer}},
   abstract    = {This paper reports on a six-year collaborative effort that cul- minated in a complete formalization of a proof of the Feit-Thompson Odd Order Theorem in the Coq proof assistant. The formalized proof is constructive, and relies on nothing but the axioms and rules of the foundational framework implemented by Coq. To support the formalization, we developed a comprehensive set of reusable libraries of formalized mathematics, including results in finite group theory, linear algebra, Galois theory, and the theories of the real and complex algebraic numbers.},
   doi         = {10.1007/978-3-642-39634-2\_14},
+  file        = {main.pdf:https\://inria.hal.science/hal-00816699v1/file/main.pdf:PDF},
   hal_id      = {hal-00816699},
   hal_version = {v1},
-  pdf         = {https://inria.hal.science/hal-00816699v1/file/main.pdf},
   url         = {https://inria.hal.science/hal-00816699},
 }
 
@@ -380,9 +380,9 @@ MRREVIEWER = {Borislav\ R.\ Draganov},
   address     = {Saint-Jacut-de-la-Mer, France},
   month       = Jan,
   abstract    = {We report on an ongoing formalization of the Fundamental Theorem of Calculus (FTC) for the Lebesgue integral in the Coq proof assistant. To this aim, we formalize Lebesgue's differentiation theorem, which has other applications and whose proof can be decomposed in lemmas of independent interest. As a result, we significantly enrich the theories of MathComp-Analysis, an extension of the Mathematical Components library for analysis, and eventually relate its definitions of derivability and of integration.},
+  file        = {jfla2024-paper-15.pdf:https\://inria.hal.science/hal-04406350v1/file/jfla2024-paper-15.pdf:PDF},
   hal_id      = {hal-04406350},
   hal_version = {v1},
-  pdf         = {https://inria.hal.science/hal-04406350v1/file/jfla2024-paper-15.pdf},
   url         = {https://inria.hal.science/hal-04406350},
 }
 


### PR DESCRIPTION
The `pdf` field is deprecated in favour of the `file` field.