### PR TITLE
chore(RealInterpolation/Main): generalize AESublinear(On) slightly

### DIFF
--- a/Carleson/ToMathlib/RealInterpolation/Main.lean
+++ b/Carleson/ToMathlib/RealInterpolation/Main.lean
@@ -188,9 +188,9 @@ lemma const (T : (α → ε₁) → ε) (P : (α → ε₁) → Prop)
 
 end AESubadditiveOn
 
-variable [TopologicalSpace ε] [ENormedSpace ε]
+variable [TopologicalSpace ε] [ESeminormedAddMonoid ε] [SMul ℝ≥0 ε]
 
-variable {ε₁ ε₂ : Type*} [TopologicalSpace ε₁] [ENormedSpace ε₁]
+variable {ε₁ ε₂ : Type*} [TopologicalSpace ε₁] [ESeminormedAddMonoid ε₁] [SMul ℝ≥0 ε₁]
 
 /-- The operator is sublinear on functions satisfying `P` with constant `A`. -/
 def SublinearOn (T : (α → ε₁) → α' → ε) (P : (α → ε₁) → Prop) (A : ℝ≥0∞) :
@@ -228,6 +228,7 @@ lemma iSup₂ {ι : Type*} {κ : ι → Sort*} {T : (i : ι) → κ i → (α �
   simp_rw [iSup_psigma']
   exact .iSup (fun ⟨i,j⟩ ↦ h i j)
 
+variable {ε : Type*} [TopologicalSpace ε] [ESeminormedAddCommMonoid ε] [Module ℝ≥0 ε] in
 lemma indicator {T : (α → ε₁) → α' → ε} {P : (α → ε₁) → Prop} {A : ℝ≥0∞} (S : Set α')
     (sl : SublinearOn T P A) :
     SublinearOn (fun u x ↦ (S.indicator (fun y ↦ T u y) x)) P A := by
@@ -281,6 +282,7 @@ lemma biSup {ι : Type*} {𝓑 : Set ι} (h𝓑 : 𝓑.Countable) {T : ι → (�
   specialize hx i hi
   simpa only [Pi.smul_apply, smul_eq_mul] using hx
 
+variable {ε₁ : Type*} [TopologicalSpace ε₁] [ESeminormedAddCommMonoid ε₁] [Module ℝ≥0 ε₁] in
 lemma biSup2 {ι : Type*} {𝓑 : Set ι} (h𝓑 : 𝓑.Countable) {T : ι → (α → ε₁) → α' → ℝ≥0∞}
     {P : (α → ε₁) → Prop} {Q : (α → ε₁) → Prop}
     (hPT : ∀ (u : α → ε₁), P u → ∀ᵐ x ∂ν, ⨆ i ∈ 𝓑, T i u x ≠ ∞)
@@ -320,6 +322,7 @@ lemma biSup2 {ι : Type*} {𝓑 : Set ι} (h𝓑 : 𝓑.Countable) {T : ι → (
   · rintro _ c ⟨f, hf, g, hg, rfl⟩
     exact ⟨c • f, hsP hf, c • g, hsQ hg, by module⟩
 
+variable {ε : Type*} [TopologicalSpace ε] [ESeminormedAddCommMonoid ε] [Module ℝ≥0 ε] in
 lemma indicator {T : (α → ε₁) → α' → ε} {P : (α → ε₁) → Prop} {A : ℝ≥0∞} (S : Set α')
     (sl : AESublinearOn T P A ν) :
     AESublinearOn (fun u x ↦ (S.indicator (fun y ↦ T u y) x)) P A ν := by


### PR DESCRIPTION
None of the file requires the fully hypotheses of an `ENormedSpace`: in fact, we can mostly get by with a seminormed monoid with scalar multiplication. Three lemmas also require a module structure, but none require scalar multiplication and the enorm to be compatible.
In passing, remove the positive definiteness requirement from the file. 