### PR TITLE
chore: fix the build

### DIFF
--- a/Carleson/ToMathlib/MeasureTheory/Measure/NoAtoms/Basics.lean
+++ b/Carleson/ToMathlib/MeasureTheory/Measure/NoAtoms/Basics.lean
@@ -10,6 +10,9 @@ public import Mathlib.MeasureTheory.VectorMeasure.Basic
 public import Mathlib.Data.PFun
 public import Mathlib.Analysis.Convex.Basic
 
+-- Upstreaming status: Needs significant clean-up (refactoring, code style, extracting lemmas,
+-- moving to proper location etc.)
+
 @[expose] public section
 
 namespace MeasureTheory
@@ -180,15 +183,15 @@ theorem PFun.le_iff {β : Type*} {f g : α →. β} :  f ≤ g ↔ f.graph' ≤ 
 theorem PFun.le_iff' {β : Type*} {f g : α →. β} :  f ≤ g ↔ ∀ (a : α), ∀ b ∈ f a, b ∈ g a := by
   rw [PFun.le_iff]
   unfold PFun.graph'
-  simp only [setOf_subset_setOf, Prod.forall]
+  simp only [ofPred_subset_ofPred, Prod.forall]
 
 theorem PFun.Dom_mono {β : Type*} {f g : α →. β} (h : f ≤ g) : f.Dom ⊆ g.Dom := by
   unfold PFun.Dom --Part.Dom
   intro a ha
-  simp only [mem_setOf_eq] at *
+  simp only [mem_ofPred_eq] at *
   rw [PFun.le_iff] at h
   unfold PFun.graph' at h
-  simp only [setOf_subset_setOf, Prod.forall] at h
+  simp only [ofPred_subset_ofPred, Prod.forall] at h
   rw [Part.dom_iff_mem] at *
   have := h a ha.choose ha.choose_spec
   use ha.choose
@@ -196,6 +199,7 @@ theorem PFun.Dom_mono {β : Type*} {f g : α →. β} (h : f ≤ g) : f.Dom ⊆ 
 theorem PFun.fn_mem {β : Type*} {f : α →. β} {a : α} (ha : a ∈ f.Dom) : f.fn a ha ∈ f a :=
   (Part.eq_get_iff_mem ha).mp rfl
 
+set_option backward.isDefEq.respectTransparency.types false in
 theorem PFun.fn_apply_eq_fn_apply_of_le {β : Type*} {f g : α →. β} (h : f ≤ g) {a : α} (ha : a ∈ f.Dom) :
     f.fn a ha = g.fn a (PFun.Dom_mono h ha) := by
   nth_rw 2 [PFun.fn_apply]
@@ -265,9 +269,10 @@ theorem PFun.Dom_insert {β : Type*} {f : α →. β} {a : α} {b : β} :
     (PFun.insert f a b).Dom = f.Dom.insert a := by
   unfold PFun.insert PFun.Dom Set.insert
   ext x
-  simp only [Part.coe_some, mem_setOf_eq]
+  simp only [Part.coe_some, mem_ofPred_eq]
   split_ifs with hx <;> simp [hx]
 
+set_option backward.isDefEq.respectTransparency.types false in
 theorem PFun.lt_insert {β : Type*} {f : α →. β} {a : α} {b : β} (ha : a ∉ f.Dom) :
     f ≤ PFun.insert f a b ∧ ¬PFun.insert f a b ≤ f := by
   unfold PFun.insert
@@ -278,6 +283,7 @@ theorem PFun.lt_insert {β : Type*} {f : α →. β} {a : α} {b : β} (ha : a �
     use a
     aesop
 
+set_option backward.isDefEq.respectTransparency.types false in
 theorem PFun.Prop_insert {β : Type*} {f : α →. β} {a : α} {b : β} {p : α → β → Prop}
   (hf : ∀ x, ∀ (hx : x ∈ f.Dom), p x (f.fn x hx)) (hb : p a b) :
     let g := PFun.insert f a b;
@@ -302,6 +308,7 @@ theorem PFun.Monotone.Monotone [Preorder α] {β : Type*} [Preorder β] {f : α 
   apply hf
   simpa
 
+set_option backward.isDefEq.respectTransparency.types false in
 theorem PFun.Monotone.insert [Preorder α] {β : Type*} [Preorder β] {f : α →. β}
   (hf : PFun.Monotone f) {a : α} {b : β}
   (hb : ∀ x ≤ a, ∀ (hx : x ∈ f.Dom), f.fn x hx ≤ b)
@@ -345,7 +352,7 @@ instance instIsCountablyGenerated_atTop [TopologicalSpace α] [LinearOrder α] [
   · obtain ⟨s, s_count, hs⟩ := exists_countable_dense α
     have : atTop = generate (Ici '' s) := by
       refine atTop_eq_generate_of_not_bddAbove fun ⟨x, hx⟩ ↦ ?_
-      simp only [eq_empty_iff_forall_notMem, IsTop, mem_setOf_eq, not_forall, not_le] at h
+      simp only [eq_empty_iff_forall_notMem, IsTop, mem_ofPred_eq, not_forall, not_le] at h
       obtain ⟨y, hy, hxy⟩ := hs.exists_mem_open isOpen_Ioi (h x)
       exact (hx hy).not_gt hxy
     rw [this]
@@ -372,6 +379,7 @@ protected theorem iInter_of_monotone {ι : Type*} [Preorder ι] [IsCodirectedOrd
   | inl _ => simp
   | inr _ => exact MeasureTheory.NoAtoms'.iInter_of_monotone_of_frequently hsm <| .of_forall hs
 
+set_option backward.isDefEq.respectTransparency.types false in
 theorem exists_measurable_sets_measure_eq :
     ∃ Ts : Set.Iic (μ univ) → Set α, Monotone Ts ∧ ∀ x, MeasurableSet (Ts x) ∧ μ (Ts x) = x := by
   set Γ := {S : Set.Iic (μ univ) →. (Set α) | PFun.Monotone S ∧
@@ -382,7 +390,7 @@ theorem exists_measurable_sets_measure_eq :
     use sSup Ts
     constructor
     · unfold Γ
-      simp only [PFun.mem_dom, forall_exists_index, mem_setOf_eq]
+      simp only [PFun.mem_dom, forall_exists_index, mem_ofPred_eq]
       constructor
       · intro x y hx hy hxy
         rcases PFun.exists_fn_of_fn_sSup hTs' hx with ⟨f, hf, hfx, h⟩
@@ -391,7 +399,7 @@ theorem exists_measurable_sets_measure_eq :
         unfold Γ at hfΓ
         have hgΓ := hTs hg
         unfold Γ at hgΓ
-        simp only [mem_setOf_eq] at hfΓ hgΓ
+        simp only [mem_ofPred_eq] at hfΓ hgΓ
         rw [h, h']
         by_cases! hfg : f = g
         · simp only [hfg]
@@ -406,14 +414,14 @@ theorem exists_measurable_sets_measure_eq :
         rcases PFun.exists_fn_of_fn_sSup hTs' (PFun.mem_dom_of_mem hT) with ⟨f, hf, hfx, h⟩
         have hfΓ := hTs hf
         unfold Γ at hfΓ
-        simp only [mem_setOf_eq] at hfΓ
+        simp only [mem_ofPred_eq] at hfΓ
         rw [h]
         use (hfΓ.2 x hfx).1, (hfΓ.2 x hfx).2
     · intro f hf
       apply PFun.le_sSup hTs' hf
   rcases this with ⟨S, hSΓ, S_maximal⟩
   unfold Γ at hSΓ
-  simp only [mem_setOf_eq] at hSΓ
+  simp only [mem_ofPred_eq] at hSΓ
   have hμuniv : ⟨μ univ, self_mem_Iic⟩ ∈ S.Dom := by
     contrapose! S_maximal
     use PFun.insert S ⟨μ univ, self_mem_Iic⟩ univ

--- a/Carleson/ToMathlib/MeasureTheory/Measure/NoAtoms/Defs.lean
+++ b/Carleson/ToMathlib/MeasureTheory/Measure/NoAtoms/Defs.lean
@@ -15,6 +15,9 @@ public import Mathlib.MeasureTheory.Measure.Typeclasses.SFinite
 # Measures having no atoms
 -/
 
+-- Upstreaming status: Needs significant clean-up (refactoring, code style, extracting lemmas,
+-- moving to proper location etc.)
+
 public section
 
 namespace MeasureTheory

--- a/Carleson/ToMathlib/MeasureTheory/Measure/NoAtoms/Metric.lean
+++ b/Carleson/ToMathlib/MeasureTheory/Measure/NoAtoms/Metric.lean
@@ -9,6 +9,9 @@ public import Carleson.ToMathlib.MeasureTheory.Measure.NoAtoms.Basics
 public import Mathlib.MeasureTheory.Constructions.UnitInterval
 public import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
 
+-- Upstreaming status: Needs significant clean-up (refactoring, code style, extracting lemmas,
+-- moving to proper location etc.)
+
 public section
 
 namespace MeasureTheory

--- a/Carleson/ToMathlib/MeasureTheory/Measure/NoAtoms/Prod.lean
+++ b/Carleson/ToMathlib/MeasureTheory/Measure/NoAtoms/Prod.lean
@@ -3,11 +3,13 @@ Copyright (c) 2026 Leo Diedering. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leo Diedering
 -/
-
 module
 
 public import Carleson.ToMathlib.MeasureTheory.Measure.NoAtoms.Defs
 public import Mathlib.MeasureTheory.Measure.Prod
+
+-- Upstreaming status: Needs significant clean-up (refactoring, code style, extracting lemmas,
+-- moving to proper location etc.)
 
 public section
 
@@ -31,7 +33,7 @@ theorem essProjSnd_eq_essProjFst_swap {s : Set (α × β)} :
     essProjSnd s μ = essProjFst (Prod.swap ⁻¹' s) μ := by
   unfold essProjFst essProjSnd
   ext y
-  simp only [mem_setOf_eq]
+  simp only [mem_ofPred_eq]
   congr!
 
 theorem essProjFst_subset {s : Set (α × β)} :
@@ -39,7 +41,7 @@ theorem essProjFst_subset {s : Set (α × β)} :
   unfold essProjFst
   intro x
   contrapose!
-  simp only [mem_image, Prod.exists, exists_and_right, exists_eq_right, not_exists, mem_setOf_eq,
+  simp only [mem_image, Prod.exists, exists_and_right, exists_eq_right, not_exists, mem_ofPred_eq,
     not_lt, nonpos_iff_eq_zero]
   intro h
   convert measure_empty (μ := ν)
@@ -78,7 +80,7 @@ theorem essProjFst_times_univ {s : Set α} (h : ν ≠ 0) :
     essProjFst (s ×ˢ univ) ν = s := by
   unfold essProjFst
   ext y
-  simp only [mem_setOf_eq]
+  simp only [mem_ofPred_eq]
   constructor
   · contrapose!
     intro hy
@@ -99,7 +101,7 @@ theorem essProjFst_mono {s t : Set (α × β)} (h : s ⊆ t) :
     essProjFst s ν ⊆ essProjFst t ν := by
   unfold essProjFst
   intro x hx
-  simp_all only [mem_setOf_eq]
+  simp_all only [mem_ofPred_eq]
   apply hx.trans_le
   gcongr
 
@@ -118,7 +120,7 @@ theorem essProjFst_inter {s t : Set (α × β)} {ν : Measure α} :
     essProjFst (s ∩ t) ν ⊆ essProjFst s ν ∩ essProjFst t ν := by
   intro b
   unfold essProjFst
-  simp only [preimage_inter, mem_setOf_eq, mem_inter_iff]
+  simp only [preimage_inter, mem_ofPred_eq, mem_inter_iff]
   sorry
 -/
 
@@ -126,7 +128,7 @@ theorem essProjFst_inter_times_univ {s : Set (α × β)} {t : Set α} :
     essProjFst (s ∩ t ×ˢ univ) ν = essProjFst s ν ∩ t := by
   unfold essProjFst
   ext y
-  simp only [preimage_inter, mem_setOf_eq, mem_inter_iff]
+  simp only [preimage_inter, mem_ofPred_eq, mem_inter_iff]
   constructor
   · intro hy
     constructor


### PR DESCRIPTION
#624 had not been updated for the mathlib bump; fix the few deprecations and newly necessary backward compatibility options by hand. Also insert a few upstreaming comments.